### PR TITLE
fix(bluefin, devmode): correctly rebase people to (image)-dx-nvidia-open

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -20,6 +20,7 @@ toggle-devmode:
     IMAGE_NAME="$(jq -rc '."image-name"' "${IMAGE_INFO_FILE}")"
     IMAGE_REF="$(jq -rc '."image-ref"' "${IMAGE_INFO_FILE}" | sed "s/.*ghcr/ghcr/")"
     CURRENT_IMAGE="${IMAGE_REF}:$(jq -rc '."image-tag"' "${IMAGE_INFO_FILE}")"
+    IMAGE_BASE_NAME="$(cut -f1 -d\- <<< "${IMAGE_NAME}")"
     set +e
 
     if grep -q -E -e "dx$" <<< "${IMAGE_NAME}" ; then
@@ -32,15 +33,15 @@ toggle-devmode:
 
     gum confirm "Would you like to enable developer mode?" || exit 0
     echo "Rebasing to a developer image"
-    NEW_IMAGE="$(sed "s/${IMAGE_NAME}/${IMAGE_NAME}-dx/" <<< "${CURRENT_IMAGE}")"
+    NEW_IMAGE="$(sed "s/${IMAGE_BASE_NAME}/${IMAGE_BASE_NAME}-dx/" <<< "${CURRENT_IMAGE}")"
     pkexec bootc switch --enforce-container-sigpolicy "${NEW_IMAGE}"
     if gum confirm "Do you want to also install the default development flatpaks?" ; then
-        ujust install-system-flatpaks 0 1
+        ADD_DEVMODE=1 ujust install-system-flatpaks 0 1
     fi
     if gum confirm "Do you want to install extra monospace fonts?" ; then
         brew bundle install --file=/usr/share/ublue-os/homebrew/fonts.Brewfile
     fi
-    echo "Use ujust dx-group to add your user to the correct groups and complete the installation"
+    echo "Use ujust dx-group to add your user to the correct groups and complete the installation after rebooting into the development image"
 
 # Configure docker,incus-admin,libvirt, container manager, serial permissions
 [group('System')]


### PR DESCRIPTION
This also adds a lil notice for using dx-group after reboot

Should fix: https://github.com/ublue-os/bluefin/issues/4001