### PR TITLE
fix(motd): guard against double display on GNOME OS / freedesktop-sdk base

### DIFF
--- a/system_files/shared/etc/profile.d/ublue-motd.sh
+++ b/system_files/shared/etc/profile.d/ublue-motd.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Guard against double-sourcing: /etc/profile and /etc/bashrc both source
+# profile.d on GNOME OS / freedesktop-sdk based images (unlike Fedora which
+# guards /etc/bashrc with shopt -q login_shell). Same pattern as BLING_SOURCED.
+[ "${UBLUE_MOTD_SHOWN:-0}" -eq 1 ] && return 0
+export UBLUE_MOTD_SHOWN=1
+
 [ ! -e "$HOME"/.config/no-show-user-motd ] && ublue-motd

--- a/system_files/shared/etc/profile.d/ublue-motd.sh
+++ b/system_files/shared/etc/profile.d/ublue-motd.sh
@@ -4,6 +4,6 @@
 # profile.d on GNOME OS / freedesktop-sdk based images (unlike Fedora which
 # guards /etc/bashrc with shopt -q login_shell). Same pattern as BLING_SOURCED.
 [ "${UBLUE_MOTD_SHOWN:-0}" -eq 1 ] && return 0
-export UBLUE_MOTD_SHOWN=1
+UBLUE_MOTD_SHOWN=1
 
 [ ! -e "$HOME"/.config/no-show-user-motd ] && ublue-motd


### PR DESCRIPTION
## Problem

On GNOME OS / freedesktop-sdk based images (e.g. dakota), the MOTD fires twice in every interactive login shell session (e.g. Ghostty).

Root cause: freedesktop-sdk's `/etc/bashrc` unconditionally sources `/etc/profile.d/*.sh`, while Fedora's `/etc/bashrc` has a `shopt -q login_shell` guard that prevents this. This creates a double-source chain:

1. `/etc/profile` → profile.d → ublue-motd.sh (**MOTD #1**)
2. `~/.profile` → `~/.bashrc` → `/etc/bashrc` → profile.d → ublue-motd.sh (**MOTD #2**)

Production Bluefin (Fedora-based) is unaffected because Fedora's bashrc has the guard. Only freedesktop-sdk based images are affected.

## Fix

Add an `UBLUE_MOTD_SHOWN=1` guard at the top of `ublue-motd.sh` — identical pattern to `BLING_SOURCED=1` already used in `bling.sh` in this repo.

## Testing

Validated on physical hardware (NUC running dakota):

```
# Before fix
$ bash --login -i <<< 'echo done' | grep -c 'Welcome to Bluefin'
2

# After fix
$ bash --login -i <<< 'echo done' | grep -c 'Welcome to Bluefin'
1
```

Upstream issue: projectbluefin/dakota #200

Note: The proper root-cause fix is to patch freedesktop-sdk's `/etc/bashrc` to add the `shopt -q login_shell` guard (via dakota's patch_queue). This guard is a defensive fix that also protects against any other future double-source scenarios.