### PR TITLE
feat(bazaar): add brief, remove rewaita

### DIFF
--- a/system_files/bluefin/etc/bazaar/content.yaml
+++ b/system_files/bluefin/etc/bazaar/content.yaml
@@ -155,7 +155,6 @@ rows:
             - io.github.kelvinnovais.Kasasa
             - de.schmidhuberj.DieBahn
             - com.github.maoschanz.drawing
-            - io.github.swordpuffin.rewaita
 
   - sections:
       - expand-horizontally: true
@@ -356,6 +355,7 @@ rows:
             - io.github.tobagin.digger
             - app.drey.Elastic
             - io.github.mfat.sshpilot
+            - io.github.shonebinu.Brief
 
   - sections:
       - expand-horizontally: true


### PR DESCRIPTION
Removed 'io.github.swordpuffin.rewaita' and added 'io.github.shonebinu.Brief' in content.yaml.

rewaita confuses new users let's just skip it.