### PR TITLE
fix(#266): drop monospace-font-name override — use GNOME default (Adwaita Mono)

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -17,7 +17,6 @@ clock-show-weekday=true
 font-antialiasing="rgba"
 font-name="Adwaita Sans 11"
 document-font-name="Adwaita Sans 12"
-monospace-font-name="JetBrains Mono 11"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]


### PR DESCRIPTION
## Summary

- Removes `monospace-font-name="JetBrains Mono 11"` from the gschema override, letting GNOME fall back to its upstream default (Adwaita Mono)

## Context

Issue #266 asked to drop our custom font diff now that GNOME has a text size slider. The blocker was whether to replace JetBrains Mono with a Nerd Font-patched Adwaita Mono. As noted in the issue:

- `che/nerd-fonts` COPR has not yet packaged Adwaita Mono ([discussion](https://discussion.fedoraproject.org/t/che-nerd-fonts/87161/18))
- Downloading from nerd-fonts.com is blocked in the build process (PR #271 hit this)
- The upstream Adwaita Mono renders nerd font icons slightly differently but is not broken

The cleanest path forward: drop the override entirely. GNOME will use Adwaita Mono by default. JetBrains Mono Nerd Font remains available opt-in via `fonts.Brewfile` for users who want it.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)