### PR TITLE
feat(bazaar): add Rclone Manager and Tube Converter to curated apps

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -266,6 +266,7 @@ rows:
             - tv.plex.PlexDesktop
             - com.plexamp.Plexamp
             - com.rafaelmardojai.Blanket
+            - org.nickvision.tubeconverter
 
   - sections:
       - expand-horizontally: true
@@ -398,6 +399,7 @@ rows:
             - io.github.plrigaux.sysd-manager
             - org.mozilla.vpn
             - org.cryptomator.Cryptomator
+            - io.github.zarestia_dev.rclone-manager
 
   - sections:
       - expand-horizontally: true


### PR DESCRIPTION
## Summary
- add Tube Converter to the Media curated apps category
- add Rclone Manager to the Utilities curated apps category

## Testing
- python3 YAML parse check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tube Converter application added to the Media section of curated apps
  * Rclone Manager application added to the Utilities section of curated apps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->