### PR TITLE
feat(nvidia): add service to sync Flatpak driver version

### DIFF
--- a/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
+++ b/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sync NVIDIA system drivers with Flatpak runtime
+After=network-online.target flatpak-system-helper.service
+Wants=network-online.target
+ConditionPathExists=/proc/driver/nvidia/version
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/libexec/ublue-nvidia-flatpak-runtime-sync check
+ExecStart=/usr/libexec/ublue-nvidia-flatpak-runtime-sync sync
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
+++ b/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
@@ -2,7 +2,7 @@
 Description=Sync NVIDIA system drivers with Flatpak runtime
 After=network-online.target flatpak-system-helper.service
 Wants=network-online.target
-ConditionPathExists=/proc/driver/nvidia/version
+ConditionPathExists=/sys/module/nvidia/version
 # To not run on live ISO
 ConditionPathExists=/run/ostree-booted
 

--- a/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
+++ b/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
@@ -9,6 +9,9 @@ Type=oneshot
 ExecCondition=/usr/libexec/ublue-nvidia-flatpak-runtime-sync check
 ExecStart=/usr/libexec/ublue-nvidia-flatpak-runtime-sync sync
 RemainAfterExit=yes
+Restart=on-failure
+RestartSec=30
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
+++ b/system_files/nvidia/usr/lib/systemd/system/ublue-nvidia-flatpak-runtime-sync.service
@@ -3,6 +3,8 @@ Description=Sync NVIDIA system drivers with Flatpak runtime
 After=network-online.target flatpak-system-helper.service
 Wants=network-online.target
 ConditionPathExists=/proc/driver/nvidia/version
+# To not run on live ISO
+ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=oneshot

--- a/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
+++ b/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
@@ -3,7 +3,7 @@
 # Workaround for: https://github.com/flatpak/flatpak/issues/3907
 set -euo pipefail
 
-SYSTEM_NVIDIA_VERSION=$(head -1 /proc/driver/nvidia/version | grep -oP '\d+(\.\d+)+')
+SYSTEM_NVIDIA_VERSION=$(cat /sys/module/nvidia/version)
 FLATPAK_NVIDIA_VERSION=$(echo "${SYSTEM_NVIDIA_VERSION}" | tr '.' '-')
 
 case "${1}" in

--- a/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
+++ b/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 
+# Workaround for: https://github.com/flatpak/flatpak/issues/3907
 set -euo pipefail
 
 SYSTEM_NVIDIA_VERSION=$(head -1 /proc/driver/nvidia/version | grep -oP '\d+(\.\d+)+')
@@ -18,6 +19,7 @@ case "${1}" in
         ;;
     sync)
         echo "Installing NVIDIA Flatpak runtime version ${SYSTEM_NVIDIA_VERSION}"
+        flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         flatpak install --system --noninteractive -y flathub \
             org.freedesktop.Platform.GL.nvidia-"${FLATPAK_NVIDIA_VERSION}" \
             org.freedesktop.Platform.GL32.nvidia-"${FLATPAK_NVIDIA_VERSION}"

--- a/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
+++ b/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SYSTEM_NVIDIA_VERSION=$(head -1 /proc/driver/nvidia/version | grep -oP '\d+\.\d+\.\d+')
+SYSTEM_NVIDIA_VERSION=$(head -1 /proc/driver/nvidia/version | grep -oP '\d+(\.\d+)+')
 FLATPAK_NVIDIA_VERSION=$(echo "${SYSTEM_NVIDIA_VERSION}" | tr '.' '-')
 
 case "${1}" in
@@ -18,7 +18,7 @@ case "${1}" in
         ;;
     sync)
         echo "Installing NVIDIA Flatpak runtime version ${SYSTEM_NVIDIA_VERSION}"
-        flatpak install --noninteractive flathub \
+        flatpak install --system --noninteractive -y flathub \
             org.freedesktop.Platform.GL.nvidia-"${FLATPAK_NVIDIA_VERSION}" \
             org.freedesktop.Platform.GL32.nvidia-"${FLATPAK_NVIDIA_VERSION}"
         ;;

--- a/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
+++ b/system_files/nvidia/usr/libexec/ublue-nvidia-flatpak-runtime-sync
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+SYSTEM_NVIDIA_VERSION=$(head -1 /proc/driver/nvidia/version | grep -oP '\d+\.\d+\.\d+')
+FLATPAK_NVIDIA_VERSION=$(echo "${SYSTEM_NVIDIA_VERSION}" | tr '.' '-')
+
+case "${1}" in
+    check)
+        # Exit 0 if sync is needed (versions mismatch), exit 1 if already in sync
+        if flatpak info --system org.freedesktop.Platform.GL.nvidia-"${FLATPAK_NVIDIA_VERSION}" >/dev/null 2>&1 && \
+           flatpak info --system org.freedesktop.Platform.GL32.nvidia-"${FLATPAK_NVIDIA_VERSION}" >/dev/null 2>&1; then
+            echo "NVIDIA Flatpak runtime ${SYSTEM_NVIDIA_VERSION} already installed"
+            exit 1
+        fi
+        echo "NVIDIA Flatpak runtime ${SYSTEM_NVIDIA_VERSION} needs to be installed"
+        exit 0
+        ;;
+    sync)
+        echo "Installing NVIDIA Flatpak runtime version ${SYSTEM_NVIDIA_VERSION}"
+        flatpak install --noninteractive flathub \
+            org.freedesktop.Platform.GL.nvidia-"${FLATPAK_NVIDIA_VERSION}" \
+            org.freedesktop.Platform.GL32.nvidia-"${FLATPAK_NVIDIA_VERSION}"
+        ;;
+    *)
+        echo "Usage: $0 {check|sync}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Supersedes https://github.com/get-aurora-dev/common/pull/133.

Tested it on my Bazzite machine which has an NVIDIA card.

```bash
○ ublue-nvidia-flatpak-runtime-sync.service - Sync NVIDIA system drivers with Flatpak runtime
     Loaded: loaded (/etc/systemd/system/ublue-nvidia-flatpak-runtime-sync.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead) (Result: exec-condition) since Wed 2026-04-01 09:16:00 CDT; 1s ago
 Invocation: dedef8b0919a46bca0c115e0bf7a1ae3
  Condition: start condition unmet at Wed 2026-04-01 09:16:00 CDT; 1s ago
    Process: 4341 ExecCondition=/usr/local/bin/TEST-ublue-nvidia-flatpak-runtime-sync check (code=exited, status=1/FAILURE)
   Mem peak: 1.6M
        CPU: 5ms

Apr 01 09:16:00 llano systemd[1]: Starting ublue-nvidia-flatpak-runtime-sync.service - Sync NVIDIA system drivers with Flatpak runtime...
Apr 01 09:16:00 llano systemd[1]: ublue-nvidia-flatpak-runtime-sync.service: Skipped due to 'exec-condition'.
Apr 01 09:16:00 llano systemd[1]: Condition check resulted in ublue-nvidia-flatpak-runtime-sync.service - Sync NVIDIA system drivers with Flatpak runtime being skipped.
```

It exited because the Flatpak platform was already in sync with the on image driver version, but it seems like it should work when they are not synced.


This is what the driver reports:

```bash
❯ cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  595.58.03  Release Build  (builder@dbdfa680a27e)  Wed Mar 25 09:03:45 UTC 2026
GCC version:  gcc version 15.2.1 20260123 (Red Hat 15.2.1-7) (GCC) 
```

This is executing the script with `-x`:

```bash
❯ sudo bash -x /usr/local/bin/TEST-ublue-nvidia-flatpak-runtime-sync check
+ set -euo pipefail
++ head -1 /proc/driver/nvidia/version
++ grep -oP '\d+\.\d+\.\d+'
+ SYSTEM_NVIDIA_VERSION=595.58.03
++ echo 595.58.03
++ tr . -
+ FLATPAK_NVIDIA_VERSION=595-58-03
+ case "${1}" in
+ flatpak info --system org.freedesktop.Platform.GL.nvidia-595-58-03
+ flatpak info --system org.freedesktop.Platform.GL32.nvidia-595-58-03
+ echo 'NVIDIA Flatpak runtime 595.58.03 already installed'
NVIDIA Flatpak runtime 595.58.03 already installed
+ exit 1
```

fixes: https://github.com/ublue-os/aurora/issues/1418