### PR TITLE
fix(bluefin,dx): remove ssh askpass configuration

### DIFF
--- a/system_files/bluefin/etc/profile.d/askpass.sh
+++ b/system_files/bluefin/etc/profile.d/askpass.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/bash
-
-SUDO_ASKPASS='/usr/libexec/openssh/gnome-ssh-askpass'
-export SUDO_ASKPASS


### PR DESCRIPTION
This should be done by the user if they want SSH_ASKPASS instead of Bluefin defining it


Fixes: https://github.com/ublue-os/bluefin/issues/3975