### PR TITLE
ci: onboard to ublue-os org-wide Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,24 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
-  ],
-
-  "rebaseWhen": "never",
-  "schedule": [
-    "* 0 * * *"
-  ],
-
-  "packageRules": [
-    {
-      "automerge": true,
-      "matchUpdateTypes": ["pin", "pinDigest"]
-    },
-    {
-      "automerge": true,
-      "groupName": "github-actions",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["digest", "patch", "minor"]
-    }
+    "github>ublue-os/renovate-config:org-inherited-config"
   ]
 }


### PR DESCRIPTION
Simplifies Renovate configuration by inheriting from `ublue-os/renovate-config` org-inherited-config instead of maintaining custom rules.

## Changes

- Updated `.github/renovate.json5` to extend `github>ublue-os/renovate-config:org-inherited-config`
- Removed redundant local configuration (best-practices, schedule, auto-merge rules)

## Benefits

✅ **Consistency** - Uses same Renovate settings as all ublue-os repositories
✅ **Simplified maintenance** - Configuration managed centrally in ublue-os/renovate-config
✅ **Inherited features**:
  - Best practices preset
  - Semantic commits
  - Custom managers for image-versions YAML files
  - Proper scheduling and auto-merge rules

The repository now inherits all org-wide Renovate configuration while maintaining the ability to add repo-specific overrides if needed in the future.

Related: https://github.com/ublue-os/renovate-config