### PR TITLE
feat: integrate brew OCI container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,8 @@
+ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
+ARG BREW_IMAGE_SHA=""
+
+FROM ${BREW_IMAGE}@${BREW_IMAGE_SHA} AS brew
+
 FROM docker.io/library/alpine:latest AS build
 
 COPY --from=ghcr.io/ublue-os/bluefin-wallpapers-gnome:latest / /out/bluefin/usr/share
@@ -24,4 +29,4 @@ COPY /system_files/bluefin /system_files/bluefin
 
 COPY --from=build /out/shared /system_files/shared
 COPY --from=build /out/bluefin /system_files/bluefin
-COPY --from=ghcr.io/ublue-os/brew:latest /system_files /system_files/shared
+COPY --from=brew /system_files /system_files/shared

--- a/Containerfile
+++ b/Containerfile
@@ -24,3 +24,4 @@ COPY /system_files/bluefin /system_files/bluefin
 
 COPY --from=build /out/shared /system_files/shared
 COPY --from=build /out/bluefin /system_files/bluefin
+COPY --from=ghcr.io/ublue-os/brew:latest /system_files /system_files/shared

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,23 @@
+brew_image := "ghcr.io/ublue-os/brew:latest"
+
 # Build the bluefin-common container locally
 build:
+    #!/usr/bin/bash
+    set -eoux pipefail
+    
+    brew_image_sha=$(yq -r '.images[] | select(.name == "brew") | .digest' image-versions.yml)
+    
+    # Verify brew image with cosign
+    cosign verify --key https://raw.githubusercontent.com/ublue-os/brew/refs/heads/main/cosign.pub ghcr.io/ublue-os/brew:latest@${brew_image_sha}
+    
+    podman build \
+        --build-arg BREW_IMAGE={{ brew_image }} \
+        --build-arg BREW_IMAGE_SHA=${brew_image_sha} \
+        -t localhost/bluefin-common:latest \
+        -f ./Containerfile .
+
+# Build without cosign verification (for testing)
+build-no-verify:
     podman build -t localhost/bluefin-common:latest -f ./Containerfile .
 
 # Inspect the directory structure of an OCI image

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,0 +1,5 @@
+images:
+  - name: brew
+    image: ghcr.io/ublue-os/brew
+    tag: latest
+    digest: sha256:23d65284b917832b6f300e078cbf252ed8dd3ccfe648aa51ee7f96927b165fb0


### PR DESCRIPTION
## Summary

Integrates Homebrew installation from the `ghcr.io/ublue-os/brew` OCI image into the common layer with proper digest pinning and cosign verification, replacing the need for the `ublue-brew` COPR package in downstream images.

## Changes

| File | Description |
|------|-------------|
| `Containerfile` | Added ARG pattern for BREW_IMAGE/BREW_IMAGE_SHA with multi-stage build |
| `image-versions.yml` | New file with pinned brew image digest for reproducibility |
| `Justfile` | Updated build command with digest extraction and cosign verification |

### Containerfile Changes
```dockerfile
ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
ARG BREW_IMAGE_SHA=""

FROM ${BREW_IMAGE}@${BREW_IMAGE_SHA} AS brew
# ... existing build stages ...
COPY --from=brew /system_files /system_files/shared
```

### New image-versions.yml
```yaml
images:
  - name: brew
    image: ghcr.io/ublue-os/brew
    tag: latest
    digest: sha256:23d65284b917832b6f300e078cbf252ed8dd3ccfe648aa51ee7f96927b165fb0
```

### Justfile Updates
- Extracts digest from `image-versions.yml` using yq
- Verifies brew image with cosign before building
- Passes `BREW_IMAGE` and `BREW_IMAGE_SHA` as build args
- Added `build-no-verify` target for local testing without cosign

## What the brew OCI image provides

| File/Service | Purpose |
|--------------|---------|
| `/usr/share/homebrew.tar.zst` | Pre-built Homebrew installation (~122MB) |
| `brew-setup.service` | First-run setup service |
| `brew-update.service` | Homebrew update service |
| `brew-upgrade.service` | Package upgrade service |
| Shell integration | bash and fish completions/paths |

## Why this belongs in common

- Homebrew is foundational to the Bluefin experience
- The Brewfiles that depend on brew (`cli.Brewfile`, `full-desktop.Brewfile`, etc.) already live in common
- Having brew installation alongside its Brewfiles maintains architectural consistency
- All Bluefin variants need brew, so it belongs in the shared layer

## Follow-up required in bluefin

After this PR is merged, bluefin will need a small follow-up PR to remove `ublue-brew` from the COPR package list in `build_files/base/04-packages.sh`.

## Test plan

- [ ] Build common image locally with `just build` (requires cosign, yq)
- [ ] Or use `just build-no-verify` for testing without cosign
- [ ] Verify brew system files are present using `just tree`
- [ ] Build downstream bluefin image and verify brew functionality

---

Closes ublue-os/bluefin#3834