### PR TITLE
feat: add ujust powerwash command for factory reset

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -128,3 +128,19 @@ rebase-helper:
 [group('System')]
 toggle-tpm2:
     @/usr/bin/luks-tpm2-autounlock
+
+# Factory reset this device (experimental)
+[group('System')]
+powerwash:
+    #!/usr/bin/bash
+    FIRST_CONFIRMATION=$(gum choose --header='Warning: This is an experimental feature that will reset this device to its factory state.' "No" "Yes - wipe this machine")
+    if [[ "$FIRST_CONFIRMATION" != "Yes - wipe this machine" ]]; then
+        echo "Powerwash cancelled."
+        exit 0
+    fi
+    SECOND_CONFIRMATION=$(gum choose --header='Are you sure?' "No" "Yes - wipe this machine")
+    if [[ "$SECOND_CONFIRMATION" != "Yes - wipe this machine" ]]; then
+        echo "Powerwash cancelled."
+        exit 0
+    fi
+    sudo bootc install reset --experimental


### PR DESCRIPTION
## Summary
Adds a new `ujust powerwash` command that performs a factory reset using `bootc install reset --experimental`.

## Details
- Implements two confirmation dialogs using `gum choose`
- Both dialogs have "No" as the default (first) option to prevent accidental data loss
- First dialog: Warning about experimental feature resetting to factory state
- Second dialog: "Are you sure?" confirmation
- Executes `sudo bootc install reset --experimental` per [bootc documentation](https://github.com/bootc-dev/bootc/blob/main/docs/src/experimental-install-reset.md)

## Testing
Run `ujust powerwash` and verify:
1. First confirmation dialog appears with warning message
2. Selecting "No" cancels the operation
3. Selecting "Yes" shows second confirmation
4. Second "No" cancels, second "Yes" runs the bootc command