### PR TITLE
feat: add loading message to ujust bbrew command

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -56,6 +56,7 @@ bbrew:
             exit 0
         fi
     fi
+    echo "Note: Some of these take a while to load, we'll keep working on it."
     bbrew -f "/usr/share/ublue-os/homebrew/$(gum choose $(find "/usr/share/ublue-os/homebrew"/*.Brewfile -exec basename '{}' '.Brewfile' ';')).Brewfile"
 
 cncf:


### PR DESCRIPTION
Display note about loading times before the Brewfile selector appears.

This adds a user-friendly message that appears after `ujust bbrew` is called and before the selector widget shows up: "Note: Some of these take a while to load, we'll keep working on it."

## Changes
- Added informational message to `bbrew` recipe in `apps.just`
- Message displays before the gum selector to set user expectations

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot