### PR TITLE
ci: skip container builds for documentation changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,17 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - '.gitignore'
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
Skip expensive container builds when only documentation files are changed, reducing CI time and GitHub Actions usage.

## Problem
Currently, every change triggers a full container build (~5-10 minutes), even when only editing markdown documentation files. This wastes CI resources and delays doc-only PR merges.

## Solution
Add `paths-ignore` filters to the build workflow to skip builds when only these files change:
- `*.md` - All markdown files (README.md, AGENTS.md, etc.)
- `LICENSE` - License file
- `.gitignore` - Git configuration

## What Still Triggers Builds ✓
- `Containerfile` changes
- `system_files/**` changes
- `Justfile` or `**.just` changes
- `bluefin-branding` submodule updates
- Workflow file changes
- Manual triggers (`workflow_dispatch`)
- Merge queue triggers

## Benefits
- ✅ Faster PR merges for documentation
- ✅ Reduced GitHub Actions minutes
- ✅ No unnecessary container image pushes
- ✅ Follows same pattern as `validate-just.yml`
- ✅ Consistent with industry best practices

## Testing
This PR itself only changes the workflow file, so it **will** trigger a build (as expected). Future documentation PRs will skip the build.

To verify:
1. Merge this PR
2. Create a test PR that only modifies README.md
3. Observe that the build workflow is skipped

## References
- GitHub Actions docs: [Workflow syntax - on.<push|pull_request>.paths](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)
- Follows pattern from `validate-just.yml` and `validate-brewfiles.yaml`