### PR TITLE
Add regex manager for ublue-os artwork releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>ublue-os/renovate-config:org-inherited-config"
+  ],
+
+  "regexManagers": [
+    {
+      "fileMatch": ["^Containerfile$"],
+      "matchStrings": [
+        "https://github\\.com/ublue-os/artwork/releases/download/bluefin-v(?<version>[0-9\\-]+)/bluefin-wallpapers\\.tar\\.zstd"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "ublue-os/artwork"
+    }
   ]
 }


### PR DESCRIPTION
This is the same format currently on aurora/common

This does need some additions to the Containerfile too but not sure how Gnome does those

f.ex in Auroras common containerfile:

``` 
COPY --from=ghcr.io/ublue-os/artwork/aurora-wallpapers:latest / /wallpapers

RUN set -xeuo pipefail && \
    cd /wallpapers && \
    rm -rf kde/*/gnome-background-properties/ && \
    mkdir -p /output/usr/share/wallpapers /output/usr/share/backgrounds && \
    mv kde/ /output/usr/share/backgrounds/aurora/ && \
    cd /output/usr/share/backgrounds && \
    for dir in aurora/*; do \
      ln -sr "/output/usr/share/backgrounds/${dir}" /output/usr/share/wallpapers/; \
    done && \
    ln -sr /output/usr/share/backgrounds/aurora/aurowa-wallpaper-6/ /output/usr/share/backgrounds/aurora/aurora-wallpaper-1 && \
    ln -sr /output/usr/share/backgrounds/aurora/aurora-wallpaper-1/ /output/usr/share/wallpapers/ && \
    rm -rf /wallpapers

FROM scratch AS ctx

COPY --from=builder /output/ /wallpapers
```
