### PR TITLE
docs(skills): update e2e-ci, governance for P0 session 2026-06-03

### DIFF
--- a/docs/skills/INDEX.md
+++ b/docs/skills/INDEX.md
@@ -7,4 +7,4 @@ Agent skill docs for the `projectbluefin/common` repo.
 | [governance.md](governance.md) | Triagers role, CODEOWNERS sentinel pattern, sync workflow, branch protection matrix |
 | [hive-review.md](hive-review.md) | `~/src/hive-status` — session start, P0/P1 triage, hive label taxonomy |
 | [queue-dashboard.md](queue-dashboard.md) | queue.projectbluefin.io — PR tiers, merge ruleset (2 approvals), refresh cadence |
-| [e2e-ci.md](e2e-ci.md) | Post-merge E2E CI architecture — common suite, brew tools masked in CI, MOTD fix, known quarantined scenarios |
+| [e2e-ci.md](e2e-ci.md) | Pre/post-merge E2E CI for common — composed PR gate, post-merge common suite, masked brew setup, quarantined scenarios |

--- a/docs/skills/e2e-ci.md
+++ b/docs/skills/e2e-ci.md
@@ -1,0 +1,32 @@
+# E2E CI
+
+## Post-merge E2E
+
+**File:** `.github/workflows/e2e.yml`
+
+- Runs after merges to `main`
+- Calls the reusable `projectbluefin/testsuite` E2E workflow with `suites: common`
+- Validates the common layer against three downstream images:
+  - `ghcr.io/ublue-os/bluefin:latest`
+  - `ghcr.io/ublue-os/bluefin:lts`
+  - `ghcr.io/projectbluefin/dakota:latest`
+- Uses SSH-mode tests from the runner, so the common suite does not require a full GNOME session
+
+## Pre-merge gate
+
+**File:** `.github/workflows/pr-e2e.yml`
+
+- Runs on PRs to `main` and on `merge_group`
+- Builds the PR's `common` layer candidate first
+- Composes a downstream test image from `ghcr.io/ublue-os/bluefin:latest` by overlaying `/system_files/shared` and `/system_files/bluefin`
+- Recompiles GSettings schemas in the composed image
+- Pushes the composed image to GHCR and runs the reusable `projectbluefin/testsuite` workflow with `suites: common`
+
+This is the pre-merge gate for common-layer changes, so regressions can fail before merge instead of waiting for post-merge E2E.
+
+## Known CI caveats and quarantines
+
+- `brew-setup.service` is masked in CI, so Homebrew-installed CLI tools are not present unless explicitly provisioned during the job
+- `testsuite#210` tracks the `bash -lc` PATH mismatch affecting `zsh`/`fish` checks in the CI user environment
+- GNOME Software scenarios are intentionally `@quarantine` after `testsuite#258`; they should not be treated as active software-store coverage
+- Bazaar coverage is currently a `@pending` placeholder tied to the same gap

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -50,6 +50,27 @@ Force a resync anytime:
 gh workflow run sync-codeowners.yml --repo projectbluefin/common
 ```
 
+## Hive sync coverage
+
+Hive progress sync now covers all five `projectbluefin` repos on staggered cron slots:
+
+| Repo | Minute |
+|---|---|
+| `dakota` | `:00` |
+| `bluefin` | `:15` |
+| `common` | `:20` |
+| `knuckle` | `:30` |
+| `bluefin-lts` | `:45` |
+
+The sync jobs count slash-separated labels (`hive/p0`, `hive/p1`) across the full repo set.
+Older references to dotted labels are stale.
+
+## Template sync namespace
+
+bonedigger's `sync-templates.yml` now targets the `projectbluefin/*` namespace,
+not the old `ublue-os/*` pre-migration namespace. `projectbluefin/knuckle` is
+included in that sync set.
+
 ## Branch protection
 
 `require_code_owner_reviews: true` is active on all four repos. A CODEOWNERS match is


### PR DESCRIPTION
## Summary
- add docs/skills/e2e-ci.md for post-merge and pre-merge common E2E behavior
- update governance.md with hive sync coverage across all 5 repos and bonedigger namespace sync details
- refresh the INDEX entry for the E2E skill doc

## Test plan
- just check
- pre-commit run --files docs/skills/INDEX.md docs/skills/governance.md docs/skills/e2e-ci.md