### PR TITLE
docs(skills): add frontmatter and Trail of Bits skill-improver CI

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -62,7 +62,7 @@ jobs:
           for f in "$SKILLS_DIR"/*.md; do
             name=$(basename "$f")
             [[ "$name" == "INDEX.md" ]] && continue
-            if ! grep -q "$name" "$INDEX"; then
+            if ! grep -qF "$name" "$INDEX"; then
               echo "::error file=$INDEX::$name is not listed in INDEX.md"
               failed=1
             fi

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,0 +1,80 @@
+name: Docs Quality
+
+on:
+  pull_request:
+    paths:
+      - "docs/skills/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/skills/**"
+  merge_group:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate skill docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          SKILLS_DIR="docs/skills"
+          INDEX="$SKILLS_DIR/INDEX.md"
+          failed=0
+
+          echo "=== Frontmatter check ==="
+          for f in "$SKILLS_DIR"/*.md; do
+            name=$(basename "$f")
+            [[ "$name" == "INDEX.md" ]] && continue
+            # Must start with --- and have name: and description: fields
+            if ! head -1 "$f" | grep -q "^---$"; then
+              echo "::error file=$f::$name is missing YAML frontmatter (must start with ---)"
+              failed=1
+              continue
+            fi
+            if ! awk '/^---$/{c++;if(c==2)exit} c==1' "$f" | grep -q "^name:"; then
+              echo "::error file=$f::$name frontmatter is missing required 'name' field"
+              failed=1
+            fi
+            if ! awk '/^---$/{c++;if(c==2)exit} c==1' "$f" | grep -q "^description:"; then
+              echo "::error file=$f::$name frontmatter is missing required 'description' field"
+              failed=1
+            fi
+          done
+
+          echo "=== Line count check ==="
+          for f in "$SKILLS_DIR"/*.md; do
+            name=$(basename "$f")
+            lines=$(wc -l < "$f")
+            if [ "$lines" -gt 500 ]; then
+              echo "::error file=$f::$name has $lines lines (hard limit: 500 — extract to a reference file)"
+              failed=1
+            elif [ "$lines" -gt 350 ]; then
+              echo "::warning file=$f::$name has $lines lines (warning threshold: 350)"
+            fi
+          done
+
+          echo "=== INDEX.md coverage check ==="
+          for f in "$SKILLS_DIR"/*.md; do
+            name=$(basename "$f")
+            [[ "$name" == "INDEX.md" ]] && continue
+            if ! grep -q "$name" "$INDEX"; then
+              echo "::error file=$INDEX::$name is not listed in INDEX.md"
+              failed=1
+            fi
+          done
+
+          echo "=== INDEX.md soundness check ==="
+          while IFS= read -r ref; do
+            target="$SKILLS_DIR/$ref"
+            if [ ! -f "$target" ]; then
+              echo "::error file=$INDEX::INDEX.md references $ref but file does not exist"
+              failed=1
+            fi
+          done < <(grep -oP '(?<=\()[^)]+\.md(?=\))' "$INDEX" || true)
+
+          exit "$failed"

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,0 +1,27 @@
+# Common Skill Router
+
+Agent entry point for `projectbluefin/common`. Load only the skill that matches your task.
+
+## Task → Skill
+
+| I need to... | Load |
+|---|---|
+| Understand CODEOWNERS, triagers, or branch protection | `docs/skills/governance.md` |
+| Run hive priority review at session start | `docs/skills/hive-review.md` |
+| Check the PR queue or merge ruleset | `docs/skills/queue-dashboard.md` |
+| Debug post-merge E2E CI, MOTD, or brew-setup masking | `docs/skills/e2e-ci.md` |
+
+## Improving skill docs
+
+All files in `docs/skills/` are Claude Code skills maintained with the Trail of Bits skill-improver:
+
+```bash
+npx skills add https://github.com/trailofbits/skills --skill skill-improver
+# Then in your editor: /skill-improver docs/skills/<file>
+```
+
+## Scope rules
+
+- **Doc tasks**: modify only `docs/` and `AGENTS.md`. Do not create `.github/` workflow files unless the task is explicitly CI work.
+- **CI tasks**: touch only `.github/` and update `docs/skills/` if learnings arise.
+- **Changes here propagate to all downstream Bluefin variants.** Keep changes surgical.

--- a/docs/skills/INDEX.md
+++ b/docs/skills/INDEX.md
@@ -8,3 +8,14 @@ Agent skill docs for the `projectbluefin/common` repo.
 | [hive-review.md](hive-review.md) | `~/src/hive-status` — session start, P0/P1 triage, hive label taxonomy |
 | [queue-dashboard.md](queue-dashboard.md) | queue.projectbluefin.io — PR tiers, merge ruleset (2 approvals), refresh cadence |
 | [e2e-ci.md](e2e-ci.md) | Post-merge E2E CI architecture — common suite, brew tools masked in CI, MOTD fix, known quarantined scenarios |
+
+## Quality standard
+
+All files in this directory are Claude Code skills. Use the Trail of Bits skill-improver to maintain them:
+
+```bash
+npx skills add https://github.com/trailofbits/skills --skill skill-improver
+# Then in your editor: /skill-improver docs/skills/<file>
+```
+
+Each file must have YAML frontmatter with `name` and `description`. CI enforces this.

--- a/docs/skills/e2e-ci.md
+++ b/docs/skills/e2e-ci.md
@@ -1,0 +1,99 @@
+---
+name: e2e-ci
+description: Post-merge E2E CI architecture for projectbluefin/common — common suite, brew masking in CI, quarantined scenarios.
+---
+
+# E2E CI Architecture — projectbluefin/common
+
+Reference for agents working on test failures in the post-merge E2E suite.
+
+## How the common suite runs
+
+The common post-merge E2E (`common/.github/workflows/e2e.yml`) calls the reusable
+workflow at `projectbluefin/testsuite/.github/workflows/e2e.yml@main` with `suites: common`.
+
+**The common suite is special** — it runs behave directly on the GHA runner (not inside
+a pre-built container). The runner SSHes to the VM at `127.0.0.1:2222` as `bluefin-test`.
+
+```yaml
+# testsuite e2e.yml (simplified)
+if: env.SUITE == 'common'
+  run: |
+    python3 -m pip install behave
+    behave tests/common/features/
+else
+  # Load pre-built runner container, then run behave inside it
+```
+
+The pre-built runner container does **not** affect the common suite because of this conditional.
+
+## VM kernel args
+
+```
+systemd.mask=brew-setup.service
+```
+
+`brew-setup.service` is masked for every test VM. This means:
+
+- Homebrew itself is present at `/home/linuxbrew/.linuxbrew/bin/brew`
+- **Brew packages are NOT installed** — `eza`, `fd`, `rg`, `bat`, `fzf`, `starship`, etc.
+  are all from `cli.Brewfile` and require brew-setup to run first
+- Any test that checks for these tools will fail in CI
+
+## Known CI failures and their status
+
+### brew CLI tools (eza, fd, ripgrep, bat, fzf, starship) — QUARANTINED
+
+**Root cause:** These are `cli.Brewfile` packages. `brew-setup.service` is masked.
+The `ublue-os/brew` image only ships a bare Homebrew tarball at `/usr/share/homebrew.tar.zst`.
+
+**Status:** Quarantined in `tests/common/features/common_shell.feature` via `@quarantine`.
+Tracking issue: projectbluefin/testsuite#210
+
+**Options to unblock:**
+1. Un-mask `brew-setup.service` in CI (adds ~60s)
+2. Install tools as RPMs in the Containerfile
+3. Add a CI step to `brew bundle install` before the suite runs
+
+### zsh / fish — QUARANTINED
+
+**Root cause:** zsh and fish ARE installed as RPMs (`/usr/bin/zsh`, `/usr/bin/fish`).
+However, under the `bash -lc '...brew_shellenv...; zsh --version'` SSH command that
+`environment.py` uses, they return `command not found`. PATH does not include
+`/usr/bin` in this non-interactive login context for the fresh `bluefin-test` user.
+
+**Status:** Quarantined. Tracking issue: projectbluefin/testsuite#210
+
+### Dakota MOTD — FIXED (testsuite PR #208)
+
+**Root cause:** `run_ssh()` in `ssh_steps.py` wraps commands in `bash -lc` (login shell)
+when `ssh_command_prefix` is set. This triggers `/etc/profile.d/ublue-motd.sh`, which
+calls `ublue-motd` and prints the MOTD to stdout. The `vm_reachable_over_ssh` step
+checked `stdout == "ok"` (exact match) but got MOTD prepended.
+
+Only Dakota prints a MOTD; Bluefin stable/LTS pass unaffected.
+
+**Fix (testsuite PR #208):**
+- Creates `~/.config/no-show-user-motd` for the CI user in VM setup
+- Changes assertion to `stdout.strip().split('\n')[-1] == "ok"`
+
+## SSH command execution model
+
+```python
+# testsuite/tests/shared/ssh_steps.py
+# When context.ssh_command_prefix is set (always true for common suite):
+cmd_wrapped = f"bash -lc {shlex.quote(f'{prefix}; {cmd}')}"
+```
+
+`environment.py` sets `ssh_command_prefix` to include `eval $(brew shellenv)` so brew
+tools are on PATH inside the VM. Side effect: login shell triggers profile.d scripts.
+
+## Images tested
+
+| Job | Image |
+|---|---|
+| E2E — Bluefin LTS | `ghcr.io/ublue-os/bluefin:lts` |
+| E2E — Bluefin Stable | `ghcr.io/ublue-os/bluefin:latest` |
+| E2E — Dakota | `ghcr.io/projectbluefin/dakota:latest` |
+
+All three run `suites: common` only. Post-merge only — not triggered on PRs.

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -1,3 +1,8 @@
+---
+name: governance
+description: "Triagers role, CODEOWNERS sentinel pattern, cross-repo sync workflow, and branch protection matrix for projectbluefin repos."
+---
+
 # Contributor Governance — Triagers & CODEOWNERS
 
 ## Roles

--- a/docs/skills/hive-review.md
+++ b/docs/skills/hive-review.md
@@ -1,0 +1,103 @@
+---
+name: hive-review
+description: Hive priority review — run ~/src/hive-status at the start of every projectbluefin/* session to get P0/P1 blockers.
+---
+
+# Hive Priority Review — Project Bluefin
+
+> **Load this skill at the start of every session in any `projectbluefin/*` repo.**
+> Step 1 in every agent session is to run the hive status check. Don't skip it.
+
+## One command — always start here
+
+```bash
+~/src/hive-status
+```
+
+That's it. This script is deterministic, requires no auth, and gives you everything
+you need to triage the current hive cycle in under 5 seconds.
+
+## What it shows
+
+```
+🐝 Hive: hive-optimistic-bluefin  [2026-06-02 04:45Z]  ACMM L3
+
+🔴 P0 BLOCKERS          — fix before anything else
+🟡 P1 THIS CYCLE        — must land this cycle
+📊 SCANNER SUMMARY      — what the scanner agent last reported
+🤖 AGENTS               — which agents are running/paused and how long
+📝 ADVISORY ITEMS       — ranked findings from all agents (CRITICAL → HIGH → ...)
+```
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| _(none)_ | One-shot snapshot |
+| `--watch` | Auto-refresh every 300 s (clears screen) |
+| `--json` | Raw snapshot JSON — useful for scripting |
+
+## How the script works
+
+- Fetches `https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/index.html`
+- Parses the embedded `render({...})` JSON payload (no auth required)
+- Extracts: P0/P1 blockers from ci-maintainer agent text, advisory items from `advisoryDigest.by_agent`, agent states/cadences
+- Advisory items are ranked: `critical → high → medium → low → info`, up to 2 per agent, 8 total
+
+## Where the script lives
+
+```
+~/src/hive-status   (executable Python 3, no dependencies beyond stdlib)
+```
+
+If it's missing, check `castrojo/copilot-config` — it's part of the workspace setup.
+
+## What to do with the output
+
+### P0 blockers
+These are release blockers the hive formation is actively tracking. If any exist,
+address them before any other work in this session. File a PR or claim the issue.
+
+### P1 items
+Must land this cycle. Triage whether any are claimable now.
+
+### Advisory items
+Cross-repo findings from hive agents. Each is tagged `[CRITICAL]`/`[HIGH]`/etc. plus the
+agent name and a one-line description. Dig into any CRITICAL items that fall in your repo.
+
+Common follow-up commands after reading advisories:
+
+```bash
+# Find the specific issue an advisory references
+gh issue view <number> --repo projectbluefin/<repo>
+
+# See all hive-tracked blockers org-wide
+gh search issues --label "hive/p0" --owner projectbluefin --state open
+
+# See all hive P1 this-cycle items
+gh search issues --label "hive/p1" --owner projectbluefin --state open
+
+# See agent-ready queue (claimable work)
+gh search issues --label "queue/agent-ready" --owner projectbluefin --state open
+```
+
+## Hive label taxonomy (quick ref)
+
+| Label | Meaning |
+|---|---|
+| `hive/p0` | Release blocker — hive is actively tracking |
+| `hive/p1` | This-cycle item — hive is actively tracking |
+| `queue/agent-ready` | Ready for agent pickup |
+| `queue/claimed` | Agent has claimed this issue |
+| `agent/blocked` | Needs human input |
+
+`hive/` labels are **dynamic** (reset each cycle by hive agents). `priority/p0` etc. are
+the repo's own static labels. An issue can have both.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `fetch failed: HTTP 404` | kubestellar/docs hasn't published a snapshot yet | Try again in a few minutes |
+| `parse failed: no render(...)` | HTML structure changed upstream | Check the raw URL manually; update the parser if needed |
+| Script missing | Workspace not fully set up | Run `just setup` in `~/src` or copy from `castrojo/copilot-config` |

--- a/docs/skills/queue-dashboard.md
+++ b/docs/skills/queue-dashboard.md
@@ -1,0 +1,59 @@
+---
+name: queue-dashboard
+description: queue.projectbluefin.io reference — PR tiers, merge ruleset (2 approvals), refresh cadence.
+---
+
+# Queue Dashboard — queue.projectbluefin.io
+
+Reference for agents reviewing PRs and checking merge readiness.
+
+## What it shows
+
+https://queue.projectbluefin.io/ is a static site regenerated hourly by GitHub Actions
+from `projectbluefin/queue`. It shows:
+
+- **P0 / P1 issues** — hive-tracked blockers and this-cycle items across the org
+- **PR tiers** — open PRs bucketed by review state
+- **Victories** — merged PRs and closed issues (7-day and 30-day windows)
+
+## PR tiers (how your PR appears)
+
+The generator queries GitHub search with these filters:
+
+```
+is:pr is:open -is:draft status:success review:approved   → ✅ Approved (ready to merge)
+is:pr is:open -is:draft status:success review:required   → ⚠️  Needs reviews
+is:pr is:open -is:draft status:success review:none       → 🔵  No reviews yet
+```
+
+**Key:** `review:approved` only turns green when ALL required approvals are satisfied.
+`review:required` means at least one review is still needed.
+
+## Merge ruleset for projectbluefin/common
+
+Ruleset: `main-review-required-with-renovate-bypass`
+
+- **Required approvals: 2** — one review leaves a PR in `review:required`, not `review:approved`
+- **Required status check: `Build and push image`** only
+- Smoke tests (`E2E — */GNOME 50 — smoke`) are **not** required checks — stale failures
+  from prior runs don't block merge
+- Renovate PRs bypass the review requirement (auto-merge eligible)
+
+## When a PR has one review
+
+`review:required` → appears in the yellow "Needs reviews" tier on the dashboard.
+A second human approval moves it to the green "Approved" tier.
+
+## Refresh cadence
+
+- Regenerated hourly via GitHub Actions in `projectbluefin/queue`
+- `hive-progress-sync.yml` in this repo posts Common-specific stats to the org project board
+  at :20 past the hour (staggered from bluefin :15, dakota :00, knuckle :30, lts :45)
+
+## Repos tracked
+
+`bluefin`, `bluefin-lts`, `common`, `dakota`, `actions`, `renovate-config`, `bonedigger`, `knuckle`
+
+## Source
+
+Generator: https://github.com/projectbluefin/queue/blob/main/generate.js


### PR DESCRIPTION
## What

Establishes the community skill quality standard for `projectbluefin/common` docs.

### Changes

- **`docs/SKILL.md`** — agent router: tells any AI agent which skill file to load for each domain
- **`docs/skills/INDEX.md`** — adds quality standard section with install instructions for the [Trail of Bits skill-improver](https://www.skills.sh/trailofbits/skills/skill-improver)
- **`docs/skills/governance.md`** — first file with YAML frontmatter (`name`/`description`), making it compatible with the ToB tool
- **`.github/workflows/docs-quality.yml`** — CI check on every PR touching `docs/skills/` that enforces:
  - YAML frontmatter present in all skill files
  - Line count limits (warn >350, fail >500)
  - `INDEX.md` routing table covers all skill files

### How to use the skill-improver

```bash
npx skills add https://github.com/trailofbits/skills --skill skill-improver
# Then in any session: point it at a skill file to get a structured quality review
```

## Migration

Other factory repos adopt this pattern incrementally. Remaining skill files in this repo will get frontmatter in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established quality standards for skill documentation, requiring consistent metadata and enforcing line count limits with automated validation.
  * Added a new routing guide to help users find relevant documentation based on their task type.
  * Implemented automated quality checks for skill documentation to maintain consistency, completeness, and adherence to established standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->