### PR TITLE
feat(just): add caffeinate recipe to prevent system sleep

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/default.just
+++ b/system_files/shared/usr/share/ublue-os/just/default.just
@@ -59,6 +59,26 @@ clean-system:
         brew cleanup
     fi
 
+# Prevent the system from sleeping, like macOS caffeinate
+# Usage: ujust caffeinate           (hold indefinitely, Ctrl+C to release)
+# ujust caffeinate -- sleep 60  (hold while command runs)
+caffeinate *args:
+    #!/usr/bin/env bash
+    if [ -z "{{ args }}" ]; then
+        echo "Preventing system sleep. Press Ctrl+C to allow sleep again."
+        exec systemd-inhibit \
+            --what=sleep:idle:handle-lid-switch \
+            --who=caffeinate \
+            --why="User requested no sleep" \
+            sleep infinity
+    else
+        exec systemd-inhibit \
+            --what=sleep:idle \
+            --who=caffeinate \
+            --why="Running: {{ args }}" \
+            {{ args }}
+    fi
+
 # Show all messages from this boot
 logs-this-boot:
     sudo journalctl --no-hostname -b 0


### PR DESCRIPTION
## Summary

Closes #350

Adds a `caffeinate` recipe to `default.just` that wraps `systemd-inhibit` to provide the macOS caffeinate experience on Linux. Without args, holds sleep indefinitely until Ctrl+C. With args, holds sleep only while the given command runs.

## Usage

```
ujust caffeinate                    # hold indefinitely, Ctrl+C to release
ujust caffeinate -- sleep 60        # hold while command runs
ujust caffeinate -- make long-build # hold while build runs
```

## Changes

- `system_files/shared/usr/share/ublue-os/just/default.just`: add `caffeinate` recipe

## Test plan

- [ ] Run `ujust caffeinate` and confirm `systemd-inhibit --list` shows the inhibitor
- [ ] Press Ctrl+C and confirm sleep is re-enabled
- [ ] Run `ujust caffeinate -- sleep 5` and confirm inhibitor is released after 5 seconds