### PR TITLE
docs: document OCI usage patterns and directory contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,60 @@
-# common
-OCI layer for things that need to be on every bluefin
+# bluefin-common
+
+Shared OCI layer containing common configuration files used across all Bluefin variants (bluefin, bluefin-dx, bluefin-lts).
+
+## What's Inside
+
+This layer contains two main configuration directories:
+
+### `/etc/ublue-os/` - System Configuration
+- **Bling configuration** - CLI theming settings
+- **Fastfetch settings** - System information display configuration
+- **Setup configuration** - First-boot and system setup parameters
+
+### `/usr/share/ublue-os/` - User-Space Configuration
+- **Firefox defaults** - Pre-configured Firefox settings
+- **Flatpak overrides** - Application-specific Flatpak configurations
+- **Just recipes** - Additional command recipes for system management
+- **MOTD templates** - Message of the day and tips
+- **Setup hooks** - Scripts for privileged, system, and user setup stages
+
+## Usage in Containerfile
+
+Reference this layer as a build stage and copy the directories you need:
+
+### Copy everything:
+```dockerfile
+FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
+
+# Copy all system files
+COPY --from=bluefin-common /system_files /
+```
+
+### Copy only system configuration:
+```dockerfile
+FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
+
+# Copy only /etc configuration
+COPY --from=bluefin-common /system_files/etc /etc
+```
+
+### Copy only user-space configuration:
+```dockerfile
+FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
+
+# Copy only /usr/share configuration
+COPY --from=bluefin-common /system_files/usr /usr
+```
+
+## Building Locally
+
+```bash
+just build
+```
+
+## Contributing
+
+See [AGENTS.md](AGENTS.md) for development guidelines and instructions.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Shared OCI layer containing common configuration files used across all Bluefin v
 This layer contains two main configuration directories:
 
 ### `/etc/ublue-os/` - System Configuration
-- **Bling configuration** - CLI theming settings
-- **Fastfetch settings** - System information display configuration
-- **Setup configuration** - First-boot and system setup parameters
+- Bling - CLI theming settings
+- Fastfetch settings - System information display configuration
+- Setup configuration - First-boot and system setup parameters
 
 ### `/usr/share/ublue-os/` - User-Space Configuration
-- **Firefox defaults** - Pre-configured Firefox settings
-- **Flatpak overrides** - Application-specific Flatpak configurations
-- **Just recipes** - Additional command recipes for system management
-- **MOTD templates** - Message of the day and tips
-- **Setup hooks** - Scripts for privileged, system, and user setup stages
+- Firefox defaults - Pre-configured Firefox settings
+- Flatpak overrides - Application-specific Flatpak configurations
+- Just recipes - Additional command recipes for system management
+- MOTD templates - Message of the day and tips
+- Setup hooks - Scripts for privileged, system, and user setup stages
 
 ## Usage in Containerfile
 
@@ -31,6 +31,9 @@ COPY --from=bluefin-common /system_files /
 ```
 
 ### Copy only system configuration:
+
+This is what Aurora should use, gives shares the common set of files and keeps the images opinions seperate.
+
 ```dockerfile
 FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
 
@@ -38,7 +41,7 @@ FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
 COPY --from=bluefin-common /system_files/etc /etc
 ```
 
-### Copy only user-space configuration:
+### Copy only the image opinion:
 ```dockerfile
 FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
 
@@ -51,11 +54,3 @@ COPY --from=bluefin-common /system_files/usr /usr
 ```bash
 just build
 ```
-
-## Contributing
-
-See [AGENTS.md](AGENTS.md) for development guidelines and instructions.
-
-## TODO
-
-Split this repo into common and bluefin specific so Aurora can copy out what is image agnostic, that way we can share config. 


### PR DESCRIPTION
Updates the README with comprehensive documentation on how to consume this OCI layer.

## Changes
- Added clear explanation of what's inside the layer
- Documented major components in `/etc/ublue-os/` and `/usr/share/ublue-os/`
- Provided three usage examples for Containerfiles:
  - Copy all system files
  - Copy only `/etc` configuration
  - Copy only `/usr` configuration
- Added local build instructions
- Improved overall structure and clarity

This makes it easier for consumers (like bluefin and bluefin-lts) to understand what this layer contains and how to use it effectively in their builds.