### PR TITLE
feat: add Whis to "AI & Machine Learning" Bazaar curation

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -439,3 +439,4 @@ rows:
             - com.jeffser.Alpaca
             - io.github.qwersyk.Newelle
             - ai.jan.Jan
+            - ink.whis.Whis


### PR DESCRIPTION
Flathub page: https://flathub.org/en/apps/ink.whis.Whis
GitHub source code: https://github.com/frankdierolf/whis

- Voice transcription app that support both local & cloud providers
- Local models: OpenAI Whisper (tiny/small/base/medium version), NVIDIA Parakeet (V2/V3 versions), with option to specify path to model .bin file (if we already download it via other apps like Ramalama/LM Studio)
- Cloud providers supported: Groq, Mistral, Deepgram, OpenAI, ElevenLabs (the first three provide free access)
- There's a text cleanup/post-processing feature option for the generated transcription, via OpenAI (cloud)/Mistral (cloud)/Ollama (local)

<img width="1366" height="768" alt="Screenshot From 2026-01-15 22-38-55" src="https://github.com/user-attachments/assets/3ab46603-a5dd-4348-bc43-d241c0a7c911" />

<img width="1366" height="736" alt="Screenshot From 2026-01-15 22-39-16" src="https://github.com/user-attachments/assets/404a8ce1-cede-4864-91de-1eec0c97c9d7" />

Pretty flexible, this can go well with Bluefin's AI principles. After this merged I can add it to [my PR for /ai docs](https://github.com/projectbluefin/documentation/pull/574) too