### PR TITLE
ci: add e2e PR gate for Bluefin LTS, Stable, and Dakota

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,12 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "*.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".github/workflows/**"
   merge_group:
     branches:
       - main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,40 @@
+# E2E PR Gate — smoke tests on all three image families
+#
+# Calls the reusable e2e workflow from projectbluefin/testsuite, which boots
+# each OCI image in QEMU/KVM on ubuntu-latest and runs behave smoke tests
+# against a live GNOME session. No self-hosted runners required.
+#
+# All three jobs are required status checks for the merge queue.
+
+name: E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  e2e-bluefin-lts:
+    name: "E2E — Bluefin LTS"
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    with:
+      image: ghcr.io/ublue-os/bluefin:lts
+      suites: smoke
+
+  e2e-bluefin-stable:
+    name: "E2E — Bluefin Stable"
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    with:
+      image: ghcr.io/ublue-os/bluefin:latest
+      suites: smoke
+
+  e2e-dakota:
+    name: "E2E — Dakota"
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    with:
+      image: ghcr.io/projectbluefin/dakota:latest
+      suites: smoke


### PR DESCRIPTION
## Summary

Adds `.github/workflows/e2e.yml` — three parallel smoke test jobs on every PR and merge group event, each calling the reusable e2e workflow from `projectbluefin/testsuite`.

## What it does

| Job | Image tested |
|-----|-------------|
| E2E — Bluefin LTS | `ghcr.io/ublue-os/bluefin:lts` |
| E2E — Bluefin Stable | `ghcr.io/ublue-os/bluefin:latest` |
| E2E — Dakota | `ghcr.io/projectbluefin/dakota:latest` |

Each job boots the OCI image in QEMU/KVM on `ubuntu-latest`, starts a GNOME session, and runs behave smoke tests via qecore-headless. **No self-hosted runners required.**

Dakota is included because `elements/bluefin/common.bst` in dakota uses `projectbluefin/common` as a direct `git_repo` source — changes here affect all three image families.

`paths-ignore` skips tests on docs/CI-only changes (README, LICENSE, .gitattributes, workflows).

## Merge gate

A repo ruleset should be created on `projectbluefin/common` requiring all three status checks:
- `E2E — Bluefin LTS / GNOME 50 — smoke`
- `E2E — Bluefin Stable / GNOME 50 — smoke`
- `E2E — Dakota / GNOME 50 — smoke`

## Dependencies

Depends on [projectbluefin/testsuite#49](https://github.com/projectbluefin/testsuite/pull/49) — fixes cross-repo checkout in the reusable workflow so callers without a `tests/` directory work correctly.