### PR TITLE
fix(opentabletdriver): fix opentabletdriver recipe

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -26,8 +26,8 @@ install-opentabletdriver:
       OTD_TMPDIR="$(mktemp -d)"
 
       curl -s "https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest" \
-        | jq -r '.assets | sort_by(.created_at) | .[] | select (.name|test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
-        | wget -qi - -O - \
+        | jq -r '.assets[] | select(.name | test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
+        | xargs curl -L -s \
         | tar --strip-components=1 -xvzf - -C "${OTD_TMPDIR}"
 
       # https://opentabletdriver.net/Wiki/Documentation/RequiredPermissions


### PR DESCRIPTION
The recipe failed to extract the downloaded tar.gz properly and the rules never got placed which is why the cp of the rules didn't succeed -> recipe couldn't find the actual udev rule

Closed #342 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenTabletDriver installation download mechanism for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->