### PR TITLE
fix(docs): update CONTRIBUTING.md — describe what belongs here vs downstream repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,30 @@
-# CONTRIBUTING 
+# CONTRIBUTING
 
-Thanks for helping out! 
+Thanks for helping out!
 
 Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
 
-This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture). 
+## What belongs here
+
+**`projectbluefin/common`** is the shared OCI layer consumed by all Bluefin variants (bluefin, bluefin-lts, dakota). Changes here propagate to every downstream image. Be surgical.
+
+- `system_files/shared/` — shared system config (staged from `ublue-os/aurorafin-shared`; upstream PRs go there, not here)
+- `system_files/bluefin/` — Bluefin-specific config editable directly in this repo
+- `Containerfile` — shared OCI image build
+- `.github/` — org governance: CODEOWNERS, issue templates, skill sync, lifecycle automation
+
+## Where to go for image-specific changes
+
+| What you want to change | Repo |
+|---|---|
+| Bluefin-specific packages / config | [projectbluefin/bluefin](https://github.com/projectbluefin/bluefin) |
+| Bluefin LTS | [projectbluefin/bluefin-lts](https://github.com/projectbluefin/bluefin-lts) |
+| Dakota / GNOME OS image | [projectbluefin/dakota](https://github.com/projectbluefin/dakota) |
+| Shared system config (Aurora + Bluefin) | [ublue-os/aurorafin-shared](https://github.com/ublue-os/aurorafin-shared) |
+| E2E test suite | [projectbluefin/testsuite](https://github.com/projectbluefin/testsuite) |
+
+Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+
+## CI
+
+PRs require only `validate-just` and `build` to pass — no expensive VM boots. Full layer validation (`common` behave suite via [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite)) runs automatically on every merge to main.


### PR DESCRIPTION
## Summary

Closes #431

The file had a copy-paste artifact from another repo redirecting contributors to `@projectbluefin/common` — but this IS that repo. Replaced with:
- A clear description of what belongs in common (shared OCI layer, org governance)
- A routing table for where to send image-specific changes (bluefin, bluefin-lts, dakota, aurorafin-shared, testsuite)
- Preserved the CI section

## Testing
Docs-only change, no CI impact.