### PR TITLE
feat: enable GNOME Calculator search provider by default

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -21,7 +21,7 @@ monospace-font-name="JetBrains Mono 16"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]
-enabled=['io.github.kolunmi.Bazaar.desktop']
+enabled=['io.github.kolunmi.Bazaar.desktop', 'org.gnome.Calculator.desktop']
 
 [org.gnome.desktop.sound]
 allow-volume-above-100-percent=true


### PR DESCRIPTION
Adds org.gnome.Calculator.desktop to the enabled search providers list so users can do math directly from GNOME search without manually enabling it in settings.

Tested locally by applying the gsettings change and confirming calculator results appear inline when typing math expressions in the GNOME overview search.

<img width="1064" height="300" alt="image" src="https://github.com/user-attachments/assets/4573e3f0-cf8e-42be-95a8-5bdd4a2ea6d4" />

Closes https://github.com/projectbluefin/common/issues/256