### PR TITLE
fix(ci): add skill-drift.yml to detect stale agent skills

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    with:
+      code-paths: '[".github/workflows/**", "Containerfile", "Justfile", "system_files/**"]'
+      skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'


### PR DESCRIPTION
## Summary

Closes #413

Adds `skill-drift.yml` — the workflow that warns when code changes outpace agent skill docs. Already runs in `bluefin`, `bluefin-lts`, and `dakota` but was missing from `common`.

**Code paths monitored:**
- `.github/workflows/**`
- `Containerfile`
- `Justfile`
- `system_files/**`

**Skill paths checked:**
- `docs/skills/**`
- `docs/*.md`
- `AGENTS.md`

Mirrors `projectbluefin/bluefin`'s skill-drift workflow with paths updated for common's layout.