### PR TITLE
docs(agents): add missing workflows to AGENTS.md inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,13 @@ system_files/
 .github/workflows/
   build.yml                # Build + push on merge to main
   e2e.yml                  # Post-merge e2e against bluefin, bluefin-lts, dakota
+  pr-e2e.yml               # Pre-merge e2e composition gate for PRs
   validate-just.yml        # PR gate: just check
   validate-brewfiles.yaml  # PR gate: Brewfile validation
+  release.yml              # Monthly release on 1st of month (cron + workflow_dispatch)
+  bonedigger.yml           # Issue lifecycle automation (claim/queue/reclaim)
+  sync-codeowners.yml      # Syncs CODEOWNERS TRIAGERS block to downstream repos on push
+  hive-progress-sync.yml   # Hourly queue stats → projectbluefin org project board
 ```
 
 ## CODEOWNERS


### PR DESCRIPTION
## Summary

Closes #429

The `.github/workflows/` inventory in AGENTS.md listed only 4 of 9 workflows. Added the missing 5:

| Workflow | Purpose |
|---|---|
| `release.yml` | Monthly release on 1st of month |
| `pr-e2e.yml` | Pre-merge e2e composition gate for PRs |
| `bonedigger.yml` | Issue lifecycle automation (claim/queue/reclaim) |
| `sync-codeowners.yml` | Syncs CODEOWNERS TRIAGERS block to downstream repos |
| `hive-progress-sync.yml` | Hourly queue stats → org project board |

## Testing
Docs-only change. No CI impact.