### PR TITLE
chore(bazaar): update curated jellyfin to org.jellyfin.JellyfinDesktop

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -262,7 +262,7 @@ rows:
             - org.videolan.VLC
             - com.github.wwmm.easyeffects
             - me.timschneeberger.jdsp4linux
-            - com.github.iwalton3.jellyfin-media-player
+            - org.jellyfin.JellyfinDesktop
             - tv.plex.PlexDesktop
             - com.plexamp.Plexamp
             - com.rafaelmardojai.Blanket


### PR DESCRIPTION
This is the new official client now: https://flathub.org/en/apps/org.jellyfin.JellyfinDesktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the curated media applications list to refresh available options for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/322)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->