### PR TITLE
fix: adjust font size to match upstream

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -15,9 +15,9 @@ secondary-color='FFFFFF'
 enable-hot-corners=false
 clock-show-weekday=true
 font-antialiasing="rgba"
-font-name="Adwaita Sans 12"
+font-name="Adwaita Sans 11"
 document-font-name="Adwaita Sans 12"
-monospace-font-name="JetBrains Mono 16"
+monospace-font-name="JetBrains Mono 11"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]


### PR DESCRIPTION
Adjust size of system fonts to match default upstream settings [1]. We're sticking with JetBrains Mono as the default monospace font since the upstream Adwaita Mono font renders nerd font symbols differently to all other nerd fonts [2].

This addresses https://github.com/projectbluefin/common/issues/266 and supersedes https://github.com/projectbluefin/common/pull/271.

[1] https://github.com/projectbluefin/common/pull/271#issuecomment-4398501377
[2] https://github.com/projectbluefin/common/pull/271#issuecomment-4384318598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted default interface font size from 12 to 11 points.
  * Updated monospace font size from 16 to 11 points.
  * Configured document font settings to Adwaita Sans 12 points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->