### PR TITLE
fix: don't show failure message on bluefin-cli

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -3,6 +3,7 @@
 
 # Configure Bluefin-CLI Terminal Experience with Brew
 [group('System')]
+[no-exit-message]
 bluefin-cli:
     @ublue-bling
     brew bundle --file=/usr/share/ublue-os/homebrew/cli.Brewfile


### PR DESCRIPTION
When you decline `ujust bluefin-cli` with "I'm boring", which happens in ublue-bling, gum will exit with 1, this in turn makes the just recipe fail. It confuses users and makes it seem like the recipe didn't behave as expected.

```
error: Recipe `aurora-cli` failed on line 36 with exit code 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted system output behavior to reduce message verbosity during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->