### PR TITLE
Fix LUKS UUID parsing on Dakota

### DIFF
--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -14,7 +14,7 @@ case "${EXIT_CODE}" in
     exit 0
 esac
 
-RD_LUKS_UUID="$(xargs -n1 -a /proc/cmdline | grep -F -e "rd.luks.uuid" | cut -d = -f 2 | sed "s/^luks-//" )"
+RD_LUKS_UUID="$(xargs -n1 -a /proc/cmdline | grep -E -e "rd.luks.(uuid|name)" | head -n 1 | cut -d= -f 2 | sed "s/^luks-//" )"
 CRYPT_DISK="$(realpath "/dev/disk/by-uuid/${RD_LUKS_UUID}")"
 
 if ! find /dev -iname "${RD_LUKS_UUID:-INVALIDINVALID}" | grep -F -e "${RD_LUKS_UUID}" &>/dev/null; then


### PR DESCRIPTION
<!--
## Thank you for contributing

Please [read the README](../README.md) and ensure your change goes to the correct directory.

### Changes related to Bluefin
If your change is gnome or bluefin change, make sure you put the change under the  system_files/bluefin/ folder.

## Global changes
Global changes that are not GNOME-specific should go in the `system_files/shared/` folder. This is also used by [Aurora](https://github.com/ublue-os/aurora), so ensure no GNOME-related changes end up here.

-->

I used Gemini to help debug this issue:

### Root Cause

  The error occurs because the system script  /usr/bin/luks-tpm2-autounlock  (invoked by  ujust toggle-tpm2 ) has a parsing bug.

  It attempts to find the boot LUKS device by searching  /proc/cmdline  strictly for the string  rd.luks.uuid :

    RD_LUKS_UUID="$(xargs -n1 -a /proc/cmdline | grep -F -e "rd.luks.uuid" | cut -d= -f 2 | sed "s/^luks-//" )"

  However, on your machine (and many Fedora Silverblue / Bluefin installations), the encrypted volume is instead specified using the  rd.luks.name  format:

    rd.luks.name=16eb9a62-8dbb-4740-bb40-2185c759d621=root

  Because the script only looks for  rd.luks.uuid , it resolves  RD_LUKS_UUID  as empty, fails the validation check, and exits with:

  │ Could not find LUKS device used to boot system on system mount table. Is your drive encrypted?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Improved LUKS TPM2 auto-unlock functionality to recognize and properly handle multiple kernel parameter formats for enhanced system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->