### PR TITLE
feat: rewrite luks autounlock script with new instructions from gnomeOS

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -123,14 +123,7 @@ alias rollback-helper := rebase-helper
 rebase-helper:
     @/usr/bin/ublue-rollback-helper
 
-# FIXME: apparently this is broken since F43
-# Enable automatic LUKS unlock via TPM
-setup-luks-tpm-unlock:
-    #!/usr/bin/bash
-    sudo /usr/libexec/luks-enable-tpm2-autounlock
-
-# Disable automatic LUKS unlock via TPM
-remove-luks-tpm-unlock:
-    #!/usr/bin/bash
-    sudo /usr/libexec/luks-disable-tpm2-autounlock
-
+# TPM2 auto-unlock toggle
+[group('System')]
+toggle-tpm2:
+    @/usr/bin/luks-tpm2-autounlock

--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# References:
+#  https://os.gnome.org/install
+#  https://www.reddit.com/r/Fedora/comments/uo4ufq/any_way_to_get_systemdcryptenroll_working_on/
+#  https://0pointer.net/blog/unlocking-luks2-volumes-with-tpm2-fido2-pkcs11-security-hardware-on-systemd-248.html
+
+gum confirm --affirmative="Enable" --negative="Disable" "Toggle TPM2 auto-unlock"
+EXIT_CODE="$?"
+case "${EXIT_CODE}" in
+  0|1)
+    ;;
+  *)
+    exit 0
+esac
+
+RD_LUKS_UUID="$(xargs -n1 -a /proc/cmdline | grep -F -e "rd.luks.uuid" | cut -d = -f 2 | sed "s/^luks-//" )"
+CRYPT_DISK="$(realpath "/dev/disk/by-uuid/${RD_LUKS_UUID}")"
+
+if ! find /dev -iname "${RD_LUKS_UUID:-INVALIDINVALID}" | grep -F -e "${RD_LUKS_UUID}" &>/dev/null; then
+  echo "Could not find LUKS device used to boot system on system mount table. Is your drive encrypted?"
+  exit 1
+fi
+
+if [ "${EXIT_CODE}" == 1 ] ; then
+  sudo systemd-cryptenroll --wipe-slot=tpm2 "${CRYPT_DISK}"
+  exit 0
+fi
+
+gum confirm "Would you like to set up a PIN?"
+EXIT_CODE="$?"
+SET_PIN_ARG=""
+case "${EXIT_CODE}" in
+  0)
+    export SET_PIN_ARG="--tpm2-with-pin=yes"
+    ;;
+  1)
+    ;;
+  *)
+    exit 0
+esac
+
+if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='' "${SET_PIN_ARG}" "${CRYPT_DISK}" ; then
+  echo "TPM2 LUKS auto-unlock configured for next reboot."
+fi

--- a/system_files/shared/usr/lib/dracut/fido-tpm2-luks.conf
+++ b/system_files/shared/usr/lib/dracut/fido-tpm2-luks.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc "


### PR DESCRIPTION

Basically just cleans up the entire luks-enable*/disable scripts from https://github.com/ublue-os/packages/blob/0d5a643bbad85d9e4b55328edeb7b0c3310b6a05/packages/ublue-os-luks/src/luks-enable-tpm2-autounlock

Before merging this:
- [ ] Remove `ublue-os-luks` from Aurora
- [ ] Remove `ublue-os-luks` from Bluefin
- [ ] Remove `ublue-os-luks` from Bluefin-LTS