### PR TITLE
fix: move StartLimitIntervalSec to [Unit]

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/flatpak-preinstall.service
+++ b/system_files/shared/usr/lib/systemd/system/flatpak-preinstall.service
@@ -4,6 +4,7 @@ After=network-online.target
 Wants=network-online.target
 ConditionPathExists=/usr/bin/flatpak
 Documentation=man:flatpak-preinstall(1)
+StartLimitIntervalSec=600
 
 [Service]
 Type=oneshot
@@ -12,7 +13,6 @@ RemainAfterExit=true
 Restart=on-failure
 RestartSec=30
 
-StartLimitIntervalSec=600
 StartLimitBurst=3
 
 [Install]


### PR DESCRIPTION
```
/usr/lib/systemd/system/flatpak-preinstall.service:15:
Unknown key 'StartLimitIntervalSec' in section [Service], ignoring.
```