### PR TITLE
feat: enable merge queue in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Add `merge_group` trigger to the build workflow to support GitHub's merge queue feature. This ensures PRs are tested in the merge queue before being merged to main.