### PR TITLE
fix(gschema): xdg-terminal-exec for terminal keyboard shortcuts

### DIFF
--- a/system_files/bluefin/etc/dconf/db/distro.d/02-bluefin-keybindings
+++ b/system_files/bluefin/etc/dconf/db/distro.d/02-bluefin-keybindings
@@ -3,13 +3,13 @@
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
 binding='<Control><Alt>t'
-command='/usr/bin/ptyxis --new-window'
-name='Ptyxis'
+command='xdg-terminal-exec'
+name='Terminal'
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
 binding='<Control><Alt>Return'
-command='/usr/bin/ptyxis --new-window'
-name='Ptyxis Alt'
+command='xdg-terminal-exec'
+name='Terminal Alt'
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2]
 binding='<Control><Shift>Escape'


### PR DESCRIPTION
## Summary

- Replace hardcoded `/usr/bin/ptyxis --new-window` with `xdg-terminal-exec` for the `ctrl+alt+t` and `ctrl+alt+return` shortcuts
- `xdg-terminal-exec` is the freedesktop standard for opening the user's configured default terminal, respecting `~/.config/xdg-terminals.list`
- Already used in Bluefin for the logo menu button (`menu-button-terminal='xdg-terminal-exec'` in `04-bluefin-logomenu-extension`)

**Motivation:** On Bluefin, this is a no-op — `xdg-terminal-exec` defaults to Ptyxis. But on downstream variants like Dakota that ship Ghostty as the default terminal, the shortcuts currently open Ptyxis instead of Ghostty, which is inconsistent with the logo menu button behavior.

## Test plan

- [ ] On Bluefin: `ctrl+alt+t` still opens Ptyxis
- [ ] On Dakota: `ctrl+alt+t` opens Ghostty
- [ ] Logo menu terminal button and keyboard shortcuts now use the same mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)