### PR TITLE
fix(docs): CONTRIBUTING.md — replace self-referential redirect with routing table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,21 @@
-# CONTRIBUTING 
+# CONTRIBUTING
 
-Thanks for helping out! 
+Thanks for helping out!
 
-Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
+## What belongs here
 
-This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+`projectbluefin/common` is the **shared OCI layer** consumed by all Bluefin variants. Changes here propagate to `bluefin`, `bluefin-lts`, and `dakota` at next build — stay surgical.
+
+| If you want to change… | Go to |
+|---|---|
+| Bluefin desktop defaults, apps, just recipes | [`projectbluefin/bluefin`](https://github.com/projectbluefin/bluefin) |
+| LTS-specific behavior | [`projectbluefin/bluefin-lts`](https://github.com/projectbluefin/bluefin-lts) |
+| Dakota (GNOME OS variant) | [`projectbluefin/dakota`](https://github.com/projectbluefin/dakota) |
+| Shared system config (applies to Aurora too) | [`ublue-os/aurorafin-shared`](https://github.com/ublue-os/aurorafin-shared) |
+| E2E test suite | [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite) |
+| Shared just recipes, profile scripts, CODEOWNERS | **here** |
+
+See the [architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture) for the full picture.
 
 ## CI
 


### PR DESCRIPTION
Closes #431

The previous content told contributors to go to `projectbluefin/common` from within `projectbluefin/common` (copy-paste artifact from a downstream repo). Replaces with a clear routing table showing what belongs here vs downstream repos, and retains the CI section.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>