### PR TITLE
feat(profile): add caffeinate alias

### DIFF
--- a/system_files/bluefin/etc/profile.d/caffeinate.sh
+++ b/system_files/bluefin/etc/profile.d/caffeinate.sh
@@ -1,0 +1,10 @@
+# Prevent system sleep while a long-running task completes.
+# Usage: caffeinate              — prevent sleep indefinitely (Ctrl+C to release)
+#        caffeinate sleep 3600   — prevent sleep for 1 hour
+caffeinate() {
+    if [ $# -eq 0 ]; then
+        systemd-inhibit --what=idle --who=caffeinate --why="User requested" --mode=block sleep infinity
+    else
+        systemd-inhibit --what=idle --who=caffeinate --why="User requested" --mode=block "$@"
+    fi
+}


### PR DESCRIPTION
## Summary

Adds a `caffeinate` shell alias that wraps `systemd-inhibit` to temporarily prevent sleep/suspend. This mirrors the familiar macOS command name and makes the sleep-blocking feature discoverable.

Closes #350

## Changes

- `system_files/bluefin/etc/profile.d/caffeinate.sh`: new alias file
- Usage: `caffeinate 300` blocks sleep for 5 minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `caffeinate` command to keep your system awake by preventing idle sleep until interrupted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->