### PR TITLE
feat(bazaar): add SpeedOfSound to AI and Machine Learning section

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -513,3 +513,4 @@ rows:
             - io.github.qwersyk.Newelle
             - ai.jan.Jan
             - ink.whis.Whis
+            - io.speedofsound.SpeedOfSound


### PR DESCRIPTION
This PR adds `io.speedofsound.SpeedOfSound` to the "AI and Machine Learning" section of the curated apps list in Bazaar.

Speed of Sound is a voice-typing application for Linux that features:
- On-device transcription using OpenAI's Whisper model.
- LLM text polishing with support for local (Ollama, vLLM) and cloud providers.
- Efficient model execution via Sherpa-ONNX.

It fits well within the curated AI section as a high-quality open-source AI utility.