### PR TITLE
ci: add monthly automated snapshot release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Monthly Release
+
+on:
+  schedule:
+    # Run on the 1st of every month at 00:00 UTC
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create monthly snapshot release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Generate release tag
+        id: tag
+        run: |
+          TAG="v$(date +'%Y.%m')"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Release tag: ${TAG}"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | head -n1)
+          
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "First release - no previous tag found"
+            NOTES="Monthly snapshot release ${TAG}
+
+This is an automated monthly snapshot of bluefin-common configuration files."
+          else
+            echo "Generating notes since ${PREVIOUS_TAG}"
+            NOTES="Monthly snapshot release ${TAG}
+
+## Changes since ${PREVIOUS_TAG}
+
+$(git log ${PREVIOUS_TAG}..HEAD --pretty=format:'- %s (%h)' --no-merges)
+
+---
+*This is an automated monthly snapshot of bluefin-common configuration files.*"
+          fi
+          
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
+        with:
+          tag: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          body: ${{ steps.notes.outputs.notes }}
+          draft: false
+          prerelease: false
+          makeLatest: true


### PR DESCRIPTION
Adds a scheduled GitHub Action that automatically creates monthly snapshot releases.

## Features
- Runs automatically on the 1st of each month at 00:00 UTC
- Tags releases as `vYYYY.MM` (e.g., `v2025.11`)
- Generates release notes from git commits since the previous release
- Can be manually triggered via workflow_dispatch for ad-hoc releases
- Marks each release as the latest

## GitHub Actions Used
- **actions/checkout@v4.2.2** - Check out repository with full git history
- **ncipollo/release-action@v1.14.0** - Create GitHub releases with automated tagging

This allows maintainers to continuously add changes while having regular monthly snapshots for tracking and versioning purposes.