### PR TITLE
Revert "feat(bluefin, gschemas): specify mutter experimental features…

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -78,7 +78,6 @@ sort-directories-first=true
 [org.gnome.mutter]
 center-new-windows=true
 check-alive-timeout=uint32 20000
-experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling']
 
 [com.github.stunkymonkey.nautilus-open-any-terminal]
 terminal='ptyxis'


### PR DESCRIPTION
… directly on gschema"

This reverts commit fc54d07800d45d5a9005833bf7e004d21a2c5067.

We're on GNOME 50 now.

Close https://github.com/projectbluefin/common/issues/253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated window manager configuration settings for improved system responsiveness handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/321)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->