### PR TITLE
fix(ujust): reload udev and unload drivers after OpenTabletDriver install

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -30,9 +30,15 @@ install-opentabletdriver:
         | tar --strip-components=1 -xvzf - -C "${OTD_TMPDIR}"
 
       # https://opentabletdriver.net/Wiki/Documentation/RequiredPermissions
+      # Clean up any old rules files from previous installs that may conflict
+      sudo rm -f /etc/udev/rules.d/90-opentabletdriver.rules /etc/udev/rules.d/99-opentabletdriver.rules
       sudo cp "${OTD_TMPDIR}/etc/udev/rules.d/70-opentabletdriver.rules" /etc/udev/rules.d/71-opentabletdriver.rules
       echo -ne "blacklist hid_uclogic\nblacklist wacom\n" | sudo tee /etc/modprobe.d/blacklist-opentabletdriver.conf
       rm -rf "${OTD_TMPDIR}"
+      # Reload udev rules and immediately unload conflicting drivers so a reboot is not required
+      sudo udevadm control --reload-rules && sudo udevadm trigger
+      sudo modprobe uinput
+      sudo rmmod wacom hid_uclogic 2>/dev/null || true
 
       flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver
 
@@ -43,7 +49,8 @@ install-opentabletdriver:
       systemctl enable --user --now opentabletdriver.service
     elif [ "${EXIT_CODE}" == 1 ] ; then
       echo "Uninstalling OpenTabletDriver..."
-      sudo rm -f /etc/modprobe.d/blacklist-opentabletdriver.rules /etc/udev/rules.d/71-opentabletdriver.rules
+      sudo rm -f /etc/modprobe.d/blacklist-opentabletdriver.conf /etc/udev/rules.d/71-opentabletdriver.rules
+      sudo udevadm control --reload-rules && sudo udevadm trigger
       flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver
     fi
 


### PR DESCRIPTION
## Summary

The `install-opentabletdriver` recipe wrote udev rules and a kernel module blacklist but never applied them, requiring a reboot before OTD could take control of the tablet. Additionally the uninstall path tried to remove `blacklist-opentabletdriver.rules` (wrong extension) instead of `blacklist-opentabletdriver.conf`, leaving the blacklist file in place after uninstall.

**Install path:**
- Remove stale `90/99-opentabletdriver.rules` from prior installations before copying the new `71-opentabletdriver.rules` (avoids conflicting rule sets)
- Run `udevadm control --reload-rules && udevadm trigger` to activate new rules immediately
- `modprobe uinput` to load the uinput module OTD requires
- `rmmod wacom hid_uclogic` (best-effort, `|| true`) to unload conflicting drivers — users no longer need to reboot

**Uninstall path:**
- Fix filename: `blacklist-opentabletdriver.rules` → `blacklist-opentabletdriver.conf`
- Run `udevadm control --reload-rules && udevadm trigger` after removing rules

Closes #340

## Test plan
- [ ] Install OTD on a machine with a Wacom or UC-Logic tablet — tablet should work without rebooting
- [ ] Uninstall OTD — verify `blacklist-opentabletdriver.conf` is removed from `/etc/modprobe.d/`
- [ ] Verify `71-opentabletdriver.rules` is removed from `/etc/udev/rules.d/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)