### PR TITLE
fix(ci): add skill-drift.yml to detect stale agent skills

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    with:
+      code-paths: '[".github/workflows/**", "Containerfile", "Justfile", "system_files/**"]'
+      skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'


### PR DESCRIPTION
Closes #413

Adds .github/workflows/skill-drift.yml to detect stale agent skills. Mirrors the pattern from the bluefin repo. Triggers on PRs touching code paths that do not also update the matching skill docs.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI