### PR TITLE
chore: bump game-devices-udev

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,8 +14,8 @@ RUN install -d /out/shared/usr/share/bash-completion/completions /out/shared/usr
   just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/zsh/site-functions/_ujust && \
   just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/fish/vendor_completions.d/ujust.fish
 
-RUN curl -fsSLo - https://codeberg.org/fabiscafe/game-devices-udev/archive/0.25.tar.gz | tar xzvf - -C /tmp/ && \
-  install -Dpm0644 -t /out/shared/usr/lib/udev/rules.d/ /tmp/game-devices-udev/*.rules && \
+RUN curl -fsSLo - https://codeberg.org/fabiscafe/game-devices-udev/archive/46238ca85bddd98d236eabe22b202b81aa3ac66e.tar.gz | tar xzvf - -C /tmp/ && \
+  install -Dpm0644 -t /out/shared/usr/lib/udev/rules.d/ /tmp/game-devices-udev/src/*.rules && \
   curl -fsSLo /out/shared/usr/lib/udev/rules.d/70-u2f.rules https://raw.githubusercontent.com/Yubico/libfido2/refs/heads/main/udev/70-u2f.rules
 
 FROM scratch AS ctx


### PR DESCRIPTION
they changed their repo structure, had some nice improvements since the last release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated game device support to a newer version in the container build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/330)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->