### PR TITLE
chore: Bump game-devices-udev. Restore the priority prefixes.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,8 +14,10 @@ RUN install -d /out/shared/usr/share/bash-completion/completions /out/shared/usr
   just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/zsh/site-functions/_ujust && \
   just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/fish/vendor_completions.d/ujust.fish
 
-RUN curl -fsSLo - https://codeberg.org/fabiscafe/game-devices-udev/archive/46238ca85bddd98d236eabe22b202b81aa3ac66e.tar.gz | tar xzvf - -C /tmp/ && \
-  install -Dpm0644 -t /out/shared/usr/lib/udev/rules.d/ /tmp/game-devices-udev/src/*.rules && \
+RUN curl -fsSLo - https://codeberg.org/fabiscafe/game-devices-udev/archive/1.0.tar.gz | tar xzvf - -C tmp/ && \
+    for f in tmp/game-devices-udev/src/*.rules; do \
+      install -Dpm0644 "$f" "out/shared/usr/lib/udev/rules.d/71-${f##*/}"; \
+    done && \
   curl -fsSLo /out/shared/usr/lib/udev/rules.d/70-u2f.rules https://raw.githubusercontent.com/Yubico/libfido2/refs/heads/main/udev/70-u2f.rules
 
 FROM scratch AS ctx


### PR DESCRIPTION
* Bumps game-devices-udev to the 1.0 tag  to get the new Steam Controller firmware updates working
* Restores the rules' priority prefix that was dropped upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `game-devices-udev` to use the stable `1.0` release version instead of an archived commit snapshot, improving build reproducibility and consistency.
  * Refined the udev rules installation process for better organization and reliability of device rule configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->