### PR TITLE
feat: disable atuin shell integration by default

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bling/bling.fish
+++ b/system_files/shared/usr/share/ublue-os/bling/bling.fish
@@ -24,11 +24,10 @@ end
 alias cat='bat --style=plain --pager=never' 2>/dev/null
 
 if status is-interactive
-    # Initialize atuin before starship to ensure proper command history capture
-    # Atuin allows these flags: "--disable-up-arrow" and/or "--disable-ctrl-r"
-    # Use by setting a universal variable, e.g. set -U ATUIN_INIT_FLAGS "--disable-up-arrow"
-    # Or set in config.fish before this file is sourced
-    [ "$(command -v atuin)" ] && eval "$(atuin init fish $ATUIN_INIT_FLAGS)"
+    # Atuin shell integration is disabled by default
+    # The atuin binary is still installed and available for manual use
+    # To enable shell integration, uncomment the following line or add it to your config.fish:
+    # [ "$(command -v atuin)" ] && eval "$(atuin init fish $ATUIN_INIT_FLAGS)"
 
     [ "$(command -v starship)" ] && eval "$(starship init fish)"
 

--- a/system_files/shared/usr/share/ublue-os/bling/bling.sh
+++ b/system_files/shared/usr/share/ublue-os/bling/bling.sh
@@ -43,8 +43,9 @@ if [ "${BLING_SHELL}" = "bash" ]; then
 fi
 
 [ "$(command -v direnv)" ] && eval "$(direnv hook "${BLING_SHELL}")"
-# Initialize atuin before starship to ensure proper command history capture
-# See: https://github.com/atuinsh/atuin/issues/2804
-[ "$(command -v atuin)" ] && eval "$(atuin init "${BLING_SHELL}" ${ATUIN_INIT_FLAGS})"
+# Atuin shell integration is disabled by default
+# The atuin binary is still installed and available for manual use
+# To enable shell integration, uncomment the following line or add it to your shell config:
+# [ "$(command -v atuin)" ] && eval "$(atuin init "${BLING_SHELL}" ${ATUIN_INIT_FLAGS})"
 [ "$(command -v starship)" ] && eval "$(starship init "${BLING_SHELL}")"
 [ "$(command -v zoxide)" ] && eval "$(zoxide init "${BLING_SHELL}")"


### PR DESCRIPTION
## Summary
Disables atuin shell integration by default in bluefin-cli while keeping the atuin binary installed via Homebrew.

## Changes
- Commented out atuin initialization in `bling.sh` (bash/zsh)
- Commented out atuin initialization in `bling.fish`
- Added clear documentation explaining the change
- Provided instructions for users who want to re-enable shell integration

## Rationale
Users can still access atuin commands manually, but the shell integration (up-arrow and ctrl-r hijacking) is now opt-in rather than opt-out.

## Testing
- The atuin binary remains in `cli.Brewfile` and will be installed
- Shell integration is disabled by default
- Users can uncomment the line to re-enable if desired