### PR TITLE
fix(renovate): use customManagers with currentValue group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,11 +4,12 @@
     "github>ublue-os/renovate-config:org-inherited-config"
   ],
 
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": ["^Containerfile$"],
+      "customType": "regex",
+      "managerFilePatterns": ["^Containerfile$"],
       "matchStrings": [
-        "https://github\\.com/ublue-os/artwork/releases/download/bluefin-v(?<version>[0-9\\-]+)/bluefin-wallpapers\\.tar\\.zstd"
+        "https://github\\.com/ublue-os/artwork/releases/download/bluefin-v(?<currentValue>[0-9\\-]+)/bluefin-wallpapers\\.tar\\.zstd"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "ublue-os/artwork"


### PR DESCRIPTION
- Migrates `regexManagers` → `customManagers` (deprecated since Renovate v36.107)
- Renames `fileMatch` → `managerFilePatterns`
- Fixes `(?<version>...)` → `(?<currentValue>...)` capture group — this was the root cause of the validation error in #235

Closes #235