### PR TITLE
fix(motd): use full terminal width

### DIFF
--- a/system_files/shared/usr/bin/ublue-motd
+++ b/system_files/shared/usr/bin/ublue-motd
@@ -3,4 +3,4 @@
 MOTD_TEMPLATE_FILE="${MOTD_TEMPLATE_FILE:-/usr/share/ublue-os/motd/template.md}"
 . "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
 
-envsubst < "${MOTD_TEMPLATE_FILE}" | glow -
+envsubst < "${MOTD_TEMPLATE_FILE}" | glow -w $(tput cols) -

--- a/system_files/shared/usr/bin/ublue-motd
+++ b/system_files/shared/usr/bin/ublue-motd
@@ -3,4 +3,9 @@
 MOTD_TEMPLATE_FILE="${MOTD_TEMPLATE_FILE:-/usr/share/ublue-os/motd/template.md}"
 . "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
 
-envsubst < "${MOTD_TEMPLATE_FILE}" | glow -w $(tput cols) -
+if command -v tput >/dev/null 2>&1 && [ -t 1 ]; then
+  cols=$(tput cols 2>/dev/null)
+  envsubst < "${MOTD_TEMPLATE_FILE}" | glow -w $cols -
+else
+  envsubst < "${MOTD_TEMPLATE_FILE}" | glow -
+fi


### PR DESCRIPTION
glow will use 78 characters by default causing some long words to be
cut off when they go beyond that limit.

This will now use the full width and this won't happen anymore.

essentially same as:
https://github.com/ublue-os/packages/pull/849

fix: if tput isn't there

It's a part of ncurses, most stuff should therefore have it.

We only want to run the motd when we have an interactive terminal and
relies on glow to handle the width if tput isn't available.


<img width="2339" height="681" alt="image" src="https://github.com/user-attachments/assets/d8541502-49eb-4b78-b4bd-2ff112317089" />

when terminal is big:
<img width="2534" height="1096" alt="image" src="https://github.com/user-attachments/assets/6bec7072-db92-462a-b9ee-d15364639c71" />

resizing
<img width="1176" height="859" alt="image" src="https://github.com/user-attachments/assets/a9b86ad7-2944-4cb0-9304-7bf26756570c" />
