### PR TITLE
feat: add Files to custom command menu

### DIFF
--- a/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
+++ b/system_files/bluefin/etc/dconf/db/distro.d/04-bluefin-custom-command-menu
@@ -6,7 +6,7 @@ menuoptions-setting=2
 menuicon-setting='ublue-logo-symbolic'
 menulocation-setting=1
 show-arrow=false
-command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
 entryrow1a-setting='---$(hostname)'
 entryrow1b-setting=''
@@ -43,22 +43,27 @@ entryrow7b-setting='flatpak run com.mattjakeman.ExtensionManager'
 entryrow7c-setting=''
 visible7-setting=true
 
-entryrow8a-setting='Terminal'
-entryrow8b-setting='xdg-terminal-exec'
+entryrow8a-setting='Files'
+entryrow8b-setting='nautilus'
 entryrow8c-setting=''
 visible8-setting=true
 
-entryrow9a-setting='---Help'
-entryrow9b-setting=''
+entryrow9a-setting='Terminal'
+entryrow9b-setting='xdg-terminal-exec'
 entryrow9c-setting=''
 visible9-setting=true
 
-entryrow10a-setting='Documentation'
-entryrow10b-setting='xdg-open https://docs.projectbluefin.io/'
+entryrow10a-setting='---Help'
+entryrow10b-setting=''
 entryrow10c-setting=''
 visible10-setting=true
 
-entryrow11a-setting='Ask Bluefin'
-entryrow11b-setting='xdg-open https://ask.projectbluefin.io'
+entryrow11a-setting='Documentation'
+entryrow11b-setting='xdg-open https://docs.projectbluefin.io/'
 entryrow11c-setting=''
 visible11-setting=true
+
+entryrow12a-setting='Ask Bluefin'
+entryrow12b-setting='xdg-open https://ask.projectbluefin.io'
+entryrow12c-setting=''
+visible12-setting=true


### PR DESCRIPTION
Add Files (Nautilus) entry above Terminal in the custom command menu, so users can access the file manager even if the dock is disabled.

<!-- This PR does not implement age verification or check the user's birth date. -->