### PR TITLE
feat: use dynamic hostname in menu label

### DIFF
--- a/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
+++ b/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
@@ -4,7 +4,7 @@
 [org/gnome/shell/extensions/custom-command-list]
 command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
-entryrow1a-setting='---Bluefin'
+entryrow1a-setting='---$(hostname)'
 entryrow1b-setting=''
 entryrow1c-setting=''
 visible1-setting=true


### PR DESCRIPTION
Now that StorageB/custom-command-menu#10 added support for `$(command)` substitution in labels, replace the hardcoded "Bluefin" section header with `$(hostname)` so the menu displays the machine's actual hostname.

Follow-up to #264.