### PR TITLE
Add common system files from bluefin

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,4 @@
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-42}"
+
+FROM scratch AS ctx
+COPY /system_files /system_files

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,2 @@
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-42}"
-
 FROM scratch AS ctx
 COPY /system_files /system_files

--- a/system_files/etc/ublue-os/bling.json
+++ b/system_files/etc/ublue-os/bling.json
@@ -1,0 +1,3 @@
+{
+  "bling-cli-name": "bluefin-cli"
+}

--- a/system_files/etc/ublue-os/fastfetch.json
+++ b/system_files/etc/ublue-os/fastfetch.json
@@ -1,0 +1,4 @@
+{
+	"logo-directory": "/usr/share/ublue-os/bluefin-logos/symbols",
+	"shuffle-logo": true
+}

--- a/system_files/etc/ublue-os/setup.json
+++ b/system_files/etc/ublue-os/setup.json
@@ -1,0 +1,4 @@
+{
+  "check-secureboot": true,
+  "setup-version": 1
+}

--- a/system_files/usr/share/ublue-os/firefox-config/01-bluefin-global.js
+++ b/system_files/usr/share/ublue-os/firefox-config/01-bluefin-global.js
@@ -1,0 +1,3 @@
+// Bluefin Global
+pref("gfx.webrender.all", true);
+pref("media.ffmpeg.vaapi.enabled", true);

--- a/system_files/usr/share/ublue-os/flatpak-overrides/io.github.kolunmi.Bazaar
+++ b/system_files/usr/share/ublue-os/flatpak-overrides/io.github.kolunmi.Bazaar
@@ -1,0 +1,2 @@
+[Context]
+filesystems=host-etc

--- a/system_files/usr/share/ublue-os/just/10-update.just
+++ b/system_files/usr/share/ublue-os/just/10-update.just
@@ -1,0 +1,91 @@
+# vim: set ft=make :
+
+alias upgrade := update
+
+# Update system, flatpaks, and containers all at once
+update:
+    #!/usr/bin/bash
+    if systemctl cat -- uupd.timer &> /dev/null; then
+        SERVICE="uupd.service"
+    else
+        SERVICE="rpm-ostreed-automatic.service"
+    fi
+    if systemctl is-active --quiet "$SERVICE"; then
+        echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
+        exit 1
+    fi
+    # rpm-ostree used due to bootc upgrade not supporting local layered packages
+    rpm-ostree upgrade
+    # Updates system Flatpaks
+    if flatpak remotes | grep -q system; then
+        flatpak update -y
+    fi
+    # Update user Flatpaks
+    if flatpak remotes | grep -q user; then
+        flatpak update --user -y
+    fi
+    # Guard Brew if the user does not own brew/doesn't exist
+    if [[ -O /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
+        # Upgrade will run brew update if needed
+        /var/home/linuxbrew/.linuxbrew/bin/brew upgrade
+    fi
+
+alias auto-update := toggle-updates
+
+# Turn automatic updates on or off
+toggle-updates ACTION="prompt":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    CURRENT_STATE="Disabled"
+    if systemctl is-enabled -q rpm-ostreed-automatic.timer; then
+        CURRENT_STATE="Enabled"
+    elif systemctl is-enabled -q uupd.timer; then
+        CURRENT_STATE="Enabled"
+    fi
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "prompt" ]; then
+        echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
+        echo "Enable or Disable automatic updates?"
+        OPTION=$(ugum choose Enable Disable)
+    elif [ "$OPTION" == "help" ]; then
+        echo "Usage: ujust toggle-updates <option>"
+        echo "  <option>: Specify the quick option - 'enable' or 'disable'"
+        echo "  Use 'enable' to Enable automatic updates."
+        echo "  Use 'disable' to Disable automatic updates."
+        exit 0
+    fi
+    if systemctl cat -- uupd.timer &> /dev/null; then
+        TIMER="uupd.timer"
+    else
+        TIMER="rpm-ostreed-automatic.timer"
+    fi
+    if [ "${OPTION,,}" == "enable" ]; then
+        sudo systemctl enable "$TIMER"
+    elif [ "${OPTION,,}" == "disable" ]; then
+        sudo systemctl disable "$TIMER"
+    fi
+
+alias changelog := changelogs
+
+# Show the changelog
+changelogs:
+    #!/usr/bin/bash
+
+    # Get Image Tag
+    TAG=$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)
+
+    # If stable or gts, get changelogs from Github Releases
+    if [[ "$TAG" =~ gts$|stable$ ]]; then
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
+        CONTENT=$(curl -Ls https://api.github.com/repos/ublue-os/bluefin/releases | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")
+    fi
+
+    # Display Content with Glow, otherwise fallback to rpm-ostree changelogs (stable-daily/latest/desynced)
+    if [[ -n "${CONTENT:-}" ]]; then
+        echo "$CONTENT" | glow -p
+    else
+        ujust changelogs-fedora
+    fi
+
+changelogs-fedora:
+    rpm-ostree db diff --changelogs

--- a/system_files/usr/share/ublue-os/motd/template.md
+++ b/system_files/usr/share/ublue-os/motd/template.md
@@ -1,0 +1,18 @@
+# 󱍢 Welcome to Bluefin
+󱋩 `%IMAGE_NAME%:%IMAGE_TAG%`
+
+|  Command | Description |
+| ------- | ----------- |
+| `ujust --choose`  | Show available commands  |
+| `ujust toggle-user-motd` | Toggle this banner on/off |
+| `ujust bluefin-cli` | Enable terminal bling |
+| `brew help` | Manage command line packages |
+
+%TIP%
+
+- **󰊤** [Issues](https://issues.projectbluefin.io)
+- **󰊤** [Ask Bluefin](https://ask.projectbluefin.io)
+- **󰈙** [Documentation](http://docs.projectbluefin.io)
+
+
+%KEY_WARN%

--- a/system_files/usr/share/ublue-os/motd/tips/10-tips.md
+++ b/system_files/usr/share/ublue-os/motd/tips/10-tips.md
@@ -1,0 +1,28 @@
+Bluefin is your gateway to Cloud Native - find your flock at [landscape.cncf.io](https://l.cncf.io)
+GNOME makes your desktop! Donate to [GNOME](https://donate.gnome.org)
+Support the app store! Donate to  [Bazaar](https://github.com/kolunmi/bazaar)!
+Need more indepth technical information?~Check out the [Bluefin Administrator's Guide](https://docs.projectbluefin.io/administration)
+Like servers? Check out [ucore](https://github.com/ublue-os/ucore)
+Update break something? You can roll back with `bootc rollback`
+Use `brew search` and `brew install` to install packages. Bluefin will take care of the updates automatically
+Use `Ctrl`-`Alt`-`Enter` to quickly open a terminal
+Tailscale is included, check out [their docs](https://tailscale.com/kb/1017/install)
+`ujust --choose` will show you each shortcut and the script it's running
+`tldr vim` will give you the basic rundown on commands for a given tool
+`ujust rebase-helper` can help you roll back to a specific image, or to a different channel entirely, check the docs for more info
+`ujust changelogs` shows a summary of the package changes since the last update
+Don't forget to check the [release notes](https://github.com/ublue-os/bluefin/releases)
+Help keep Bluefin alive and healthy, consider [donating](https://docs.projectbluefin.io/donations)
+Develop with devcontainers! Use `devcontainer.json` files in your projects for isolated, reproducible environments
+Use DistroShelf (in the logo menu under "Containers") to create pet containers for different distros
+`ujust jetbrains-toolbox` installs JetBrains tools in your home directory, all ready to go!
+Performance profiling tools are built-in: try `sysprof`, `bpftrace`, and other debugging tools
+Switch shells safely: change your shell in Terminal settings instead of system-wide
+VS Code comes with devcontainers extension pre-installed - perfect for containerized development
+Container development is OS-agnostic - your devcontainers work on Linux, macOS, and Windows
+Use `docker compose` for multi-container development if devcontainers don't fit your workflow
+`ujust bluefin-k8s` gets you started with Kubernetes development tools like `kind` and `kubectl`
+`ujust bluefin-ai` installs a selection of AI tools
+`ujust bluefin-fonts` installs a well-curated collection of monospace fonts
+Open a folder with Clapgrep (Found in the Bazaar App Store) for super powerful search
+Bluefin separates the OS from your development environment - embrace the cloud-native workflow

--- a/system_files/usr/share/ublue-os/privileged-setup.hooks.d/10-tailscale.sh
+++ b/system_files/usr/share/ublue-os/privileged-setup.hooks.d/10-tailscale.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script tailscale privileged 1 || exit 0
+
+set -xeuo pipefail
+
+tailscale set --operator="$(getent passwd "$PKEXEC_UID" | cut -d: -f1)"

--- a/system_files/usr/share/ublue-os/privileged-setup.hooks.d/99-flatpaks.sh
+++ b/system_files/usr/share/ublue-os/privileged-setup.hooks.d/99-flatpaks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script flatpaks privileged 1 || exit 0
+
+set -x
+
+# Set up Firefox default configuration
+ARCH=$(arch)
+if [ "$ARCH" != "aarch64" ] ; then
+	mkdir -p "/var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/${ARCH}/stable/defaults/pref"
+	rm -f "/var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/${ARCH}/stable/defaults/pref/*bluefin*.js"
+	/usr/bin/cp -rf /usr/share/ublue-os/firefox-config/* "/var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/${ARCH}/stable/defaults/pref/"
+fi

--- a/system_files/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
+++ b/system_files/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script framework system 2 || exit 0
+
+set -x
+
+CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
+VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
+BIOS_VERSION="$(cat /sys/devices/virtual/dmi/id/bios_version 2>/dev/null)"
+
+# GLOBAL
+KARGS=$(rpm-ostree kargs)
+NEEDED_KARGS=()
+echo "Current kargs: $KARGS"
+
+if [[ $KARGS =~ "nomodeset" ]]; then
+	echo "Removing nomodeset"
+	NEEDED_KARGS+=("--delete-if-present=nomodeset")
+fi
+
+if [[ ":Framework:" =~ :$VEN_ID: ]]; then
+	if [[ "GenuineIntel" == "$CPU_VENDOR" ]]; then
+		if [[ ! $KARGS =~ "hid_sensor_hub" ]]; then
+			echo "Intel Framework Laptop detected, applying needed keyboard fix"
+			NEEDED_KARGS+=("--append-if-missing=module_blacklist=hid_sensor_hub")
+		fi
+	fi
+fi
+
+#shellcheck disable=SC2128
+if [[ -n "$NEEDED_KARGS" ]]; then
+	echo "Found needed karg changes, applying the following: ${NEEDED_KARGS[*]}"
+	plymouth display-message --text="Updating kargs - Please wait, this may take a while" || true
+	rpm-ostree kargs "${NEEDED_KARGS[*]}" --reboot || exit 1
+else
+	echo "No karg changes needed"
+fi
+
+SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
+
+# FRAMEWORK 13 FIXES
+if [[ "$VEN_ID" == "Framework" && "$SYS_ID" == "Laptop 13 ("* ]]; then
+    echo "Framework Laptop 13 detected"
+
+    # Older versions of this script applied a modprobe flag to fix 3.5 mm jack headset detection
+    # which is no longer needed because the kernel applies this automatically.
+    if [[ ! -f /etc/modprobe.d/alsa.conf ]]; then
+        echo "Removing obsolete 3.5mm audio jack fix"
+        rm -f /etc/modprobe.d/alsa.conf
+    fi
+
+    # Suspend fix for Framework 13 Ryzen 7040
+    # On BIOS versions >= 3.09, the workaround is not needed
+    # (https://knowledgebase.frame.work/framework-laptop-13-bios-and-driver-releases-amd-ryzen-7040-series-r1rXGVL16)
+    if [[ "$SYS_ID" == "Laptop 13 (AMD Ryzen 7040Series)" && "$(printf '%s\n' 03.08 "$BIOS_VERSION" | sort -V | tail -n1)" == "03.08" ]]; then
+        # BIOS is older, apply workaround
+        if [[ ! -f /etc/udev/rules.d/20-suspend-fixes.rules ]]; then
+            echo "Framework 13 Ryzen 7040 with BIOS $BIOS_VERSION < 3.09 — applying suspend workaround"
+            echo 'ACTION=="add", SUBSYSTEM=="serio", DRIVERS=="atkbd", ATTR{power/wakeup}="disabled"' \
+                > /etc/udev/rules.d/20-suspend-fixes.rules
+        fi
+    else
+        # BIOS is >= 3.09, remove workaround if present
+        # Older versions of this script also mistakenly applied then
+        # workaround to Framework 13 Ryzen AI 300. Will get cleaned up here too.
+        if [[ -f /etc/udev/rules.d/20-suspend-fixes.rules ]]; then
+            echo "Removing old suspend workaround"
+            rm -f /etc/udev/rules.d/20-suspend-fixes.rules
+        fi
+    fi
+fi

--- a/system_files/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
+++ b/system_files/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script theming user 1 || exit 0
+
+set -xeuo pipefail
+
+VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
+
+if [[ ":Framework:" =~ :$VEN_ID: ]]; then
+	echo 'Setting Framework logo menu'
+	dconf write /org/gnome/shell/extensions/Logo-menu/symbolic-icon true
+	dconf write /org/gnome/shell/extensions/Logo-menu/menu-button-icon-image 31
+	echo 'Setting touch scroll type'
+	dconf write /org/gnome/desktop/peripherals/mouse/natural-scroll true
+	if [[ $SYS_ID == "Laptop ("* ]]; then
+		echo 'Applying font fix for Framework 13'
+		dconf write /org/gnome/desktop/interface/text-scaling-factor 1.25
+	fi
+fi
+
+SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
+
+if [[ ":Thelio Astra:" =~ :$SYS_ID: ]]; then
+	echo 'Setting Ampere Logo'
+ 	dconf write /org/gnome/shell/extensions/Logo-menu/symbolic-icon true
+	dconf write /org/gnome/shell/extensions/Logo-menu/menu-button-icon-image 32
+ fi

--- a/system_files/usr/share/ublue-os/user-setup.hooks.d/99-privileged.sh
+++ b/system_files/usr/share/ublue-os/user-setup.hooks.d/99-privileged.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Running all privileged units"
+
+pkexec /usr/libexec/ublue-privileged-setup


### PR DESCRIPTION
This PR adds common system files from bluefin to enable code reuse across bluefin and bluefin-lts repositories.

## Changes
- Copy /usr/share/ublue-os files from bluefin shared system_files
- Copy /etc/ublue-os configuration files  
- Create Containerfile with ctx stage following bluefin pattern

## Usage
Bluefin and bluefin-lts can now use:
```dockerfile
COPY --from=ghcr.io/ublue-os/bluefin-common:latest /system_files /ctx/system_files
```

This eliminates duplication and centralizes common configuration files.