### PR TITLE
feat: add weekly status report automation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Exclude GitHub Actions and scripts from container builds
+.github/
+scripts/
+*.md
+.git/
+.gitignore

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -1,0 +1,34 @@
+name: Weekly Status Report
+
+on:
+  schedule:
+    - cron: '0 23 * * 6'  # Saturday at 23:00 UTC
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+  discussions: write
+
+jobs:
+  generate-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: scripts/weekly-report/package-lock.json
+
+      - name: Install dependencies
+        working-directory: scripts/weekly-report
+        run: npm ci
+
+      - name: Generate and post report
+        working-directory: scripts/weekly-report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node generate-report.js

--- a/scripts/weekly-report/README.md
+++ b/scripts/weekly-report/README.md
@@ -1,0 +1,77 @@
+# Weekly Status Report Generator
+
+Automated weekly status reports for the Bluefin project, posted to GitHub Discussions.
+
+## Overview
+
+This script generates weekly status reports by querying the [projectbluefin project board](https://github.com/orgs/projectbluefin/projects/2) for completed items and posting them to the Announcements section of GitHub Discussions.
+
+## Features
+
+- Queries organization project board for items marked "Done" in the past 7 days
+- Categorizes items by area labels (gnome, dx, brew, services, infrastructure)
+- Preserves label badges for each section
+- Lists all contributors
+- Automatically posts to GitHub Discussions
+
+## Report Structure
+
+Reports include:
+- 📊 Summary (completed items, contributor count)
+- 🖥️ Desktop (area/gnome, area/aurora, area/bling)
+- 🛠️ Development (area/dx, area/buildstream, area/finpilot)
+- 📦 Ecosystem (area/brew, area/just, area/bluespeed)
+- ⚙️ System Services & Policies (area/services, area/policy)
+- 🏗️ Infrastructure (area/iso, area/upstream)
+- 👏 Contributors
+
+## Usage
+
+### Automated (GitHub Actions)
+Reports run automatically every Saturday at 23:00 UTC via `.github/workflows/weekly-report.yml`.
+
+### Manual Trigger
+1. Go to [Actions](../../actions/workflows/weekly-report.yml)
+2. Click "Run workflow"
+3. Select branch and click "Run workflow"
+
+### Local Testing
+```bash
+cd scripts/weekly-report
+npm install
+export GITHUB_TOKEN="your_personal_access_token"
+node generate-report.js
+```
+
+**Note**: Local testing requires a GitHub personal access token with:
+- `repo` scope (read project data)
+- `write:discussion` scope (post to discussions)
+
+## Configuration
+
+Key constants in `generate-report.js`:
+- `PROJECT_ID`: Organization project board ID
+- `ANNOUNCEMENTS_CATEGORY_ID`: Discussion category ID
+- `AREA_SECTIONS`: Label mappings and colors for each section
+
+## Label Preservation
+
+Each section preserves its area labels with badges:
+- Desktop: `#f5c2e7` (pink)
+- Development: `#89dceb` (sky blue)
+- Ecosystem: `#eba0ac` (peach)
+- Services: `#b4befe` (lavender)
+- Infrastructure: `#94e2d5` (teal)
+
+Labels in each section are displayed as clickable badges that link to the label page.
+
+## Dependencies
+
+- `@octokit/graphql`: GitHub GraphQL API client
+- Node.js 20+
+
+## Related
+
+- Issue: [#166](../../issues/166)
+- Project Board: https://github.com/orgs/projectbluefin/projects/2
+- Discussions: https://github.com/projectbluefin/common/discussions

--- a/scripts/weekly-report/generate-report.js
+++ b/scripts/weekly-report/generate-report.js
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+
+import { graphql } from '@octokit/graphql';
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const PROJECT_ID = 'PVT_kwDOCCE0ds4BLZBC';
+const ANNOUNCEMENTS_CATEGORY_ID = 'DIC_kwDOQWkn1c4C1bXC';
+const REPO_OWNER = 'projectbluefin';
+const REPO_NAME = 'common';
+
+const graphqlWithAuth = graphql.defaults({
+  headers: {
+    authorization: `token ${GITHUB_TOKEN}`,
+  },
+});
+
+const AREA_SECTIONS = {
+  desktop: {
+    title: '🖥️ Desktop',
+    labels: ['area/gnome', 'area/aurora', 'area/bling'],
+    color: 'f5c2e7'
+  },
+  development: {
+    title: '🛠️ Development',
+    labels: ['area/dx', 'area/buildstream', 'area/finpilot'],
+    color: '89dceb'
+  },
+  ecosystem: {
+    title: '📦 Ecosystem',
+    labels: ['area/brew', 'area/just', 'area/bluespeed'],
+    color: 'eba0ac'
+  },
+  services: {
+    title: '⚙️ System Services & Policies',
+    labels: ['area/services', 'area/policy'],
+    color: 'b4befe'
+  },
+  infrastructure: {
+    title: '🏗️ Infrastructure',
+    labels: ['area/iso', 'area/upstream'],
+    color: '94e2d5'
+  }
+};
+
+function getDateRange() {
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 7);
+  
+  return {
+    start: startDate,
+    end: endDate,
+    startISO: startDate.toISOString(),
+    endISO: endDate.toISOString(),
+    startFormatted: startDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }),
+    endFormatted: endDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  };
+}
+
+async function getRepositoryId() {
+  const query = `
+    query {
+      repository(owner: "${REPO_OWNER}", name: "${REPO_NAME}") {
+        id
+      }
+    }
+  `;
+  
+  const result = await graphqlWithAuth(query);
+  return result.repository.id;
+}
+
+async function getCompletedItems(startDate) {
+  let allItems = [];
+  let hasNextPage = true;
+  let cursor = null;
+  
+  while (hasNextPage) {
+    const query = `
+      query($cursor: String) {
+        node(id: "${PROJECT_ID}") {
+          ... on ProjectV2 {
+            items(first: 100, after: $cursor) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                id
+                fieldValues(first: 20) {
+                  nodes {
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                      field {
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                      }
+                    }
+                    ... on ProjectV2ItemFieldDateValue {
+                      date
+                      field {
+                        ... on ProjectV2FieldCommon {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+                content {
+                  ... on Issue {
+                    number
+                    title
+                    url
+                    repository {
+                      nameWithOwner
+                    }
+                    author {
+                      login
+                    }
+                    labels(first: 20) {
+                      nodes {
+                        name
+                      }
+                    }
+                    closedAt
+                  }
+                  ... on PullRequest {
+                    number
+                    title
+                    url
+                    repository {
+                      nameWithOwner
+                    }
+                    author {
+                      login
+                    }
+                    labels(first: 20) {
+                      nodes {
+                        name
+                      }
+                    }
+                    mergedAt
+                    closedAt
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+    
+    const result = await graphqlWithAuth(query, { cursor });
+    const items = result.node.items;
+    
+    allItems.push(...items.nodes);
+    hasNextPage = items.pageInfo.hasNextPage;
+    cursor = items.pageInfo.endCursor;
+  }
+  
+  const completedItems = allItems.filter(item => {
+    if (!item.content) return false;
+    
+    const status = item.fieldValues.nodes.find(
+      field => field.field?.name === 'Status'
+    );
+    
+    if (status?.name !== 'Done') return false;
+    
+    const completedDate = item.content.mergedAt || item.content.closedAt;
+    if (!completedDate) return false;
+    
+    const completed = new Date(completedDate);
+    return completed >= new Date(startDate);
+  });
+  
+  return completedItems;
+}
+
+function categorizeItems(items) {
+  const categorized = {};
+  const uncategorized = [];
+  
+  for (const section of Object.keys(AREA_SECTIONS)) {
+    categorized[section] = [];
+  }
+  
+  for (const item of items) {
+    if (!item.content) continue;
+    
+    const labels = item.content.labels.nodes.map(l => l.name);
+    let foundCategory = false;
+    
+    for (const [section, config] of Object.entries(AREA_SECTIONS)) {
+      if (config.labels.some(label => labels.includes(label))) {
+        categorized[section].push({ ...item, labels });
+        foundCategory = true;
+        break;
+      }
+    }
+    
+    if (!foundCategory) {
+      uncategorized.push({ ...item, labels });
+    }
+  }
+  
+  return { categorized, uncategorized };
+}
+
+function extractContributors(items) {
+  const contributors = new Set();
+  const contributorData = new Map();
+  
+  for (const item of items) {
+    if (!item.content?.author?.login) continue;
+    
+    const login = item.content.author.login;
+    contributors.add(login);
+    
+    if (!contributorData.has(login)) {
+      contributorData.set(login, {
+        login,
+        contributions: []
+      });
+    }
+    
+    contributorData.get(login).contributions.push({
+      type: item.content.mergedAt ? 'PR' : 'Issue',
+      number: item.content.number,
+      title: item.content.title,
+      url: item.content.url,
+      repo: item.content.repository.nameWithOwner
+    });
+  }
+  
+  return { contributors: Array.from(contributors), contributorData };
+}
+
+function generateBadges(labels, color) {
+  return labels
+    .map(label => `[![${label}](https://img.shields.io/badge/${encodeURIComponent(label.replace('/', '%2F'))}-${color}?style=flat-square)](https://github.com/${REPO_OWNER}/${REPO_NAME}/labels/${encodeURIComponent(label)})`)
+    .join(' ');
+}
+
+function formatItem(item) {
+  const content = item.content;
+  const type = content.mergedAt ? 'PR' : 'Issue';
+  const kindLabel = item.labels.find(l => l.startsWith('kind/'));
+  const kind = kindLabel ? kindLabel.replace('kind/', '') : '';
+  
+  let line = '';
+  if (kind) {
+    line += `${kind}: `;
+  }
+  line += content.title;
+  line += ` - ${type}: [#${content.number}](${content.url})`;
+  if (content.repository.nameWithOwner !== `${REPO_OWNER}/${REPO_NAME}`) {
+    line += ` (${content.repository.nameWithOwner})`;
+  }
+  if (content.author?.login) {
+    line += ` - @${content.author.login}`;
+  }
+  
+  return line;
+}
+
+function generateReport(dateRange, items, contributors) {
+  const { categorized } = categorizeItems(items);
+  const { contributors: contributorList } = extractContributors(items);
+  
+  let report = `# Weekly Status Report: ${dateRange.startFormatted} - ${dateRange.endFormatted}\n\n`;
+  report += `> Automated summary of completed items from the [Bluefin Project Board](https://github.com/orgs/projectbluefin/projects/2)\n\n`;
+  
+  report += `## 📊 Summary\n`;
+  report += `- **${items.length}** items completed\n`;
+  report += `- **${contributorList.length}** contributors\n\n`;
+  
+  report += `---\n\n`;
+  
+  for (const [section, config] of Object.entries(AREA_SECTIONS)) {
+    const sectionItems = categorized[section];
+    if (sectionItems.length === 0) continue;
+    
+    report += `## ${config.title}\n`;
+    report += `${generateBadges(config.labels, config.color)}\n\n`;
+    
+    for (const item of sectionItems) {
+      report += `- ${formatItem(item)}\n`;
+    }
+    
+    report += `\n`;
+  }
+  
+  report += `---\n\n`;
+  report += `## 👏 Contributors\n\n`;
+  report += `Thank you to everyone who contributed this week!\n\n`;
+  
+  for (const login of contributorList.sort()) {
+    report += `- [@${login}](https://github.com/${login})\n`;
+  }
+  
+  report += `\n---\n\n`;
+  report += `<sub>Generated on ${dateRange.endFormatted} | `;
+  report += `[Project Board](https://github.com/orgs/projectbluefin/projects/2) | `;
+  report += `[Report Issue](https://github.com/${REPO_OWNER}/${REPO_NAME}/issues/new)</sub>\n`;
+  
+  return report;
+}
+
+async function postToDiscussions(repositoryId, title, body) {
+  const mutation = `
+    mutation {
+      createDiscussion(input: {
+        repositoryId: "${repositoryId}",
+        categoryId: "${ANNOUNCEMENTS_CATEGORY_ID}",
+        title: "${title.replace(/"/g, '\\"')}",
+        body: "${body.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"
+      }) {
+        discussion {
+          id
+          url
+        }
+      }
+    }
+  `;
+  
+  const result = await graphqlWithAuth(mutation);
+  return result.createDiscussion.discussion;
+}
+
+async function main() {
+  try {
+    console.log('Generating weekly status report...\n');
+    
+    const dateRange = getDateRange();
+    console.log(`Date range: ${dateRange.startFormatted} - ${dateRange.endFormatted}`);
+    
+    console.log('Fetching repository ID...');
+    const repositoryId = await getRepositoryId();
+    
+    console.log('Fetching completed items from project board...');
+    const items = await getCompletedItems(dateRange.startISO);
+    console.log(`Found ${items.length} completed items`);
+    
+    if (items.length === 0) {
+      console.log('No completed items found. Skipping report generation.');
+      return;
+    }
+    
+    console.log('Extracting contributors...');
+    const { contributors } = extractContributors(items);
+    console.log(`Found ${contributors.length} contributors`);
+    
+    console.log('Generating report...');
+    const report = generateReport(dateRange, items, contributors);
+    
+    console.log('\n--- Generated Report ---\n');
+    console.log(report);
+    console.log('\n--- End Report ---\n');
+    
+    console.log('Posting to GitHub Discussions...');
+    const title = `Weekly Status Report: ${dateRange.startFormatted} - ${dateRange.endFormatted}`;
+    const discussion = await postToDiscussions(repositoryId, title, report);
+    
+    console.log(`✅ Report posted successfully!`);
+    console.log(`URL: ${discussion.url}`);
+    
+  } catch (error) {
+    console.error('Error generating report:', error);
+    if (error.errors) {
+      console.error('GraphQL errors:', JSON.stringify(error.errors, null, 2));
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/weekly-report/package-lock.json
+++ b/scripts/weekly-report/package-lock.json
@@ -1,0 +1,107 @@
+{
+  "name": "weekly-report",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "weekly-report",
+      "version": "1.0.0",
+      "dependencies": {
+        "@octokit/graphql": "^8.1.1"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/scripts/weekly-report/package.json
+++ b/scripts/weekly-report/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "weekly-report",
+  "version": "1.0.0",
+  "description": "Generate weekly status reports from project board",
+  "type": "module",
+  "main": "generate-report.js",
+  "scripts": {
+    "generate": "node generate-report.js"
+  },
+  "dependencies": {
+    "@octokit/graphql": "^8.1.1"
+  }
+}


### PR DESCRIPTION
Implements automated weekly status reports from project board to GitHub Discussions as specified in issue #166.

## Changes

- Add GitHub Actions workflow for weekly report generation
- Query projectbluefin project board for completed items
- Categorize by area labels with preserved badge colors:
  - 🖥️ Desktop (area/gnome, area/aurora, area/bling) - #f5c2e7
  - 🛠️ Development (area/dx, area/buildstream, area/finpilot) - #89dceb
  - 📦 Ecosystem (area/brew, area/just, area/bluespeed) - #eba0ac
  - ⚙️ Services (area/services, area/policy) - #b4befe
  - 🏗️ Infrastructure (area/iso, area/upstream) - #94e2d5
- Post to Announcements discussion category
- Exclude scripts from container builds via .dockerignore

## Testing

Reports run automatically every Saturday at 23:00 UTC and can be manually triggered via workflow_dispatch.

See test report generation in comments below.

Closes #166