### PR TITLE
fix(scripts): Check for rpm-ostreed.conf existence before grep

### DIFF
--- a/system_files/bluefin/usr/bin/ublue-rollback-helper
+++ b/system_files/bluefin/usr/bin/ublue-rollback-helper
@@ -70,7 +70,7 @@ fi
 
 gum confirm "Confirm rebase to ${rebase_target}?" || exit 1
 
-if grep -q "^LockLayering=true" /etc/rpm-ostreed.conf; then
+if [ -f /etc/rpm-ostreed.conf ] && grep -q "^LockLayering=true" /etc/rpm-ostreed.conf; then
   pkexec bootc switch --enforce-container-sigpolicy "${rebase_target}"
 else
   rpm-ostree rebase ostree-image-signed:docker://"${rebase_target}"

--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -14,7 +14,7 @@ update:
         echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
         exit 1
     fi
-    if grep -q -E -e "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*false([[:space:]]*(#.*)?)?$" /etc/rpm-ostreed.conf ; then
+    if [ -f /etc/rpm-ostreed.conf ] && grep -q -E -e "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*false([[:space:]]*(#.*)?)?$" /etc/rpm-ostreed.conf ; then
         rpm-ostree upgrade
     else
         sudo bootc upgrade


### PR DESCRIPTION
<!--
## Thank you for contributing

Please [read the README](../README.md) and ensure your change goes to the correct directory.

### Changes related to Bluefin
If your change is gnome or bluefin change, make sure you put the change under the  system_files/bluefin/ folder.

## Global changes
Global changes that are not GNOME-specific should go in the `system_files/shared/` folder. This is also used by [Aurora](https://github.com/ublue-os/aurora), so ensure no GNOME-related changes end up here.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stability of system update and rollback processes by adding file existence validation checks. The system now gracefully handles scenarios where expected configuration files may be missing, preventing errors during system maintenance operations and ensuring more reliable updates and rollbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->