### PR TITLE
fix(security): add hash pinning to udev and u2f config downloads

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,11 +14,15 @@ RUN install -d /out/shared/usr/share/bash-completion/completions /out/shared/usr
   just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/zsh/site-functions/_ujust && \
   just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/fish/vendor_completions.d/ujust.fish
 
-RUN curl -fsSLo - https://codeberg.org/fabiscafe/game-devices-udev/archive/1.0.tar.gz | tar xzvf - -C tmp/ && \
+RUN curl -fsSLo /tmp/game-devices-udev-1.0.tar.gz https://codeberg.org/fabiscafe/game-devices-udev/archive/1.0.tar.gz && \
+    echo "642315c110f427d0765abe66369f3080604c3fb7243c07d1aa77303b31f6dc6d  /tmp/game-devices-udev-1.0.tar.gz" | sha256sum -c - && \
+    tar xzvf /tmp/game-devices-udev-1.0.tar.gz -C tmp/ && \
     for f in tmp/game-devices-udev/src/*.rules; do \
       install -Dpm0644 "$f" "out/shared/usr/lib/udev/rules.d/71-${f##*/}"; \
     done && \
-  curl -fsSLo /out/shared/usr/lib/udev/rules.d/70-u2f.rules https://raw.githubusercontent.com/Yubico/libfido2/refs/heads/main/udev/70-u2f.rules
+  curl -fsSLo /tmp/70-u2f.rules https://raw.githubusercontent.com/Yubico/libfido2/refs/heads/main/udev/70-u2f.rules && \
+    echo "eb5ab4db095e5bbc841b023ad3281a22f6d86fefccfaae06fc3f0e1db6cf8152  /tmp/70-u2f.rules" | sha256sum -c - && \
+    install -Dpm0644 /tmp/70-u2f.rules /out/shared/usr/lib/udev/rules.d/70-u2f.rules
 
 FROM scratch AS ctx
 COPY /aurorafin-shared/system_files/shared /system_files/shared/


### PR DESCRIPTION
## Summary
Adds SHA256 hash verification to external artifact downloads in the build process:
- game-devices-udev 1.0 archive from Codeberg
- libfido2 u2f udev rules from GitHub

Downloads are now verified against known good hashes before use, mitigating supply chain attacks from compromised sources.

## Changes
- Downloads tar.gz and rules files to temporary locations
- Verifies each file's SHA256 hash matches expected values
- Only proceeds with installation after successful verification
- Uses standard sha256sum -c for hash validation

## Hashes verified
- game-devices-udev-1.0.tar.gz: 642315c110f427d0765abe66369f3080604c3fb7243c07d1aa77303b31f6dc6d
- 70-u2f.rules: eb5ab4db095e5bbc841b023ad3281a22f6d86fefccfaae06fc3f0e1db6cf8152

## Test plan
- [ ] Verify container build completes successfully
- [ ] Confirm hash verification passes with correct downloads
- [ ] Test that hash mismatch causes build to fail appropriately

Generated with Claude Code