### PR TITLE
fix(custom-command-menu): add menu icon settings to dconf distro database

### DIFF
--- a/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
+++ b/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
@@ -2,6 +2,10 @@
 # https://github.com/StorageB/custom-command-menu
 
 [org/gnome/shell/extensions/custom-command-list]
+menuoptions-setting=2
+menuicon-setting='ublue-logo-symbolic'
+menulocation-setting=0
+show-arrow=false
 command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
 entryrow1a-setting='---$(hostname)'

--- a/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
+++ b/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
@@ -4,7 +4,7 @@
 [org/gnome/shell/extensions/custom-command-list]
 menuoptions-setting=2
 menuicon-setting='ublue-logo-symbolic'
-menulocation-setting=0
+menulocation-setting=1
 show-arrow=false
 command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 

--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -89,7 +89,7 @@ flatpak='off'
 [org.gnome.shell.extensions.custom-command-list]
 menuoptions-setting=2
 menuicon-setting='ublue-logo-symbolic'
-menulocation-setting=0
+menulocation-setting=1
 show-arrow=false
 
 [org.gnome.shell.extensions.search-light]


### PR DESCRIPTION
The custom-command-menu extension reads settings from its own bundled schema dir via `getSettings()`, so the gschema overrides in `zz0-bluefin-modifications.gschema.override` have no effect. Adds the menu display settings (icon, location, arrow) to the dconf distro database where the extension actually reads them.
<!-- This PR does not implement age verification -->