### PR TITLE
feat(brew): add Homebrew systemd services and setup

### DIFF
--- a/ 
+++ b/ 
@@ -1,0 +1,5 @@
+# Homebrew is installed at build-time to /var/home/linuxbrew
+# These directives ensure proper ownership for first user (UID 1000) at runtime
+d /var/lib/homebrew 0755 1000 1000 - -
+d /var/cache/homebrew 0755 1000 1000 - -
+d /var/home/linuxbrew 0755 1000 1000 - -

--- a/system_files/shared/etc/profile.d/brew-bash-completion.sh
+++ b/system_files/shared/etc/profile.d/brew-bash-completion.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# shellcheck shell=sh disable=SC1091,SC2039,SC2166
+# Check for interactive bash and that we haven't already been sourced.
+if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" != x -a "x${BREW_BASH_COMPLETION-}" = x ]; then
+
+    # Check for recent enough version of bash.
+    if [ "${BASH_VERSINFO[0]}" -gt 4 ] ||
+        [ "${BASH_VERSINFO[0]}" -eq 4 -a "${BASH_VERSINFO[1]}" -ge 2 ]; then
+        if [ -w /home/linuxbrew/.linuxbrew ]; then
+            if ! test -L /home/linuxbrew/.linuxbrew/etc/bash_completion.d/brew; then
+                /home/linuxbrew/.linuxbrew/bin/brew completions link > /dev/null
+            fi
+        fi
+        if test -d /home/linuxbrew/.linuxbrew/etc/bash_completion.d; then
+            for rc in /home/linuxbrew/.linuxbrew/etc/bash_completion.d/*; do
+                if test -r "$rc"; then
+                . "$rc"
+                fi
+            done
+            unset rc
+        fi
+    fi
+    BREW_BASH_COMPLETION=1
+    export BREW_BASH_COMPLETION
+fi

--- a/system_files/shared/etc/profile.d/brew.sh
+++ b/system_files/shared/etc/profile.d/brew.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+[[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/system_files/shared/etc/security/limits.d/30-brew-limits.conf
+++ b/system_files/shared/etc/security/limits.d/30-brew-limits.conf
@@ -1,0 +1,9 @@
+#This file sets the resource limits for the users logged in via PAM,
+#more specifically, users logged in on via SSH or tty (console).
+#Limits related to terminals in Wayland/Xorg sessions depend on a
+#change to /etc/systemd/user.conf.
+#This does not affect resource limits of the system services.
+#This file overrides defaults set in /etc/security/limits.conf
+
+* soft nofile 4096
+root soft nofile 4096

--- a/system_files/shared/usr/lib/systemd/system/brew-setup.service
+++ b/system_files/shared/usr/lib/systemd/system/brew-setup.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Setup Brew
+Wants=basic.target
+After=basic.target
+ConditionPathExists=!/etc/.linuxbrew
+ConditionPathExists=!/var/home/linuxbrew/.linuxbrew
+ConditionPathExists=/usr/share/homebrew.tar.zst
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mkdir -p /tmp/homebrew
+ExecStart=/usr/bin/mkdir -p /var/home/linuxbrew
+ExecStart=/usr/bin/tar --zstd -xvf /usr/share/homebrew.tar.zst -C /tmp/homebrew
+ExecStart=/usr/bin/cp -R -n /tmp/homebrew/home/linuxbrew/.linuxbrew /var/home/linuxbrew
+ExecStart=/usr/bin/chown -R 1000:1000 /var/home/linuxbrew
+ExecStart=/usr/bin/rm -rf /tmp/homebrew
+ExecStart=/usr/bin/touch /etc/.linuxbrew
+
+[Install]
+WantedBy=default.target multi-user.target

--- a/system_files/shared/usr/lib/systemd/system/brew-update.service
+++ b/system_files/shared/usr/lib/systemd/system/brew-update.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Auto update brew for mutable brew installs
+After=local-fs.target
+After=network-online.target
+ConditionPathExists=/home/linuxbrew/.linuxbrew/bin/brew
+ConditionPathIsExecutable=/home/linuxbrew/.linuxbrew/bin/brew
+
+[Service]
+User=1000
+Type=oneshot
+Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew update"

--- a/system_files/shared/usr/lib/systemd/system/brew-update.timer
+++ b/system_files/shared/usr/lib/systemd/system/brew-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer for brew update for mutable brew
+Wants=network-online.target
+
+[Timer]
+OnBootSec=10min
+OnUnitInactiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/system_files/shared/usr/lib/systemd/system/brew-upgrade.service
+++ b/system_files/shared/usr/lib/systemd/system/brew-upgrade.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Upgrade Brew packages
+After=local-fs.target
+After=network-online.target
+ConditionPathExists=/home/linuxbrew/.linuxbrew/bin/brew
+ConditionPathIsExecutable=/home/linuxbrew/.linuxbrew/bin/brew
+
+[Service]
+User=1000
+Type=oneshot
+Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
+# Prevent Brew from overriding important system binaries
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink systemd"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink dbus"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink python"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink gsettings"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink bash"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink rpm"

--- a/system_files/shared/usr/lib/systemd/system/brew-upgrade.timer
+++ b/system_files/shared/usr/lib/systemd/system/brew-upgrade.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer for brew upgrade for on image brew
+Wants=network-online.target
+
+[Timer]
+OnBootSec=30min
+OnUnitInactiveSec=8h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/system_files/shared/usr/lib/tmpfiles.d/homebrew.conf
+++ b/system_files/shared/usr/lib/tmpfiles.d/homebrew.conf
@@ -1,0 +1,5 @@
+# Homebrew is extracted at first boot by brew-setup.service to /var/home/linuxbrew
+# These directives ensure proper ownership for first user (UID 1000) at runtime
+d /var/lib/homebrew 0755 1000 1000 - -
+d /var/cache/homebrew 0755 1000 1000 - -
+d /var/home/linuxbrew 0755 1000 1000 - -

--- a/system_files/shared/usr/share/fish/vendor_conf.d/ublue-brew.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/ublue-brew.fish
@@ -1,0 +1,13 @@
+#!/usr/bin/fish
+#shellcheck disable=all
+if status --is-interactive
+    if [ -d /home/linuxbrew/.linuxbrew ]
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        if test -d (brew --prefix)/share/fish/completions
+            set -p fish_complete_path (brew --prefix)/share/fish/completions
+        end
+        if test -d (brew --prefix)/share/fish/vendor_completions.d
+            set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+        end
+    end
+end


### PR DESCRIPTION
### Summary
- Add systemd services and timers for automated Homebrew setup, updates, and upgrades
- Add shell integration for bash and fish with proper PATH and completions
- Include tmpfiles.d and security limits configuration for Homebrew

### Changes
- **brew-setup.service**: One-shot service to extract pre-packaged Homebrew tarball on first boot
- **brew-update.service/timer**: Daily automatic `brew update`
- **brew-upgrade.service/timer**: Weekly automatic `brew upgrade` with safety unlinking of system-critical packages (systemd, dbus, python, bash, rpm, etc.)
- **Shell integration**: Profile scripts for bash and fish to set up Homebrew environment
- **Bash completions**: Dynamic completion loading for brew commands
- **tmpfiles.d**: Creates required directory structure
- **limits.conf**: Sets appropriate resource limits for Homebrew operations
