### PR TITLE
feat(renovate): add OCI digest tracking in Containerfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,26 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "ublue-os/artwork"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["^Containerfile$"],
+      "matchStrings": [
+        "alpine:latest@sha256:(?<currentValue>[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "alpine",
+      "autoReplaceStringTemplate": "alpine:latest@sha256:{{{newDigest}}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["^Containerfile$"],
+      "matchStrings": [
+        "ghcr\\.io/ublue-os/bluefin-wallpapers-gnome:latest@sha256:(?<currentValue>[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/ublue-os/bluefin-wallpapers-gnome",
+      "autoReplaceStringTemplate": "ghcr.io/ublue-os/bluefin-wallpapers-gnome:latest@sha256:{{{newDigest}}}"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes issue #433. Adds Renovate custom managers to track and auto-update OCI digests in the Containerfile:
- `alpine:latest@sha256:...` digests
- `ghcr.io/ublue-os/bluefin-wallpapers-gnome:latest@sha256:...` digests

## What changed
- Added two new custom regex managers to `.github/renovate.json5`
- Each manager:
  - Targets the Containerfile
  - Matches the image digest pattern
  - Uses docker datasource for updates
  - Auto-replaces the digest value when updates are found

## Benefits
- Keeps OCI base images up-to-date with latest digests
- Reduces manual maintenance of pinned image digests
- Follows immutable image versioning best practices

## Test plan
- Verified regex patterns match the existing digests in Containerfile
- Confirmed Renovate schema remains valid
- Configuration follows Renovate custom manager patterns