### PR TITLE
fix(security): pin curl fetches in Containerfile to verified hashes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,11 +14,14 @@ RUN install -d /out/shared/usr/share/bash-completion/completions /out/shared/usr
   just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/zsh/site-functions/_ujust && \
   just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > /out/shared/usr/share/fish/vendor_completions.d/ujust.fish
 
-RUN curl -fsSLo - https://codeberg.org/fabiscafe/game-devices-udev/archive/1.0.tar.gz | tar xzvf - -C tmp/ && \
+RUN curl -fsSLo tmp/game-devices-udev-1.0.tar.gz https://codeberg.org/fabiscafe/game-devices-udev/archive/1.0.tar.gz && \
+    echo "642315c110f427d0765abe66369f3080604c3fb7243c07d1aa77303b31f6dc6d  tmp/game-devices-udev-1.0.tar.gz" | sha256sum -c && \
+    tar xzvf tmp/game-devices-udev-1.0.tar.gz -C tmp/ && \
     for f in tmp/game-devices-udev/src/*.rules; do \
       install -Dpm0644 "$f" "out/shared/usr/lib/udev/rules.d/71-${f##*/}"; \
     done && \
-  curl -fsSLo /out/shared/usr/lib/udev/rules.d/70-u2f.rules https://raw.githubusercontent.com/Yubico/libfido2/refs/heads/main/udev/70-u2f.rules
+  curl -fsSLo /out/shared/usr/lib/udev/rules.d/70-u2f.rules https://raw.githubusercontent.com/Yubico/libfido2/b974e7cf2ee7392134cc12c08b76a068cf250dd8/udev/70-u2f.rules && \
+    echo "eb5ab4db095e5bbc841b023ad3281a22f6d86fefccfaae06fc3f0e1db6cf8152  /out/shared/usr/lib/udev/rules.d/70-u2f.rules" | sha256sum -c
 
 FROM scratch AS ctx
 COPY /aurorafin-shared/system_files/shared /system_files/shared/


### PR DESCRIPTION
Closes #428.

## Summary
- pin the `game-devices-udev` Codeberg tarball fetch to the 1.0 release and verify it with SHA256 before extraction
- pin the `libfido2` `70-u2f.rules` fetch to the commit behind tag `1.17.0` and verify it with SHA256 after download

## Validation
- `just check`