### PR TITLE
feat: add DX variant of ublue panel logo

### DIFF
--- a/system_files/bluefin/usr/share/icons/hicolor/scalable/actions/ublue-logo-dx-symbolic.svg
+++ b/system_files/bluefin/usr/share/icons/hicolor/scalable/actions/ublue-logo-dx-symbolic.svg
@@ -1,0 +1,17 @@
+<svg width="496" height="496" viewBox="0 0 296 296" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <clipPath id="outer">
+    <path d="M296 296H120C53.7258 296 0 242.274 0 176V30C0 13.4315 13.4315 0 30 0H266C282.569 0 296 13.4315 296 30V296Z" />
+  </clipPath>
+  <mask id="u-mask">
+    <rect width="296" height="296" fill="white" />
+    <path fill="black" d="M86.3349 70.6279V156.792C86.3349 185.485 109.654 208.744 138.419 208.744H208.665V70.6279V55H224.333H240V70.6279V240H138.419C92.3478 240 55 202.747 55 156.792V70.6279C55 61.9968 62.0146 55 70.6675 55H86.3349V70.6279Z" />
+  </mask>
+</defs>
+<g mask="url(#u-mask)">
+  <path fill="currentColor" d="M296 296H120C53.7258 296 0 242.274 0 176V30C0 13.4315 13.4315 0 30 0H266C282.569 0 296 13.4315 296 30V296Z" />
+  <g clip-path="url(#outer)">
+    <rect x="170" y="-80" width="50" height="520" transform="rotate(40 180 130)" fill="#5BC0EB" />
+  </g>
+</g>
+</svg>


### PR DESCRIPTION
Adds `ublue-logo-dx-symbolic.svg`: a variant of the panel logo with a diagonal blue racing stripe behind the U shape. Intended to visually indicate when DX mode is active.

The idea came from a conversation with Jorge about having a subtle visual difference in the panel when DX is enabled,  like a racing stripe or hood scoop. The stripe is rendered between the backing and the U cutout, so it peeks through like the turbo glowing underneath.

- Uses `currentColor` for the backing + U cutout (works on light and dark panels)
- Blue stripe (`#5BC0EB`) clipped to the outer shape
- U is a transparent mask cutout for proper theme compatibility