### PR TITLE
feat(ublue-bling): clean up fish script

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bling/bling.fish
+++ b/system_files/shared/usr/share/ublue-os/bling/bling.fish
@@ -1,35 +1,45 @@
 #!/usr/bin/env fish
 
-# FIXME: add no-source-twice fix
-
-# ls aliases
-if [ "$(command -v eza)" ]
-    alias ll='eza -l --icons=auto --group-directories-first'
-    alias l.='eza -d .*'
-    alias ls='eza'
-    alias l1='eza -1'
-end
-
-# ugrep for grep
-if [ "$(command -v ug)" ]
-    alias grep='ug'
-    alias egrep='ug -E'
-    alias fgrep='ug -F'
-    alias xzgrep='ug -z'
-    alias xzegrep='ug -zE'
-    alias xzfgrep='ug -zF'
-end
-
-# bat for cat
-alias cat='bat --style=plain --pager=never' 2>/dev/null
-
 if status is-interactive
+    test "$BLING_SOURCED" = 1; and return; or set -g BLING_SOURCED 1
+
+    function __bling_abbr -d "Create an abbreviation or alias"
+        test "$BLING_USE_ABBR" != 0; and abbr -a $argv; or alias $argv
+    end
+
+    # ls aliases
+    if type -q eza
+        __bling_abbr ll 'eza -l --icons=auto --group-directories-first'
+        __bling_abbr l. 'eza -d .*'
+        __bling_abbr ls 'eza'
+        __bling_abbr l1 'eza -1'
+    end
+
+    # ugrep for grep
+    if type -q ug
+        __bling_abbr grep 'ug'
+        __bling_abbr egrep 'ug -E'
+        __bling_abbr fgrep 'ug -F'
+        __bling_abbr xzgrep 'ug -z'
+        __bling_abbr xzegrep 'ug -zE'
+        __bling_abbr xzfgrep 'ug -zF'
+    end
+
+    # bat for cat
+    if type -q bat
+        __bling_abbr cat 'bat --style=plain --pager=never'
+    end
+
+    type -q direnv; and direnv hook fish | source    
+
     # Atuin shell integration is disabled by default
     # The atuin binary is still installed and available for manual use
     # To enable shell integration, uncomment the following line or add it to your config.fish:
-    # [ "$(command -v atuin)" ] && eval "$(atuin init fish $ATUIN_INIT_FLAGS)"
+    # type -q atuin; and atuin init fish $ATUIN_INIT_FLAGS | source
 
-    [ "$(command -v starship)" ] && eval "$(starship init fish)"
+    type -q starship; and starship init fish | source 
 
-    [ "$(command -v zoxide)" ] && eval "$(zoxide init fish)"
+    type -q zoxide; and zoxide init fish | source 
+
+    type -q mise; and test "$MISE_FISH_AUTO_ACTIVATE" != 0; and mise activate fish | source
 end


### PR DESCRIPTION
Add a variety of fixes to the bling.fish script to bring it up to par with bling.sh.

- only blingify in an interactive terminal
- add no-source-twice fix
- Simplify command existence checks
- Add command existence check for bat
- Add direnv and mise
- Use `command init fish | source` pattern (every tool has that pattern as the correct way to set up the tool in their respective documentations).
- Use `abbr -a` instead of `alias` by default. Abbr is generally preferred over alias in fish. This does result in a functional change though: `abbr` expands in the terminal. This is one of the reasons they are preferred (you can see the exact command instead of the real command being effecively hidden), but some people may prefer the simpler aliases, so I added a flag similar to what `mise` has to disable `abbr` and go back to `alias` if a user prefers that.