### PR TITLE
fix: #3919 add no-op for appimage files

### DIFF
--- a/system_files/bluefin/etc/xdg/mimeapps.list
+++ b/system_files/bluefin/etc/xdg/mimeapps.list
@@ -1,3 +1,4 @@
 [Default Applications]
 application/pdf=org.gnome.Papers.desktop
 application/vnd.flatpak.ref=io.github.kolunmi.Bazaar.desktop
+application/vnd.appimage=noop.desktop

--- a/system_files/bluefin/usr/share/applications/noop.desktop
+++ b/system_files/bluefin/usr/share/applications/noop.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=
+Comment=Prevents GNOME Disks from opening non-executable AppImage files
+Exec=/usr/bin/true
+NoDisplay=true
+Terminal=false
+MimeType=application/vnd.appimage;


### PR DESCRIPTION
Fix for https://github.com/ublue-os/bluefin/issues/3919

AppImage files are considered raw disk images, so when non-executable AppImage files are opened Gnome Disks offers to write it to disk.

Adding this desktop entry makes launching non-executable AppImages a no-op by default.

`noop.desktop` is needed because modifying/overriding `mimeapps.list` is not enough to prevent Disks being the default application. In the absence of an `application/vnd.appimage` handler, Gnome still considers Disks as the default because AppImages are considered raw disk images, which `gnome-disk-image-writer.desktop` advertises it can handle.

Here's what it looks like if you right click:

<img width="462" height="503" alt="image" src="https://github.com/user-attachments/assets/552188c9-916c-448d-8d76-019cfc580060" />

And if you right click and select "open with..." (and Gear Lever is installed, just fyi)

<img width="425" height="562" alt="image" src="https://github.com/user-attachments/assets/237e2531-ef5a-4365-8ab2-44bf6cda3ef7" />