### PR TITLE
fix(ublue-fastfetch): use exec to preserve parent shell detection

### DIFF
--- a/system_files/shared/usr/bin/ublue-fastfetch
+++ b/system_files/shared/usr/bin/ublue-fastfetch
@@ -22,9 +22,9 @@ export DEFAULT_THEME # Gets passed to `ublue-bling-fastfetch`
 DEFAULT_THEME="$(get_config '."default-theme"' "slate")"
 if [ "$SHUFFLE_LOGO" == "true" ] ; then
   FETCH_LOGO="$(find "$LOGO_DIRECTORY" -type f | shuf -n 1)"
-  fastfetch --logo "$FETCH_LOGO" --color "$(ublue-bling-fastfetch)" --config "${FASTFETCH_CONFIG}" "${@}"
+  exec fastfetch --logo "$FETCH_LOGO" --color "$(ublue-bling-fastfetch)" --config "${FASTFETCH_CONFIG}" "${@}"
 else
-  fastfetch --color "$(ublue-bling-fastfetch)" --config "${FASTFETCH_CONFIG}" "${@}"
+  exec fastfetch --color "$(ublue-bling-fastfetch)" --config "${FASTFETCH_CONFIG}" "${@}"
 fi
 
 


### PR DESCRIPTION
## Summary

- Add `exec` before both `fastfetch` invocations in `system_files/shared/usr/bin/ublue-fastfetch`

## Details

fastfetch determines the user's shell by looking at its parent process. The current wrapper script runs fastfetch as a child of bash, so fastfetch always reports \"bash\" even when invoked from fish, zsh, or other shells.

Using `exec` replaces the bash wrapper process with fastfetch, allowing it to see the actual parent shell (the user's interactive shell) instead.

**Before:**
```
fish (real shell)
  └─ bash (ublue-fastfetch wrapper)
        └─ fastfetch  → reports "bash"
```

**After:**
```
fish (real shell)
  └─ fastfetch  → reports "fish"
```

## Changes

- Added `exec` to both `fastfetch` call sites in `system_files/shared/usr/bin/ublue-fastfetch`

## Testing

Ran the patched wrapper from a fish shell session; the shell line in fastfetch output now correctly reports `fish` instead of `bash`.

## Related

This is a resubmission of ublue-os/packages#1159 which was redirected here by @renner0e since the `ublue-fastfetch` package is no longer installed in any image and this file is now the canonical source.