### PR TITLE
fix: update bazaar refs to new bazaar-org location

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -1,4 +1,4 @@
-# https://github.com/kolunmi/bazaar/blob/main/docs/overview.org
+# https://github.com/bazaar-org/bazaar/blob/main/docs/overview.md
 
 css: |
   .global-section banner {

--- a/system_files/bluefin/usr/lib/systemd/user/bazaar.service
+++ b/system_files/bluefin/usr/lib/systemd/user/bazaar.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Bazaar background service
-Documentation=https://github.com/kolunmi/bazaar
+Documentation=https://github.com/bazaar-org/bazaar
 After=graphical-session.target
 StartLimitBurst=10
 

--- a/system_files/bluefin/usr/share/ublue-os/motd/tips/10-tips.md
+++ b/system_files/bluefin/usr/share/ublue-os/motd/tips/10-tips.md
@@ -1,6 +1,6 @@
 Bluefin is your gateway to Cloud Native - find your flock at [landscape.cncf.io](https://l.cncf.io)
 GNOME makes your desktop! Donate to [GNOME](https://donate.gnome.org)
-Support the app store! Donate to  [Bazaar](https://github.com/kolunmi/bazaar)!
+Support the app store! Donate to  [Bazaar](https://github.com/bazaar-org/bazaar)!
 Need more indepth technical information?~Check out the [Bluefin Administrator's Guide](https://docs.projectbluefin.io/administration)
 Like servers? Check out [ucore](https://github.com/ublue-os/ucore)
 Update break something? You can roll back with `bootc rollback`


### PR DESCRIPTION
The bazaar project transferred from kolunmi/bazaar to bazaar-org/bazaar. Update all URL references to the canonical new location. Also update the docs link from overview.org to the renamed overview.md.

Closes #285

Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated system configuration and documentation references to point to the updated project repository location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->