### PR TITLE
docs(skills): add lifecycle automation table and common workflow inventory

### DIFF
--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -82,3 +82,17 @@ required for a PR to merge — triagers count for `docs/**` and `*.md` paths.
 | `bluefin` | Branch protection on `main` | 1 |
 | `bluefin-lts` | Branch protection on `main` | 1 |
 | `dakota` | Branch protection on `main` | 1 |
+
+## Lifecycle automation (bonedigger)
+
+| Repo | Workflow | State |
+|---|---|---|
+| `bluefin` | `bonedigger.yml` | ✅ live |
+| `common` | `bonedigger.yml` | ✅ live (added 2026-06-03, PR #453) |
+| `bluefin-lts` | — | ❌ not yet |
+| `dakota` | `actionadon.yml` | ⚠️ different engine |
+| `knuckle` | `actionadon.yml` | ⚠️ different engine |
+
+`common`'s workflow calls `projectbluefin/bonedigger/.github/workflows/lifecycle.yml` at a pinned commit SHA. Brand: `Common` / 🧱.
+
+Full unification (claim TTL, heartbeat, linked-PR requirement, stale-claim recovery across all engines) is tracked in projectbluefin/common#409.


### PR DESCRIPTION
Updates to docs/skills after the 2026-06-03 P1 triage session.

- **governance.md**: adds Lifecycle automation table showing bonedigger state across all 5 repos (common ✅, bluefin ✅, bluefin-lts ❌, dakota/knuckle ⚠️ actionadon), links #409 for full unification tracking
- **bluefin-ci skill**: adds common repo workflow inventory table with all 9 workflows including bonedigger.yml; documents that `Build and push image` is the only required check (Compose PR test image is non-blocking)

Follows the work in #453 (bonedigger), #454 (AGENTS.md), #455 (hash pinning).

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>