### PR TITLE
feat(just): add ujust install-asus for ASUS laptop tools

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -74,3 +74,23 @@ cncf:
     fi
     bbrew -f "/usr/share/ublue-os/homebrew/cncf.Brewfile"
     [[ -t 0 ]] && ujust --choose || true
+
+# Install ASUS laptop tools (asusctl daemon + ROG Control Center) | https://gitlab.com/asus-linux/asusctl
+[group('Apps')]
+install-asus:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Installing ASUS laptop tools..."
+    brew install --cask ublue-os/tap/asusctl-linux
+    brew install --cask ublue-os/tap/rog-control-center-linux
+    echo ""
+    echo "Enabling system services..."
+    sudo systemctl enable --now asusd.service asus-shutdown.service
+    sudo udevadm control --reload
+    sudo udevadm trigger
+    echo ""
+    echo "Enabling user daemon..."
+    systemctl --user daemon-reload
+    systemctl --user enable --now asusd-user.service
+    echo ""
+    echo "ASUS tools installed! Run 'rog-control-center' or find it in your app launcher."


### PR DESCRIPTION
Another QoL fix. 

Adds install-asus recipe to apps.just that installs and activates both the asusctl system daemon (asusctl-linux) and the ROG Control Center GUI (rog-control-center-linux) from ublue-os/tap.

Handles the full setup flow: brew install both casks, enable asusd.service + asus-shutdown.service via sudo, reload udev rules, and enable the asusd-user.service user unit.

Closes #287
Closes #298

Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an installation command for ASUS laptop tools that automates installing ASUS utilities, enables required services, sets up device rules, and provides next-step guidance to complete setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->