### PR TITLE
build: use buildah in Justfile for consistency with CI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,3 @@
 # Build the bluefin-common container locally
 build:
-    podman build -t bluefin-common:latest .
+    buildah build -t bluefin-common:latest -f ./Containerfile .


### PR DESCRIPTION
Aligns the local build command with the GitHub Actions workflow which uses buildah. Also adds explicit `-f` flag to match the CI build command exactly.

This ensures consistency between local development and CI builds.

Tested locally - build succeeds and produces a 31.4 KB image.