### PR TITLE
chore(ci): enable renovate for git-submodules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,10 @@
     "github>ublue-os/renovate-config:org-inherited-config"
   ],
 
+  "git-submodules": {
+    "enabled": true
+  },
+
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
We are using submodules only for the branding for now but this is nice to have automated.