### PR TITLE
chore: remove unused dracut config

### DIFF
--- a/system_files/shared/usr/lib/dracut/fido-tpm2-luks.conf
+++ b/system_files/shared/usr/lib/dracut/fido-tpm2-luks.conf
@@ -1,1 +1,0 @@
-add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc "


### PR DESCRIPTION
This is not even in the proper directory to work with dracut, this config file should also not be here, this should not be shared between any image variants and should be on the repo of the image itself.

Not every image uses dracut. We seem to have missed this when introducing this here into this repo.

<!--
## Thank you for contributing

Please [read the README](../README.md) and ensure your change goes to the correct directory.

### Changes related to Bluefin
If your change is gnome or bluefin change, make sure you put the change under the  system_files/bluefin/ folder.

## Global changes
Global changes that are not GNOME-specific should go in the `system_files/shared/` folder. This is also used by [Aurora](https://github.com/ublue-os/aurora), so ensure no GNOME-related changes end up here.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dracut configuration to remove FIDO2, TPM2-TSS, PKCS11, and PCSC module inclusions from the boot initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->