### PR TITLE
fix: fix clean system ujust recipe

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/00-entry.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/00-entry.just
@@ -1,5 +1,5 @@
-set allow-duplicate-recipes := true
-set ignore-comments := true
+set allow-duplicate-recipes
+set ignore-comments
 
 _default:
     #!/usr/bin/bash

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -131,4 +131,3 @@ alias rollback-helper := rebase-helper
 [group('System')]
 rebase-helper:
     @/usr/bin/ublue-rollback-helper
-

--- a/system_files/shared/usr/share/ublue-os/just/default.just
+++ b/system_files/shared/usr/share/ublue-os/just/default.just
@@ -29,10 +29,14 @@ bios-info:
 clean-system:
     #!/usr/bin/bash
     if gum confirm "Prune all Podman images and volumes?"; then
-        echo "Images that would be pruned:"
-        podman image ls --filter dangling=true --format "{{.Repository}}:{{.Tag}}  {{.ID}}" 2>/dev/null | head -20
-        echo "Volumes that would be pruned:"
+        echo "Images that would be pruned (showing up to 20):"
+        # Fixed the format error, changed filter to match 'prune -a' (all unused, not just dangling)
+        podman image ls --filter "dangling=false" --filter "readonly=false" --format "{{.ID}} - {{.Repository}}:{{.Tag}}" 2>/dev/null | head -20
+        podman image ls --filter "dangling=true" --format "{{.ID}} - <dangling>" 2>/dev/null | head -20
+
+        echo -e "\nVolumes that would be pruned:"
         podman volume ls --filter dangling=true --quiet 2>/dev/null | head -20
+
         if gum confirm "Proceed with pruning Podman images and volumes?"; then
             podman image prune -af
             podman volume prune -f
@@ -41,10 +45,13 @@ clean-system:
 
     if command -v docker >/dev/null 2>&1; then
       if gum confirm "Prune all Docker images and volumes?"; then
-        echo "Images that would be pruned:"
-        docker image ls --filter dangling=true --format "{{.Repository}}:{{.Tag}}  {{.ID}}" 2>/dev/null | head -20
-        echo "Volumes that would be pruned:"
+        echo "Images that would be pruned (showing up to 20):"
+        # Fixed Docker template to safely display dangling and non-dangling alike
+        docker image ls --format "{{.ID}}   {{.Repository}}:{{.Tag}}" 2>/dev/null | head -20
+
+        echo -e "\nVolumes that would be pruned:"
         docker volume ls --filter dangling=true --quiet 2>/dev/null | head -20
+
         if gum confirm "Proceed with pruning Docker images and volumes?"; then
             docker image prune -af
             docker volume prune -f

--- a/system_files/shared/usr/share/ublue-os/just/default.just
+++ b/system_files/shared/usr/share/ublue-os/just/default.just
@@ -47,7 +47,7 @@ clean-system:
       if gum confirm "Prune all Docker images and volumes?"; then
         echo "Images that would be pruned (showing up to 20):"
         # Fixed Docker template to safely display dangling and non-dangling alike
-        docker image ls --format "{{.ID}}   {{.Repository}}:{{.Tag}}" 2>/dev/null | head -20
+        docker image ls --format "{{.ID}} - {{.Repository}}:{{.Tag}}" 2>/dev/null | head -20
 
         echo -e "\nVolumes that would be pruned:"
         docker volume ls --filter dangling=true --quiet 2>/dev/null | head -20


### PR DESCRIPTION
PR https://github.com/projectbluefin/common/pull/363 broke the just recipes because a format error on in clean-system recipe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a rebase-helper command to streamline system rollback and management operations.

* **Improvements**
  * Enhanced the clean-system command preview to display clearer image information in a more organized format. The preview now better highlights volumes that would be affected during cleanup, with improved separation between different sections and information types for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->