### PR TITLE
feat: add bluefin-ai recipe to install AI tools bundle

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -6,6 +6,12 @@
 bluefin-cli:
     @/usr/bin/ublue-bling
 
+# Install AI tools bundle with Brew
+[group('System')]
+bluefin-ai:
+    #!/usr/bin/env bash
+    brew bundle install --file=/usr/share/ublue-os/homebrew/ai-tools.Brewfile
+
 # alias for toggle-devmode
 devmode:
     @ujust toggle-devmode


### PR DESCRIPTION
Add `ujust bluefin-ai` command that installs AI tools from the ai-tools.Brewfile using Homebrew bundle.

We missed this when moving it over, this fixes: https://github.com/ublue-os/bluefin/issues/3849