### PR TITLE
feat(bluefin, gschemas): specify mutter experimental features directly on gschema

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -78,6 +78,7 @@ sort-directories-first=true
 [org.gnome.mutter]
 center-new-windows=true
 check-alive-timeout=uint32 20000
+experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling']
 
 [com.github.stunkymonkey.nautilus-open-any-terminal]
 terminal='ptyxis'


### PR DESCRIPTION
This makes it so Bluefin LTS also gets these

Need PRs on LTS and Fedora for nvidia

Fixes: https://github.com/ublue-os/bluefin-lts/issues/968

Can be merged after this:

- https://github.com/ublue-os/bluefin/pull/3984
- https://github.com/ublue-os/bluefin-lts/pull/970