### PR TITLE
ci: add Renovate configuration for automated dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices"
+  ],
+
+  "rebaseWhen": "never",
+  "schedule": [
+    "* 0 * * *"
+  ],
+
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["pin", "pinDigest"]
+    },
+    {
+      "automerge": true,
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "patch", "minor"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds Renovate bot configuration to automate dependency updates, based on the configuration from ublue-os/toolboxes.

## Features
- **Daily schedule** - Runs at midnight UTC
- **Auto-merge** - Automatically merges pin and digest updates
- **Grouped updates** - GitHub Actions updates are grouped together
- **Best practices** - Uses Renovate's recommended best practices preset

## What gets updated
- GitHub Actions in workflows (actions/checkout, ncipollo/release-action, etc.)
- Automatically pins and updates action digests
- Groups patches and minor updates for easier review

This ensures the repository stays up-to-date with the latest security patches and features without manual intervention.

Based on: https://github.com/ublue-os/toolboxes/blob/main/.github/renovate.json5