### PR TITLE
Switch to podman and buildah for container builds

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -25,37 +25,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Lowercase Registry
-        id: registry_case
-        uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
-
-      - name: Generate Image Metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5
-        id: meta
-        with:
-          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
+      - name: Build Image
+        id: build
+        run: |
+          buildah build -t ${{ env.IMAGE_NAME }}:latest -f ./Containerfile .
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login -u "${{ github.actor }}" --password-stdin ghcr.io
 
-      - name: Build and Push Image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
-        id: build
-        with:
-          context: .
-          file: ./Containerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Push Image
+        if: github.event_name != 'pull_request'
+        run: |
+          podman push ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       # - name: Install Cosign
       #   uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
@@ -64,7 +47,7 @@ jobs:
       # - name: Sign container image
       #   if: github.event_name != 'pull_request'
       #   run: |
-      #     cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+      #     cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
       #   env:
       #     COSIGN_EXPERIMENTAL: false
       #     COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Common Files
+name: Build
 on:
   pull_request:
     branches:


### PR DESCRIPTION
This PR replaces Docker-based actions with native podman and buildah commands.

## Changes
- Remove docker/build-push-action in favor of buildah build
- Remove docker/login-action in favor of podman login
- Simplify workflow with direct buildah and podman commands
- Tag only as :latest following podman best practices

## Benefits
- Uses native OCI tools (podman/buildah)
- Simpler, more straightforward workflow
- Aligns with ublue-os tooling standards
- No external Docker dependencies

The workflow builds the container with buildah and pushes with podman to ghcr.io/projectbluefin/bluefin-common:latest