### PR TITLE
fix: togge-tpm2 recipe when NO pin is used

### DIFF
--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -40,6 +40,6 @@ case "${EXIT_CODE}" in
     exit 0
 esac
 
-if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='' "${SET_PIN_ARG}" "${CRYPT_DISK}" ; then
+if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='' ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
   echo "TPM2 LUKS auto-unlock configured for next reboot."
 fi


### PR DESCRIPTION
The "${SET_PIN_ARG}" breaks the script from running if user selects NO when asked if PIN is used to unlock.

_When SET_PIN_ARG is empty (user chose "No" to PIN), the quoted "${SET_PIN_ARG}" becomes an empty string "", which systemd-cryptenroll interprets as an extra positional argument, causing the "too many arguments" error._

Should close https://github.com/projectbluefin/common/issues/60 and https://github.com/ublue-os/aurora/issues/1483

Can't test this right now as not home and don't have access to my linux machines