### PR TITLE
chore(ci): add renovate.json5 configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,22 +1,46 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Enable GitHub's native automerge; merging is handled by GitHub and remains subject to branch protection/bypass settings
+  "platformAutomerge": true,
+
+  // Only target main branch
+  "baseBranchPatterns": ["main"],
+
   "extends": [
-    "github>ublue-os/renovate-config:org-inherited-config"
+    "config:best-practices",
   ],
 
   "git-submodules": {
     "enabled": true
   },
 
+  // Do not rebase when the default branch is updated
+  "rebaseWhen": "never",
   "customManagers": [
     {
-      "customType": "regex",
-      "managerFilePatterns": ["^Containerfile$"],
-      "matchStrings": [
-        "https://github\\.com/ublue-os/artwork/releases/download/bluefin-v(?<currentValue>[0-9\\-]+)/bluefin-wallpapers\\.tar\\.zstd"
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^Justfile$/',
       ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "ublue-os/artwork"
+      matchStrings: [
+        '(?<justName>.+?)\\s:=\\s"(?<packageName>\\S+):(?<currentValue>\\S+)@(?<currentDigest>sha256:[a-f0-9]+?)"',
+      ],
+      datasourceTemplate: 'docker',
+    },
+    ],
+
+  "packageRules": [
+    {
+      // Auto-merge all digest/pin updates across all managers (dockerfile, github-actions, regex/Justfile)
+      "automerge": true,
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"]
+    },
+    {
+      // Auto-merge minor/patch version bumps for GitHub Actions (e.g. cosign-installer v3.8 → v3.9)
+      "automerge": true,
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }

--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -17,7 +17,6 @@ clock-show-weekday=true
 font-antialiasing="rgba"
 font-name="Adwaita Sans 11"
 document-font-name="Adwaita Sans 12"
-monospace-font-name="JetBrains Mono 11"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]


### PR DESCRIPTION
Add renovate.json5 configuration file for automated dependency updates.

This configures Renovate to manage dependencies with automerge for digest and minor/patch updates.

The baseBranchPatterns is set to ['main'] for the common repository.

Related to issue #410.