### PR TITLE
fix(apps): remove duplicate VideoTrimmer from productivity section

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -308,7 +308,6 @@ rows:
             - org.audacityteam.Audacity
             - org.ardour.Ardour
             - org.gnome.Fractal
-            - org.gnome.gitlab.YaLTeR.VideoTrimmer
 
   - sections:
       - expand-horizontally: true


### PR DESCRIPTION
VideoTrimmer shows up in both featured and office apps -- remove the duplicate in Productivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a video trimmer application from the curated Office & Productivity applications list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/320)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->