### PR TITLE
feat: move `ublue-setup-services` to here

### DIFF
--- a/system_files/shared/usr/bin/ublue-privileged-setup
+++ b/system_files/shared/usr/bin/ublue-privileged-setup
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+get_config() {
+	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+PRIVILEGED_HOOKS_DIRECTORY="$(get_config '."privileged-hooks-directory"' "/usr/share/ublue-os/privileged-setup.hooks.d")"
+HOOKS_VERBOSE="${HOOKS_VERBOSE:-$(get_config '."verbose"' "false")}"
+
+if [ "${HOOKS_VERBOSE}" == "true" ] ; then
+	set -x
+fi
+
+if [ -d "${PRIVILEGED_HOOKS_DIRECTORY}" ] ; then
+	for script in $PRIVILEGED_HOOKS_DIRECTORY/* ; do
+		bash $script
+	done
+fi

--- a/system_files/shared/usr/bin/ublue-system-setup
+++ b/system_files/shared/usr/bin/ublue-system-setup
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+get_config() {
+	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+SYSTEM_HOOKS_DIRECTORY="$(get_config '."system-hooks-directory"' "/usr/share/ublue-os/system-setup.hooks.d")"
+HOOKS_VERBOSE="${HOOKS_VERBOSE:-$(get_config '."verbose"' "false")}"
+
+if [ "${HOOKS_VERBOSE}" == "true" ] ; then
+	set -x
+fi
+
+if [ -d "${SYSTEM_HOOKS_DIRECTORY}" ] ; then
+	for script in $SYSTEM_HOOKS_DIRECTORY/* ; do
+		bash $script
+	done
+fi
+

--- a/system_files/shared/usr/bin/ublue-user-setup
+++ b/system_files/shared/usr/bin/ublue-user-setup
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+get_config() {
+	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-os/user-setup.hooks.d")"
+HOOKS_VERBOSE="${HOOKS_VERBOSE:-$(get_config '."verbose"' "false")}"
+
+if [ "${HOOKS_VERBOSE}" == "true" ] ; then
+	set -x
+fi
+
+# Privileged setup can be called via user services
+if [ -d "$USER_HOOKS_DIRECTORY" ] ; then
+	for script in $USER_HOOKS_DIRECTORY/* ; do
+		bash $script
+	done
+fi

--- a/system_files/shared/usr/lib/systemd/system/ublue-system-setup.service
+++ b/system_files/shared/usr/lib/systemd/system/ublue-system-setup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Configure system
+After=rpm-ostreed.service
+Before=systemd-user-sessions.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ublue-system-setup
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/shared/usr/lib/systemd/user/ublue-user-setup.service
+++ b/system_files/shared/usr/lib/systemd/user/ublue-user-setup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Configure system for current user
+Wants=network-online.target
+After=network-online.target
+ConditionUser=!@system
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ublue-user-setup
+
+[Install]
+WantedBy=graphical-session.target

--- a/system_files/shared/usr/lib/ublue/setup-services/libsetup.sh
+++ b/system_files/shared/usr/lib/ublue/setup-services/libsetup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+SETUP_CHECKER_FILE="${SETUP_CHECKER_FILE:-$HOME/.local/share/ublue/setup_versioning.json}"
+
+# Meant to be used at the start of any setup service script. Will version your script accordingly on $SETUP_CHECKER_FILE
+# :target_versioning_name: Whatever you want to name your versioning tag. Please keep it always the same
+# :type_of_service: Must be either `user`, `privileged`, or `system`
+# :version: Target version to check/apply to your file
+#
+# Meant to be used as follows (or similar):
+# version-script tailscale user 1 || exit 0
+function version-script() {
+  TARGET_VERSIONING_NAME=$1
+  TYPE_OF_SERVICE=$2
+  VERSION=$3
+  shift
+  shift
+  shift
+
+  if [ ! -e "${SETUP_CHECKER_FILE}" ] ; then
+    mkdir -p "$(dirname "${SETUP_CHECKER_FILE}")"
+    echo "{}" > "${SETUP_CHECKER_FILE}"
+  fi
+
+  if [ "$(jq -r -c ".version.${TYPE_OF_SERVICE}.\"${TARGET_VERSIONING_NAME}\"" "${SETUP_CHECKER_FILE}")" == "${VERSION}" ] ; then
+    echo "Exiting as current version (${VERSION}) for ${TYPE_OF_SERVICE}-${TARGET_VERSIONING_NAME} is the same as latest version recorded on ${SETUP_CHECKER_FILE}"
+    return 1
+  fi
+  ANNOYING_JQ_WORKAROUND=$(mktemp)
+  jq ".version.${TYPE_OF_SERVICE}.\"${TARGET_VERSIONING_NAME}\" = \"${VERSION}\"" "${SETUP_CHECKER_FILE}" >"${ANNOYING_JQ_WORKAROUND}"
+  mv "${ANNOYING_JQ_WORKAROUND}" "${SETUP_CHECKER_FILE}"
+  set +x
+  return 0
+}

--- a/system_files/shared/usr/share/polkit-1/actions/org.ublue.privileged.user.setup.policy
+++ b/system_files/shared/usr/share/polkit-1/actions/org.ublue.privileged.user.setup.policy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>Universal Blue</vendor>
+  <vendor_url>https://github.com/ublue-os/</vendor_url>
+
+  <action id="org.ublue.policykit.privileged.user.setup">
+    <description>Allows certain user configuration tasks to run as root</description>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/ublue-privileged-setup</annotate>
+  </action>
+
+</policyconfig>

--- a/system_files/shared/usr/share/polkit-1/rules.d/20-privileged-user-setup.rules
+++ b/system_files/shared/usr/share/polkit-1/rules.d/20-privileged-user-setup.rules
@@ -1,0 +1,10 @@
+polkit.addRule(function(action,subject) {
+    if ( (action.id == "org.freedesktop.policykit.exec") &&
+         (action.lookup("program") == "/usr/bin/ublue-privileged-setup") &&
+         (subject.isInGroup("wheel") ) ) {
+      return polkit.Result.YES;
+    }
+
+    return polkit.Result.NOT_HANDLED;
+  }
+);


### PR DESCRIPTION

Same as https://github.com/ublue-os/packages/blob/0d5a643bbad85d9e4b55328edeb7b0c3310b6a05/packages/ublue-setup-services/ but here instead! Refactored to use `/usr/bin` instead of `/usr/libexec`.
