### PR TITLE
fix(docs): fix broken skill links, AGENTS.md gaps, CONTRIBUTING.md self-ref

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,14 +59,17 @@ When in doubt, post nothing.
 Containerfile              # OCI image build
 Justfile                   # Build automation
 system_files/
-  shared/                  # Config applied to ALL Bluefin variants (and Aurora)
+  shared/                  # Shared system config from the aurorafin-shared git submodule
   bluefin/                 # Config applied to Bluefin-specific variants only
 .github/workflows/
   build.yml                # Build + push on merge to main
   e2e.yml                  # Post-merge e2e against bluefin, bluefin-lts, dakota
+  release.yml              # Monthly versioned OCI release (runs on 1st of month)
   validate-just.yml        # PR gate: just check
   validate-brewfiles.yaml  # PR gate: Brewfile validation
 ```
+
+`system_files/shared/` is provided by the `aurorafin-shared` git submodule (see `.gitmodules`). Agents who need to change shared system config should work in [`ublue-os/aurorafin-shared`](https://github.com/ublue-os/aurorafin-shared).
 
 ## CODEOWNERS
 
@@ -84,6 +87,8 @@ pre-commit run --all-files   # hygiene checks (json/yaml/toml + actionlint)
 ```
 
 ## Submodule
+
+`aurorafin-shared` → `ublue-os/aurorafin-shared` (shared `system_files/shared/` content). Make shared system config changes there.
 
 `bluefin-branding` → projectbluefin/branding (wallpapers, logos). `just build` initializes it automatically.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping out!
 
 Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
 
-This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+This repository is the shared OCI layer and coordination hub for the Bluefin factory: shared `system_files/` overlays, governance and process docs, and the canonical skill docs live here. If you need to change an image-specific build or runtime behavior, work in the relevant image repo instead (`projectbluefin/bluefin`, `projectbluefin/bluefin-lts`, `projectbluefin/dakota`, or `projectbluefin/knuckle`). See the [architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture) for the repo boundaries.
 
 ## CI
 

--- a/docs/skills/INDEX.md
+++ b/docs/skills/INDEX.md
@@ -5,6 +5,6 @@ Agent skill docs for the `projectbluefin/common` repo.
 | File | What it covers |
 |---|---|
 | [governance.md](governance.md) | Triagers role, CODEOWNERS sentinel pattern, sync workflow, branch protection matrix |
-| [hive-review.md](hive-review.md) | `~/src/hive-status` — session start, P0/P1 triage, hive label taxonomy |
-| [queue-dashboard.md](queue-dashboard.md) | queue.projectbluefin.io — PR tiers, merge ruleset (2 approvals), refresh cadence |
-| [e2e-ci.md](e2e-ci.md) | Post-merge E2E CI architecture — common suite, brew tools masked in CI, MOTD fix, known quarantined scenarios |
+| [hive-review.md](hive-review.md) _(pending PR #426)_ | `~/src/hive-status` — session start, P0/P1 triage, hive label taxonomy |
+| [queue-dashboard.md](queue-dashboard.md) _(pending PR #426)_ | queue.projectbluefin.io — PR tiers, merge ruleset (2 approvals), refresh cadence |
+| [e2e-ci.md](e2e-ci.md) _(pending PR #426)_ | Post-merge E2E CI architecture — common suite, brew tools masked in CI, MOTD fix, known quarantined scenarios |


### PR DESCRIPTION
Fixes found during factory gap analysis (2026-06-03):

- **docs/skills/INDEX.md**: Mark 3 broken links (hive-review, queue-dashboard, e2e-ci) as pending PR #426
- **AGENTS.md**: Add missing `release.yml` to workflow inventory  
- **AGENTS.md**: Clarify that `system_files/shared/` comes from `ublue-os/aurorafin-shared` submodule (was misleading agents into looking for a local path that doesn't exist)
- **CONTRIBUTING.md**: Fix self-referential redirect that told users to go to `@projectbluefin/common` when they were already there

These are all small documentation correctness fixes — no functional changes.