### PR TITLE
fix: set over amplification to false

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -24,7 +24,7 @@ accent-color="slate"
 enabled=['io.github.kolunmi.Bazaar.desktop', 'org.gnome.Calculator.desktop']
 
 [org.gnome.desktop.sound]
-allow-volume-above-100-percent=true
+allow-volume-above-100-percent=false
 theme-name="freedesktop"
 
 [org.gnome.desktop.wm.preferences]


### PR DESCRIPTION
solves https://github.com/projectbluefin/common/issues/150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System audio volume is now properly limited to 100% maximum, preventing potential distortion and protecting audio hardware integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->