### PR TITLE
ujust: don't hardcode to `/usr/bin/just` so we can use homebrew just for `ujust`!

### DIFF
--- a/system_files/shared/usr/bin/ujust
+++ b/system_files/shared/usr/bin/ujust
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-/usr/bin/just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"
+just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"


### PR DESCRIPTION
Thats it really
