### PR TITLE
feat: add IDE Brewfile with VSCode, VSCodium, and JetBrains

### DIFF
--- a/system_files/usr/share/ublue-os/homebrew/ide.Brewfile
+++ b/system_files/usr/share/ublue-os/homebrew/ide.Brewfile
@@ -1,0 +1,4 @@
+tap "ublue-os/homebrew-tap"
+cask "ublue-os/homebrew-tap/visual-studio-code"
+cask "ublue-os/homebrew-tap/vscodium"
+cask "ublue-os/homebrew-tap/jetbrains-toolbox"


### PR DESCRIPTION
Add ide.Brewfile containing IDE tools from @ublue-os/homebrew-tap:
- visual-studio-code
- vscodium
- jetbrains-toolbox

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot