### PR TITLE
fix: swap the logic on toggle-user-motd ujust

### DIFF
--- a/system_files/usr/share/ublue-os/just/default.just
+++ b/system_files/usr/share/ublue-os/just/default.just
@@ -47,16 +47,16 @@ enroll-secure-boot-key:
 toggle-user-motd:
     #!/usr/bin/bash
     if [ -e "${HOME}/.config/no-show-user-motd" ] ; then
-      if gum confirm "Would you like to disable the MOTD?" ; then
+      if gum confirm "Would you like to enable the MOTD?" ; then
         rm -f "${HOME}/.config/no-show-user-motd"
-        echo "MOTD will not be shown anymore"
+        echo "MOTD will now be shown on login."
         exit 0
       fi
     fi
-    if gum confirm "Would you like to enable the MOTD?" ; then
+    if gum confirm "Would you like to DISABLE the MOTD?" ; then
       mkdir -p "${HOME}/.config"
       touch "${HOME}/.config/no-show-user-motd"
-      echo "MOTD will be shown now"
+      echo "MOTD will not be shown anynow"
       exit 0
     fi
 


### PR DESCRIPTION
The current implementation is backwards. 

After fresh install if the `ujust toggle-user-motd` is run, the script asks "do you want to enable it" which is backwards, as it should ask if you want to disable it because the file that it checks doesn't exist :)