### PR TITLE
fix: ignore commented LockLayering setting

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -14,7 +14,7 @@ update:
         echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
         exit 1
     fi
-    if grep -q -E -e "LockLayering=false" /etc/rpm-ostreed.conf ; then
+    if grep -q -E -e "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*false([[:space:]]*(#.*)?)?$" /etc/rpm-ostreed.conf ; then
         rpm-ostree upgrade
     else
         sudo bootc upgrade


### PR DESCRIPTION
## Summary
- only treat active `LockLayering=false` as enabled
- keep commented examples from selecting `rpm-ostree upgrade`

## Validation
- checked commented `# LockLayering=false` does not match
- checked active `LockLayering=false` still matches