### PR TITLE
feat: add `ujust toggle-testing`

### DIFF
--- a/system_files/bluefin/usr/bin/ublue-rollback-helper
+++ b/system_files/bluefin/usr/bin/ublue-rollback-helper
@@ -31,9 +31,9 @@ IMAGE_NAME="$(gum choose --header="Select your image:" "${IMAGES[@]}" cancel)"
 base_image="${IMAGE_REGISTRY}/${IMAGE_NAME}"
 declare -a CHANNELS
 if [ "${LTS_MODE}" == "1" ] ; then
-  CHANNELS=(lts lts-hwe)
+  CHANNELS=(lts lts-testing lts-hwe lts-hwe-testing)
   if grep -q -e "gdx" <<< "${IMAGE_NAME}" ; then
-    CHANNELS=(lts)
+    CHANNELS=(lts lts-testing)
   fi
 else 
   CHANNELS=(gts stable stable-daily latest)
@@ -51,7 +51,10 @@ if gum confirm --default=no "Would you like to pin to a specific build date?" ; 
   filter="${channel_selected}.[0-9]{8}"
 
   if [ "${LTS_MODE}" == 1 ] ; then
-    if grep -q -e "hwe" -e "gdx" <<< "${channel_selected}" ; then
+    if grep -q -e "testing" <<< "${channel_selected}" ; then
+      # Testing channels: filter is already correct (e.g., lts-testing.[0-9]{8})
+      valid_tags=( $(list_tags "$filter") )
+    elif grep -q -e "hwe" -e "gdx" <<< "${channel_selected}" ; then
       filter="lts.[0-9]{8}"
       valid_tags=( $(list_tags "$filter" | grep hwe) )
     else

--- a/system_files/bluefin/usr/share/ublue-os/just/00-entry.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/00-entry.just
@@ -7,6 +7,7 @@ _default:
     ujust --list --list-heading $'Available commands:\n' --list-prefix $' - '
 
 # Imports
+
 import "/usr/share/ublue-os/just/apps.just"
 import "/usr/share/ublue-os/just/changelog.just"
 import "/usr/share/ublue-os/just/default.just"

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -129,6 +129,7 @@ install-system-flatpaks $confirm="1" $dx_only="0":
     brew bundle --file="${TARGET_FLATPAK_FILE:-/usr/share/ublue-os/homebrew/system-flatpaks.Brewfile}"
 
 # Install default system flatpaks (alias for install-system-flatpaks)
+
 # For additional applications, use: ujust bbrew
 [group('System')]
 bluefin-apps:

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -43,6 +43,51 @@ toggle-devmode:
     fi
     echo "Use ujust dx-group to add your user to the correct groups and complete the installation after rebooting into the development image"
 
+# Toggle between stable and testing images (LTS only)
+[group('System')]
+toggle-testing:
+    #!/usr/bin/env bash
+    IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
+    IMAGE_TAG="$(jq -rc '."image-tag"' "${IMAGE_INFO_FILE}")"
+
+    # Guard: only LTS images have testing variants
+    if ! grep -q "^lts" <<< "${IMAGE_TAG}" ; then
+        echo "toggle-testing is only available on Bluefin LTS images."
+        echo "Current image tag: ${IMAGE_TAG}"
+        exit 0
+    fi
+
+    # Detect current booted image reference via bootc
+    BOOTED_IMAGE="$(sudo bootc status --json | jq -rc '.status.booted.image.image.image')"
+    if [ -z "${BOOTED_IMAGE}" ] || [ "${BOOTED_IMAGE}" == "null" ] ; then
+        echo "Error: Could not determine current booted image from bootc status."
+        exit 1
+    fi
+
+    # Split into registry/name and tag
+    IMAGE_BASE="${BOOTED_IMAGE%%:*}"
+    CURRENT_TAG="${BOOTED_IMAGE##*:}"
+
+    if grep -q "\-testing" <<< "${CURRENT_TAG}" ; then
+        STABLE_TAG="${CURRENT_TAG%-testing}"
+        TARGET="${IMAGE_BASE}:${STABLE_TAG}"
+        echo "You are currently on a testing image."
+        echo "  Current: ${BOOTED_IMAGE}"
+        echo "  Target:  ${TARGET}"
+        gum confirm "Switch from testing to stable?" || exit 0
+    else
+        TESTING_TAG="${CURRENT_TAG}-testing"
+        TARGET="${IMAGE_BASE}:${TESTING_TAG}"
+        echo "You are currently on a stable image."
+        echo "  Current: ${BOOTED_IMAGE}"
+        echo "  Target:  ${TARGET}"
+        gum confirm "Switch from stable to testing? Testing images may be less stable." || exit 0
+    fi
+
+    # --enforce-container-sigpolicy is MANDATORY for security (container signature verification)
+    pkexec bootc switch --enforce-container-sigpolicy "${TARGET}"
+    echo "Reboot to apply the change."
+
 # Configure docker,incus-admin,libvirt, container manager, serial permissions
 [group('System')]
 dx-group:

--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -12,7 +12,6 @@ install-jetbrains-toolbox:
     brew tap ublue-os/homebrew-tap
     brew install --cask jetbrains-toolbox-linux
 
-
 # Install OpenTabletDriver, an open source, cross-platform, user-mode tablet driver
 [group('Apps')]
 install-opentabletdriver:


### PR DESCRIPTION
This adds a toggle similar to dx. Since LTS is the only one with this setup that's behind a gate. Also got an initial pass from KyleGospo before PRing this in. 

cc @renner0e: 

Bluefin has to wait until gts is gone to implement this but the pull app config in LTS is good to ship if you want it for Aurora. Only issue is figuring out how to cron it, currently it does a release when you merge the testing branch into the prod one. I don't know what's cleaner, adding a new workflow for just the cron? The issue was maintaining the cron snippet in the same file in both `main` and `lts`.