### PR TITLE
feat(ide): add VSCode Insiders to ide Brewfile

### DIFF
--- a/system_files/shared/usr/share/ublue-os/homebrew/ide.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/ide.Brewfile
@@ -1,5 +1,6 @@
 tap "ublue-os/tap"
 cask "ublue-os/tap/visual-studio-code-linux"
+cask "ublue-os/tap/visual-studio-code-linux@insiders"
 cask "ublue-os/tap/vscodium-linux"
 cask "ublue-os/tap/antigravity-linux"
 cask "ublue-os/tap/jetbrains-toolbox-linux"


### PR DESCRIPTION
Tested and confirmed locally. Adds visual-studio-code-linux@insiders from ublue-os/tap, which landed in ublue-os/homebrew-tap#337. Installs side-by-side with the stable release using the code-insiders binary.

Closes #267

Assisted-by: claude-sonnet-4-5 via pi