### PR TITLE
fix(shared, uupd): enable uupd on a preset by default

### DIFF
--- a/system_files/shared/usr/lib/systemd/system-preset/01-uupd.preset
+++ b/system_files/shared/usr/lib/systemd/system-preset/01-uupd.preset
@@ -1,0 +1,1 @@
+enable uupd.timer


### PR DESCRIPTION
This is so people get this default straight on systemctl as well, we dont want this service to be disabled like ever unless explicitly set by the user

```diff
[~/opt/projectbluefin/common-uupd-preset]$ systemctl status uupd.timer
● uupd.timer - Auto Update System Timer For Universal Blue
-     Loaded: loaded (/usr/lib/systemd/system/uupd.timer; enabled; preset: disabled)
+     Loaded: loaded (/usr/lib/systemd/system/uupd.timer; enabled; preset: enabled)
     Active: active (waiting) since Sat 2026-01-03 11:20:14 -03; 8h ago
 Invocation: 31d6f37e159240978bf3030e17c9325a
    Trigger: Sat 2026-01-03 20:13:13 -03; 34min left
   Triggers: ● uupd.service
```