### PR TITLE
feat: add most of `ublue-polkit-rules`

### DIFF
--- a/system_files/shared/usr/share/polkit-1/rules.d/org.debian.pcsc-lite.access_card.rules
+++ b/system_files/shared/usr/share/polkit-1/rules.d/org.debian.pcsc-lite.access_card.rules
@@ -1,0 +1,16 @@
+// allow members of the wheel group to access gpg cards via pcscd service
+// this is needed for access to yubikey devices
+// installation details from https://github.com/drduh/YubiKey-Guide/issues/376
+
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_card" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_pcsc" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});


### PR DESCRIPTION
This does not include our `sudoers` configuration for bootc since it is
a source of privilege escalation issues. We have an advisory for it on
`ublue-os/packages` even.

- [ ] Bluefin/Aurora/LTS need PRs for migration
