### PR TITLE
fix(just): return to ujust menu after bbrew and cncf submenus

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -61,6 +61,7 @@ bbrew:
     fi
     echo "Note: Some of these take a while to load, we'll keep working on it."
     bbrew -f "/usr/share/ublue-os/homebrew/$(gum choose $(find "/usr/share/ublue-os/homebrew"/*.Brewfile -exec basename '{}' '.Brewfile' ';')).Brewfile"
+    [[ -t 0 ]] && ujust --choose || true
 
 cncf:
     #!/usr/bin/env bash
@@ -72,3 +73,4 @@ cncf:
         fi
     fi
     bbrew -f "/usr/share/ublue-os/homebrew/cncf.Brewfile"
+    [[ -t 0 ]] && ujust --choose || true


### PR DESCRIPTION
## Summary

Closes #126

After `bbrew` or `cncf` exits, calls `ujust --choose` to return the user to the main ujust recipe list instead of dropping them to the terminal.

This addresses the UX issue where exiting bbrew's TUI submenu leaves the user at a shell prompt with no way back to the recipe menu.

## Changes

- `system_files/shared/usr/share/ublue-os/just/apps.just`: add `ujust --choose` after `bbrew` invocation in both `bbrew` and `cncf` recipes

## Test plan

- [ ] Run `ujust --choose` → select `bbrew` → exit bbrew → verify ujust choose menu reappears
- [ ] Run `ujust --choose` → select `cncf` → exit bbrew → verify ujust choose menu reappears