### PR TITLE
fix(ci): add skill-drift workflow and block floating GHA tags in pre-commit

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@13e3593568d87cfe075a86e3995930e350f8c5ea # v1
+    with:
+      code-paths: '[".github/workflows/**", "system_files/**", "Containerfile", "Justfile"]'
+      skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,11 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: no-floating-action-tags
+        name: Block floating GitHub Action tags
+        language: pygrep
+        entry: 'uses:.*@(main|master|latest|v[0-9]+)\s*$'
+        types: [yaml]
+        files: '^\.github/workflows/'


### PR DESCRIPTION
Fixes #413 and #477.

## Changes

### skill-drift.yml
Adds the skill drift detection workflow to common. This workflow runs on PRs to detect when agent skills are out of date relative to code changes. Adapted from bluefin's version with code-paths updated for common's structure (system_files/, Containerfile) instead of build_files/.

### .pre-commit-config.yaml
Adds a local pygrep hook that blocks floating GitHub Action tags (`@main`, `@master`, `@latest`, `@v1`, `@v2`, etc.) in workflow files at commit time. This complements Renovate's existing SHA-pinning management by preventing new floating tags from being introduced.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI