### PR TITLE
feat(just): add check-sb-key recipe for Secure Boot status

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -131,3 +131,35 @@ alias rollback-helper := rebase-helper
 [group('System')]
 rebase-helper:
     @/usr/bin/ublue-rollback-helper
+
+# Check Secure Boot status and key enrollment
+[group('System')]
+check-sb-key:
+    #!/usr/bin/bash
+    echo "== Secure Boot Status =="
+    if [ -d /sys/firmware/efi ]; then
+        if command -v mokutil &> /dev/null; then
+            mokutil --sb-state
+        else
+            echo "mokutil not available — checking EFI vars..."
+            if [ -f /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c ]; then
+                SB=$(od -An -t u1 /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c | awk '{print $NF}')
+                [ "$SB" = "1" ] && echo "SecureBoot is enabled" || echo "SecureBoot is disabled"
+            else
+                echo "Cannot determine Secure Boot status"
+            fi
+        fi
+        echo ""
+        echo "== Machine Owner Key (MOK) Status =="
+        if command -v mokutil &> /dev/null; then
+            mokutil --list-enrolled 2>/dev/null | head -6 || echo "No MOK keys enrolled or mokutil requires sudo"
+        fi
+        echo ""
+        echo "== Kernel Signature =="
+        uname -r
+        if command -v sbverify &> /dev/null; then
+            sbverify --list /boot/vmlinuz-$(uname -r) 2>/dev/null || echo "sbverify not available (install sbsigntools)"
+        fi
+    else
+        echo "Not an EFI system — Secure Boot does not apply."
+    fi


### PR DESCRIPTION
Adds a ujust check-sb-key command that reports Secure Boot status, MOK enrollment, and kernel signature verification.

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to check Secure Boot configuration and status. On EFI systems it reports Secure Boot state, MOK enrollment, and kernel signature information; on non‑EFI systems it reports that Secure Boot does not apply.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/common/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->