### PR TITLE
Add Justfile with build recipe for local container builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,3 @@
+# Build the bluefin-common container locally
+build:
+    podman build -t bluefin-common:latest .


### PR DESCRIPTION
Adds a root Justfile that allows building the container locally with `just build`, which uses podman to build the bluefin-common container.