### PR TITLE
docs: mention LUKS in toggle-tpm2 comment for better ujust --choose discoverability

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/shared.just
+++ b/system_files/shared/usr/share/ublue-os/just/shared.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 # These are recipes that are generic and should be available in bluefin and aurora
 
-# TPM2 auto-unlock toggle
+# Toggle LUKS auto-unlock via TPM2
 [group('System')]
 toggle-tpm2:
     @/usr/bin/luks-tpm2-autounlock


### PR DESCRIPTION
The comment on the toggle-tpm2 recipe only mentioned TPM2, but not LUKS. This made the recipe undiscoverable when searching for "luks" in ujust --choose.

By adding LUKS to the description, the recipe shows up as expected without requiring any changes to ujust itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description text for the TPM2 auto-unlock toggle feature to provide clearer terminology and better reflect its functionality with LUKS encryption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->