### PR TITLE
fix(just): make validation recipe properly fail on errors and fix syntax errors

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,21 +7,25 @@ build:
 
 check:
     #!/usr/bin/bash
-    find . -type f -name "*.just" | while read -r file; do
+    failed=0
+    while read -r file; do
       echo "Checking syntax: $file"
-      {{ just }} --unstable --fmt --check -f $file
-    done
+      {{ just }} --unstable --fmt --check -f "$file" || failed=1
+    done < <(find . -type f -name "*.just")
     echo "Checking syntax: Justfile"
-        {{ just }} --unstable --fmt --check -f Justfile
+    {{ just }} --unstable --fmt --check -f Justfile || failed=1
+    exit "$failed"
 
 fix:
     #!/usr/bin/bash
-    find . -type f -name "*.just" | while read -r file; do
+    failed=0
+    while read -r file; do
       echo "Fixing syntax: $file"
-      {{ just }} --unstable --fmt -f $file
-    done
+      {{ just }} --unstable --fmt -f "$file" || failed=1
+    done < <(find . -type f -name "*.just")
     echo "Fixing syntax: Justfile"
-    {{ just }} --unstable --fmt -f Justfile || { exit 1; }
+    {{ just }} --unstable --fmt -f Justfile || failed=1
+    exit "$failed"
 
 # Inspect the directory structure of an OCI image
 tree IMAGE="localhost/bluefin-common:latest":

--- a/system_files/bluefin/usr/share/ublue-os/just/00-entry.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/00-entry.just
@@ -1,5 +1,5 @@
-set allow-duplicate-recipes := true
-set ignore-comments := true
+set allow-duplicate-recipes
+set ignore-comments
 
 _default:
     #!/usr/bin/bash

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -131,4 +131,3 @@ alias rollback-helper := rebase-helper
 [group('System')]
 rebase-helper:
     @/usr/bin/ublue-rollback-helper
-

--- a/system_files/shared/usr/share/ublue-os/just/default.just
+++ b/system_files/shared/usr/share/ublue-os/just/default.just
@@ -30,7 +30,7 @@ clean-system:
     #!/usr/bin/bash
     if gum confirm "Prune all Podman images and volumes?"; then
         echo "Images that would be pruned:"
-        podman image ls --filter dangling=true --format "{{.Repository}}:{{.Tag}}  {{.ID}}" 2>/dev/null | head -20
+        podman image ls --filter dangling=true --format "{{{{.Repository}}}}:{{{{.Tag}}}}  {{{{.ID}}}}" 2>/dev/null | head -20
         echo "Volumes that would be pruned:"
         podman volume ls --filter dangling=true --quiet 2>/dev/null | head -20
         if gum confirm "Proceed with pruning Podman images and volumes?"; then
@@ -42,7 +42,7 @@ clean-system:
     if command -v docker >/dev/null 2>&1; then
       if gum confirm "Prune all Docker images and volumes?"; then
         echo "Images that would be pruned:"
-        docker image ls --filter dangling=true --format "{{.Repository}}:{{.Tag}}  {{.ID}}" 2>/dev/null | head -20
+        docker image ls --filter dangling=true --format "{{{{.Repository}}}}:{{{{.Tag}}}}  {{{{.ID}}}}" 2>/dev/null | head -20
         echo "Volumes that would be pruned:"
         docker volume ls --filter dangling=true --quiet 2>/dev/null | head -20
         if gum confirm "Proceed with pruning Docker images and volumes?"; then


### PR DESCRIPTION
This PR fixes the Justfile validation step where errors inside the `while read` loop were ignored and did not result in a non-zero exit status for the job.

### Changes:
1. Updated the `check` and `fix` recipes in `Justfile` to accumulate exit statuses of individual checks and exit with a non-zero code if any file check fails.
2. Fixed syntax/formatting errors in `.just` files, including:
   - Escaped double curly braces `{{` and `}}` in `system_files/shared/usr/share/ublue-os/just/default.just` to avoid incorrect just interpolation (using quadruple braces `{{{{` and `}}}}`).
   - Standardized setting syntax in `00-entry.just`.
   - Cleaned up trailing newline formats in other just files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rebase-helper` task for system operations.

* **Bug Fixes**
  * Improved failure tracking in check and fix tasks across multiple files.
  * Fixed container image list formatting to display correctly.

* **Chores**
  * Updated configuration syntax in entry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->