### PR TITLE
add dynamic wallpaper timer

### DIFF
--- a/system_files/bluefin/usr/lib/systemd/user/bluefin-dynamic-wallpaper.service
+++ b/system_files/bluefin/usr/lib/systemd/user/bluefin-dynamic-wallpaper.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Bluefin Dynamic Wallpaper
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/bluefin-dynamic-wallpaper

--- a/system_files/bluefin/usr/lib/systemd/user/bluefin-dynamic-wallpaper.timer
+++ b/system_files/bluefin/usr/lib/systemd/user/bluefin-dynamic-wallpaper.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Bluefin Dynamic Wallpaper daily
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=24h
+Persistent=true
+
+[Install]
+WantedBy=graphical-session.target

--- a/system_files/bluefin/usr/libexec/bluefin-dynamic-wallpaper
+++ b/system_files/bluefin/usr/libexec/bluefin-dynamic-wallpaper
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly WALLPAPER_BASE_PATH="/usr/share/backgrounds/bluefin"
+
+CURRENT_WALLPAPER="$(gsettings get org.gnome.desktop.background picture-uri)"
+CURRENT_WALLPAPER="${CURRENT_WALLPAPER#\'file://}"
+CURRENT_WALLPAPER="${CURRENT_WALLPAPER%\'}"
+
+CURRENT_WALLPAPER_DARK="$(gsettings get org.gnome.desktop.background picture-uri-dark)"
+CURRENT_WALLPAPER_DARK="${CURRENT_WALLPAPER_DARK#\'file://}"
+CURRENT_WALLPAPER_DARK="${CURRENT_WALLPAPER_DARK%\'}"
+
+if [[ "$CURRENT_WALLPAPER" != "${WALLPAPER_BASE_PATH}"/*-bluefin.xml ]] ||
+   [[ "$CURRENT_WALLPAPER_DARK" != "${WALLPAPER_BASE_PATH}"/*-bluefin.xml ]]; then
+    echo "User has a personal wallpaper set. Not changing it."
+    exit 0
+fi
+
+MONTH="$(date +%m)"
+MONTH_NUM="${MONTH#0}"
+
+LATITUDE="$(/usr/libexec/get-geoclue-latitude)" && LOCATION_EXIT=0 || LOCATION_EXIT=$?
+
+HEMISPHERE="north"
+
+if [[ $LOCATION_EXIT -eq 2 ]]; then
+    echo "Location services disabled or denied, defaulting to northern hemisphere"
+elif [[ $LOCATION_EXIT -ne 0 ]]; then
+    echo "Error getting location, defaulting to northern hemisphere"
+elif ! [[ "$LATITUDE" =~ ^-?[0-9]+\.?[0-9]*$ ]]; then
+    echo "Invalid latitude format: $LATITUDE, defaulting to northern hemisphere"
+elif [[ "${LATITUDE:0:1}" == "-" ]]; then
+    HEMISPHERE="south"
+    # Add 6 months for southern hemisphere seasons; months are 1-12 so adjust before modulo.
+    MONTH_NUM=$(( (MONTH_NUM + 5) % 12 + 1 ))
+fi
+
+if [[ $MONTH_NUM -lt 10 ]]; then
+    MONTH_PADDED="0$MONTH_NUM"
+else
+    MONTH_PADDED="$MONTH_NUM"
+fi
+
+WALLPAPER_PATH="${WALLPAPER_BASE_PATH}/${MONTH_PADDED}-bluefin.xml"
+
+if [[ ! -f "$WALLPAPER_PATH" ]]; then
+    echo "Wallpaper file not found: $WALLPAPER_PATH" >&2
+    exit 1
+fi
+
+if gsettings set org.gnome.desktop.background picture-uri "file://$WALLPAPER_PATH" &&
+   gsettings set org.gnome.desktop.background picture-uri-dark "file://$WALLPAPER_PATH"; then
+    echo "Successfully set wallpaper to $WALLPAPER_PATH (adjusted month: $MONTH_NUM, hemisphere: $HEMISPHERE)"
+else
+    echo "Failed to set wallpaper" >&2
+    exit 1
+fi

--- a/system_files/bluefin/usr/libexec/get-geoclue-latitude
+++ b/system_files/bluefin/usr/libexec/get-geoclue-latitude
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly LOCATION_TIMEOUT_SECONDS=30
+readonly POLL_INTERVAL=0.5
+readonly MAX_ATTEMPTS=$(( LOCATION_TIMEOUT_SECONDS * 2 ))
+
+CLIENT_PATH=""
+
+cleanup() {
+    if [[ -n "$CLIENT_PATH" ]]; then
+        gdbus call --system \
+            --dest org.freedesktop.GeoClue2 \
+            --object-path "$CLIENT_PATH" \
+            --method org.freedesktop.GeoClue2.Client.Stop &>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+if ! command -v gdbus &>/dev/null; then
+    echo "error: gdbus not found" >&2
+    exit 1
+fi
+
+CREATE_OUTPUT="$(gdbus call --system \
+    --dest org.freedesktop.GeoClue2 \
+    --object-path /org/freedesktop/GeoClue2/Manager \
+    --method org.freedesktop.GeoClue2.Manager.CreateClient 2>&1)" || {
+    if [[ "$CREATE_OUTPUT" == *"org.freedesktop.DBus.Error.AccessDenied"* ]]; then
+        echo "error: location services disabled or denied" >&2
+        exit 2
+    fi
+    echo "error: failed to create GeoClue2 client: $CREATE_OUTPUT" >&2
+    exit 1
+}
+
+CLIENT_PATH="$(sed -n "s|.*'\(/org/freedesktop/GeoClue2/Client/[0-9]*\)'.*|\1|p" <<< "$CREATE_OUTPUT")"
+if [[ -z "$CLIENT_PATH" ]]; then
+    echo "error: failed to parse client path from: $CREATE_OUTPUT" >&2
+    exit 1
+fi
+
+run_gdbus() {
+    local description="$1"
+    shift
+    local output
+
+    output="$(gdbus call --system "$@" 2>&1)" || {
+        if [[ "$output" == *"org.freedesktop.DBus.Error.AccessDenied"* ]]; then
+            echo "error: location services disabled or denied" >&2
+            exit 2
+        fi
+        echo "error: failed to $description: $output" >&2
+        exit 1
+    }
+
+    printf '%s\n' "$output"
+}
+
+run_gdbus "set GeoClue2 DesktopId" \
+    --dest org.freedesktop.GeoClue2 \
+    --object-path "$CLIENT_PATH" \
+    --method org.freedesktop.DBus.Properties.Set \
+    org.freedesktop.GeoClue2.Client DesktopId \
+    "<'bluefin-dynamic-wallpaper'>" >/dev/null
+
+run_gdbus "set GeoClue2 RequestedAccuracyLevel" \
+    --dest org.freedesktop.GeoClue2 \
+    --object-path "$CLIENT_PATH" \
+    --method org.freedesktop.DBus.Properties.Set \
+    org.freedesktop.GeoClue2.Client RequestedAccuracyLevel \
+    "<uint32 4>" >/dev/null
+
+run_gdbus "start GeoClue2 client" \
+    --dest org.freedesktop.GeoClue2 \
+    --object-path "$CLIENT_PATH" \
+    --method org.freedesktop.GeoClue2.Client.Start >/dev/null
+
+ATTEMPT=0
+LOCATION_PATH=""
+while (( ATTEMPT < MAX_ATTEMPTS )); do
+    LOC_OUTPUT="$(gdbus call --system \
+        --dest org.freedesktop.GeoClue2 \
+        --object-path "$CLIENT_PATH" \
+        --method org.freedesktop.DBus.Properties.Get \
+        org.freedesktop.GeoClue2.Client Location 2>/dev/null)" || true
+
+    LOCATION_PATH="$(sed -n "s|.*'\(/org/freedesktop/GeoClue2/Location/[0-9]*\)'.*|\1|p" <<< "$LOC_OUTPUT")"
+    if [[ -n "$LOCATION_PATH" ]]; then
+        break
+    fi
+
+    sleep "$POLL_INTERVAL"
+    (( ATTEMPT += 1 ))
+done
+
+if [[ -z "$LOCATION_PATH" ]]; then
+    echo "error: location unavailable after ${LOCATION_TIMEOUT_SECONDS}s timeout" >&2
+    exit 1
+fi
+
+LAT_OUTPUT="$(run_gdbus "read latitude" \
+    --dest org.freedesktop.GeoClue2 \
+    --object-path "$LOCATION_PATH" \
+    --method org.freedesktop.DBus.Properties.Get \
+    org.freedesktop.GeoClue2.Location Latitude)"
+
+LATITUDE="$(sed -n 's|.*<\(double \)\?\(-\?[0-9][0-9]*\.\?[0-9]*\)>.*|\2|p' <<< "$LAT_OUTPUT")"
+if [[ -z "$LATITUDE" ]]; then
+    echo "error: failed to parse latitude from: $LAT_OUTPUT" >&2
+    exit 1
+fi
+
+LON_OUTPUT="$(run_gdbus "read longitude" \
+    --dest org.freedesktop.GeoClue2 \
+    --object-path "$LOCATION_PATH" \
+    --method org.freedesktop.DBus.Properties.Get \
+    org.freedesktop.GeoClue2.Location Longitude)"
+
+LONGITUDE="$(sed -n 's|.*<\(double \)\?\(-\?[0-9][0-9]*\.\?[0-9]*\)>.*|\2|p' <<< "$LON_OUTPUT")"
+if [[ -z "$LONGITUDE" ]]; then
+    echo "error: failed to parse longitude from: $LON_OUTPUT" >&2
+    exit 1
+fi
+
+if [[ "$LATITUDE" =~ ^-?0+(\.0+)?$ ]] && [[ "$LONGITUDE" =~ ^-?0+(\.0+)?$ ]]; then
+    echo "error: coordinates are (0.0, 0.0), likely uninitialized" >&2
+    exit 1
+fi
+
+echo "$LATITUDE"

--- a/system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh
+++ b/system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script dynamic-wallpaper user 1 || exit 0
+
+echo "Enabling dynamic wallpaper timer"
+systemctl --user enable --now bluefin-dynamic-wallpaper.timer


### PR DESCRIPTION
## Summary

- Add a shared user systemd timer and service for Bluefin dynamic wallpapers.
- Add a GeoClue-backed latitude helper that falls back cleanly when location is unavailable or denied.
- Add a user setup hook so the timer is enabled for users through the common layer.

## Why

This ports the applicable shared-layer work from ublue-os/bluefin#3890 into `projectbluefin/common`, where shared Bluefin workload behavior belongs. That keeps the feature in one layer for downstream Bluefin variants instead of landing it only in `ublue-os/bluefin`.

## Scope note

The approved Bluefin PR also removed the old build-time month rewrite from `ublue-os/bluefin` at `build_files/base/05-override-install.sh`. That file does not exist in `projectbluefin/common`, so this PR cannot remove that line directly. If that rewrite still runs in Bluefin after this common change lands, it should be removed in a small follow-up PR against `ublue-os/bluefin`.

## Testing

- `shellcheck system_files/shared/usr/libexec/bluefin-dynamic-wallpaper system_files/shared/usr/libexec/get-geoclue-latitude system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh`
- `bash -n system_files/shared/usr/libexec/bluefin-dynamic-wallpaper system_files/shared/usr/libexec/get-geoclue-latitude system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh`
- `git diff --check HEAD~1..HEAD`
- `systemd-analyze verify` with a temporary host-valid `ExecStart` relocation
- Fake `gsettings` test confirmed southern hemisphere maps May to November and updates both light/dark wallpaper URIs
- Fake `gsettings` test confirmed custom dark wallpaper is not overwritten
- Fake `gdbus` tests confirmed valid latitude, AccessDenied exit 2, and `(0.0, 0.0)` rejection

`just check` was also run. It fails on existing formatting drift in untouched Justfiles under `system_files/bluefin/usr/share/ublue-os/just/`; this PR does not touch `Justfile` or `*.just`, so that path-filtered workflow should not run for this change.

Refs ublue-os/bluefin#3890


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic monthly wallpaper that selects images per hemisphere and updates automatically.
  * Automatic daily wallpaper refresh with safe behavior to preserve custom user-set wallpapers.

* **Chores**
  * User setup now enables and starts the per-user wallpaper timer so updates run automatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->