### PR TITLE
fix(deps): track OCI image digests in Containerfile with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,10 @@
     "enabled": true
   },
 
+  "dockerfile": {
+    "managerFilePatterns": ["^Containerfile$"]
+  },
+
   "customManagers": [
     {
       "customType": "regex",
@@ -17,6 +21,15 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "ublue-os/artwork"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["^Containerfile$"],
+      "matchStrings": [
+        "COPY --from=(?<depName>ghcr\\.io/ublue-os/bluefin-wallpapers-gnome):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Fixes #433.

## Problem
The Containerfile uses two pinned OCI image digests that Renovate did not track:
- `docker.io/library/alpine:latest@sha256:...` (base build image)
- `ghcr.io/ublue-os/bluefin-wallpapers-gnome:latest@sha256:...` (wallpapers)

Both would silently go stale without Renovate updating them.

## Fix
- Enable the built-in `dockerfile` manager for `Containerfile` — this handles the `FROM` instruction's digest automatically
- Add a custom regex manager for the `COPY --from=` pattern for the wallpapers image
- Use the current Renovate schema so the config passes `renovate-config-validator --strict`

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI