### PR TITLE
feat(ci): add common factory guardrails

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,12 @@
 # Post-merge E2E — common layer validation
 #
-# Runs AFTER a merge to main (not on PRs). PRs are gated only by the
-# lightweight validate-just and build workflows.
+# Runs AFTER a merge to main (not on PRs). PRs get validate/build plus the
+# advisory composed-image gate in pr-e2e.yml.
 #
-# Uses the projectbluefin/testsuite reusable e2e workflow with the `common`
-# suite, which validates that the files shipped by this repo (dconf defaults,
-# ujust, setup scripts, desktop entries, shell config) are present and
-# functional in the composed Bluefin images.
+# Uses the local run-testsuite wrapper with the `common` suite, which validates
+# that the files shipped by this repo (dconf defaults, ujust, setup scripts,
+# desktop entries, shell config) are present and functional in the downstream
+# images.
 #
 # The `common` suite runs in SSH mode from the GHA runner — no full GNOME
 # session needed, so jobs complete in ~15 min vs ~60 min for GUI suites.
@@ -26,23 +26,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e-bluefin-lts:
-    name: "E2E — Bluefin LTS"
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@262ba3726dda2979aa3aa9acf84b60fecfdbc776 # main
+  e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Bluefin LTS
+            image: ghcr.io/ublue-os/bluefin:lts
+            suites: common
+          - name: Bluefin Stable
+            image: ghcr.io/ublue-os/bluefin:latest
+            suites: common
+          - name: Dakota
+            image: ghcr.io/projectbluefin/dakota:latest
+            suites: common
+    name: "E2E — ${{ matrix.name }}"
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/run-testsuite.yml
     with:
-      image: ghcr.io/ublue-os/bluefin:lts
-      suites: common
-
-  e2e-bluefin-stable:
-    name: "E2E — Bluefin Stable"
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@262ba3726dda2979aa3aa9acf84b60fecfdbc776 # main
-    with:
-      image: ghcr.io/ublue-os/bluefin:latest
-      suites: common
-
-  e2e-dakota:
-    name: "E2E — Dakota"
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@262ba3726dda2979aa3aa9acf84b60fecfdbc776 # main
-    with:
-      image: ghcr.io/projectbluefin/dakota:latest
-      suites: common
+      image: ${{ matrix.image }}
+      suites: ${{ matrix.suites }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -115,7 +115,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@262ba3726dda2979aa3aa9acf84b60fecfdbc776 # main
+    uses: ./.github/workflows/run-testsuite.yml
     with:
       image: ${{ needs.compose.outputs.image }}
       suites: common

--- a/.github/workflows/promotion-candidate-e2e.yml
+++ b/.github/workflows/promotion-candidate-e2e.yml
@@ -1,0 +1,29 @@
+name: Promotion Candidate E2E
+
+# Common cannot add a full installer gate for downstream repos by itself, but it
+# can continuously exercise the exact testing-stream tags that feed promotion.
+on:
+  schedule:
+    - cron: "0 3 * * 2"
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Bluefin Testing
+            image: ghcr.io/projectbluefin/bluefin:testing
+            suites: smoke,common
+          - name: Bluefin LTS Testing
+            image: ghcr.io/projectbluefin/bluefin:lts-testing
+            suites: smoke,common
+    name: "E2E — ${{ matrix.name }}"
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/run-testsuite.yml
+    with:
+      image: ${{ matrix.image }}
+      suites: ${{ matrix.suites }}

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -1,0 +1,30 @@
+name: Run Testsuite
+
+# Reusable wrapper around projectbluefin/testsuite e2e.yml.
+# Keeps the testsuite SHA pin in one place for PR, post-merge, and
+# promotion-candidate gates in this repo.
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Full image ref to test"
+        required: true
+        type: string
+      suites:
+        description: "Comma-separated test suites to run"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  e2e:
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@82a233861b343cd71f359cc1e0d7b134fea78e88 # main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image: ${{ inputs.image }}
+      suites: ${{ inputs.suites }}

--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   skill-drift:
-    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@77d4fe331590da249555c5eee24bdcfa447092e6 # main
     with:
-      code-paths: '[".github/workflows/**", "Containerfile", "Justfile", "system_files/**"]'
+      code-paths: '[".github/workflows/**", "system_files/**", "Containerfile", "Justfile"]'
       skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,11 @@ jobs:
               }
           }
           pattern = re.compile(r"ghcr\.io/projectbluefin/(bluefin|aurora|bazzite)(?::[A-Za-z0-9._-]+)?")
-          candidates = list(Path(".github/workflows").rglob("*.yml"))
+          candidates = [
+              path
+              for path in Path(".github/workflows").rglob("*.yml")
+              if path.name != "validate.yml"
+          ]
           candidates += list(Path(".github/workflows").rglob("*.yaml"))
           candidates.append(Path("system_files/bluefin/usr/bin/ublue-rollback-helper"))
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,17 +59,43 @@ jobs:
         shell: bash
         run: |
           echo "Checking for disallowed ublue-os→projectbluefin OCI image ref changes..."
-          # Production images are still published at ghcr.io/ublue-os/. Do not change these refs.
-          if grep -rE 'ghcr\.io/projectbluefin/(bluefin|aurora|bazzite)' \
-              .github/workflows/ \
-              system_files/bluefin/usr/bin/ublue-rollback-helper 2>/dev/null; then
-            echo ""
-            echo "ERROR: Found projectbluefin OCI image refs. Production images are published"
-            echo "at ghcr.io/ublue-os/, not ghcr.io/projectbluefin/. Do not change these refs"
-            echo "until the org migration for OCI image publishing is complete."
-            echo "See docs/skills/image-registry.md for details."
-            exit 1
-          fi
+          python - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          allowed_refs = {
+              Path(".github/workflows/promotion-candidate-e2e.yml"): {
+                  "ghcr.io/projectbluefin/bluefin:testing",
+                  "ghcr.io/projectbluefin/bluefin:lts-testing",
+              }
+          }
+          pattern = re.compile(r"ghcr\.io/projectbluefin/(bluefin|aurora|bazzite)(?::[A-Za-z0-9._-]+)?")
+          candidates = list(Path(".github/workflows").rglob("*.yml"))
+          candidates += list(Path(".github/workflows").rglob("*.yaml"))
+          candidates.append(Path("system_files/bluefin/usr/bin/ublue-rollback-helper"))
+
+          violations = []
+          for path in candidates:
+              for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+                  for match in pattern.finditer(line):
+                      ref = match.group(0)
+                      if ref in allowed_refs.get(path, set()):
+                          continue
+                      violations.append(f"{path}:{lineno}:{ref}")
+
+          if violations:
+              print("")
+              print("ERROR: Found disallowed projectbluefin OCI image refs:")
+              for violation in violations:
+                  print(f"  - {violation}")
+              print("")
+              print("Production images are still published at ghcr.io/ublue-os/.")
+              print("Only the promotion-candidate testing tags are allowed under")
+              print("ghcr.io/projectbluefin/bluefin in .github/workflows/promotion-candidate-e2e.yml.")
+              print("See docs/skills/image-registry.md for details.")
+              sys.exit(1)
+          PY
           echo "No disallowed image ref changes found."
 
       - name: Validate dconf lock/override parity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Load the relevant skill doc before making changes in these areas.
 | Image refs / registry paths | [`docs/skills/image-registry.md`](docs/skills/image-registry.md) |
 | `ublue-rollback-helper` changes | [`docs/skills/rollback-helper.md`](docs/skills/rollback-helper.md) |
 | CI / GitHub Actions | [`docs/skills/ci-tooling.md`](docs/skills/ci-tooling.md) |
+| What a `common` workflow is for | [`docs/skills/workflow-map.md`](docs/skills/workflow-map.md) |
 | E2E test changes | [`docs/skills/e2e-ci.md`](docs/skills/e2e-ci.md) |
 | Governance / CODEOWNERS | [`docs/skills/governance.md`](docs/skills/governance.md) |
 | PR queue / merge decisions | [`docs/skills/queue-dashboard.md`](docs/skills/queue-dashboard.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,14 @@ system_files/
   shared/                  # Shared config staged from aurorafin-shared (not edited directly here)
   bluefin/                 # Local editable config for Bluefin-specific variants only
 .github/workflows/
+  bonedigger.yml           # Issue lifecycle automation for common
   build.yml                # Build + push on merge to main
   e2e.yml                  # Post-merge e2e against bluefin, bluefin-lts, dakota
+  pr-e2e.yml               # PR-time composed-image common-suite gate
+  promotion-candidate-e2e.yml # Weekly smoke/common checks for testing promotion candidates
   release.yml              # Monthly versioned OCI release (1st of month, also workflow_dispatch)
+  run-testsuite.yml        # Local wrapper that centralizes the testsuite SHA pin
+  skill-drift.yml          # PR advisory gate for implementation/doc parity
   validate.yml             # PR gate: just check, pre-commit, shellcheck, submodule drift
   validate-brewfiles.yaml  # PR gate: Brewfile validation
 ```

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Users can install these bundles using the `ujust bbrew` command, which will prom
 
 Changes are validated in three layers:
 
+If you need the per-workflow purpose and ownership map, start with
+[`docs/skills/workflow-map.md`](docs/skills/workflow-map.md).
+
 **On every PR**:
 - `validate.yml` — `just check`, shellcheck, pre-commit, submodule drift, registry/dconf guards
 - `build.yml` — builds the OCI image with `buildah`

--- a/README.md
+++ b/README.md
@@ -102,16 +102,21 @@ Users can install these bundles using the `ujust bbrew` command, which will prom
 
 ## CI / Testing
 
-Changes are validated in two stages:
+Changes are validated in three layers:
 
-**On every PR** — lightweight checks only (no VM boot):
-- `validate-just` — lints the Justfile and all `.just` recipes
-- `build` — builds the OCI image with `buildah`
+**On every PR**:
+- `validate.yml` — `just check`, shellcheck, pre-commit, submodule drift, registry/dconf guards
+- `build.yml` — builds the OCI image with `buildah`
+- `skill-drift.yml` — warns when implementation changes land without matching skill-doc updates
+- `pr-e2e.yml` — advisory composed-image common-suite check against a downstream Bluefin base
 
 **On merge to main** — full layer validation via [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite):
 - Runs the [`common` behave suite](https://github.com/projectbluefin/testsuite/tree/main/tests/common) against Bluefin LTS, Bluefin Stable, and Dakota
 - SSH-mode: behave runs from the GHA runner over SSH into a QEMU VM — no full GNOME session needed, completes in ~15 min
 - Validates dconf defaults, locked keys, `ujust`, setup scripts, desktop entries, and shell configuration as they land in the composed images
+
+**Before downstream testing → stable promotions**:
+- `promotion-candidate-e2e.yml` runs `smoke,common` against `ghcr.io/projectbluefin/bluefin:{testing,lts-testing}` on Tuesdays, giving `common` a repo-local signal on the exact candidate tags that feed promotion
 
 ## Building Locally
 

--- a/docs/factory/README.md
+++ b/docs/factory/README.md
@@ -55,7 +55,8 @@ Lifecycle: `filed → approved → queued → claimed → done`
 Operational notes:
 - Bonedigger manages this lifecycle in `bluefin`.
 - actionadon manages the equivalent flow in `dakota`/`knuckle`.
-- `common` and `bluefin-lts` do **not** yet have lifecycle automation; agents must avoid double-claiming and stale claims manually.
+- `common` now has bonedigger lifecycle automation; `bluefin-lts` still does not.
+- `bluefin-lts` still requires manual care to avoid double-claiming and stale claims until lifecycle automation lands there.
 - No PR activity in 7 days should return the claim (`/unclaim`) until org-wide automation exists.
 
 ## Agent rules of engagement
@@ -72,16 +73,18 @@ Operational notes:
 |---|---|---|---|---|---|---|
 | AGENTS.md | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | pre-commit | ✅ | ✅ | ✅ | ❌ | — | — |
-| skill-drift.yml | ❌ | ✅ | ✅ | ✅ | ✅ | — |
-| no-floating-action-tags hook | ❌ | ✅ | ✅ | ❌ | ✅ | — |
-| bonedigger lifecycle | ❌ | ✅ | ❌ | ❌ | — | — |
+| skill-drift.yml | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| no-floating-action-tags hook | ✅ | ✅ | ✅ | ❌ | ✅ | — |
+| bonedigger lifecycle | ✅ | ✅ | ❌ | ❌ | — | — |
 | Renovate config | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Post-merge e2e | ✅ | ✅ | ❌ | partial | — | — |
-| Installability gate | ❌ | ❌ | ❌ | ❌ | — | ❌ |
+| Installability gate | ⚠️ testing-stream smoke/common only | ❌ | ❌ | ❌ | — | ❌ |
 | CODEOWNERS active | ✅ | ✅ | ✅ | ✅ | — | — |
 | docs/skills/ populated | ✅ | ✅ | partial | ✅ | ✅ | ✅ |
 
-Read this table as an execution warning, not a scorecard: parity is incomplete, automation is fragmented, and agents must compensate for missing guardrails in `common` and `bluefin-lts`.
+Read this table as an execution warning, not a scorecard: parity is incomplete, automation is fragmented, and agents must still compensate for missing guardrails across the factory, especially in `bluefin-lts`.
+
+`common` also has a new **promotion-candidate smoke/common gate** in `.github/workflows/promotion-candidate-e2e.yml`. It is not a full installer gate, but it gives repo-local signal on `bluefin:testing` and `bluefin:lts-testing` before the downstream Tuesday promotions.
 
 ## Per-repo AGENTS.md entry points
 

--- a/docs/factory/README.md
+++ b/docs/factory/README.md
@@ -31,6 +31,9 @@ dakota      ─┘                  │
 - `iso`: installation media fed by validated image outputs
 - `actions`: shared GitHub Actions used across the org
 
+For the workflow-by-workflow purpose map inside `common`, see
+[`../skills/workflow-map.md`](../skills/workflow-map.md).
+
 ## Factory repos
 
 - `common` — https://github.com/projectbluefin/common

--- a/docs/skills/INDEX.md
+++ b/docs/skills/INDEX.md
@@ -7,6 +7,7 @@ Agent skill docs for the `projectbluefin/common` repo.
 | [governance.md](governance.md) | Triagers role, CODEOWNERS sentinel pattern, sync workflow, branch protection matrix |
 | [hive-review.md](hive-review.md) | `~/src/hive-status` — session start, P0/P1 triage, hive label taxonomy |
 | [queue-dashboard.md](queue-dashboard.md) | queue.projectbluefin.io — PR tiers, merge ruleset (2 approvals), refresh cadence |
+| [workflow-map.md](workflow-map.md) | What each `common` GitHub workflow is for — validation, E2E, release, and factory-policy boundaries |
 | [e2e-ci.md](e2e-ci.md) | Pre/post-merge and promotion-candidate E2E CI for common — composed PR gate, testing-stream smoke/common checks, masked brew setup, quarantined scenarios |
 | [ci-tooling.md](ci-tooling.md) | Pre-commit floating-tag guard, live skill-drift workflow, Renovate OCI digest tracking |
 | [onboarding.md](onboarding.md) | Verified setup commands, correct pip/npm flags, and PR branch targets for all projectbluefin repos |

--- a/docs/skills/INDEX.md
+++ b/docs/skills/INDEX.md
@@ -7,8 +7,8 @@ Agent skill docs for the `projectbluefin/common` repo.
 | [governance.md](governance.md) | Triagers role, CODEOWNERS sentinel pattern, sync workflow, branch protection matrix |
 | [hive-review.md](hive-review.md) | `~/src/hive-status` — session start, P0/P1 triage, hive label taxonomy |
 | [queue-dashboard.md](queue-dashboard.md) | queue.projectbluefin.io — PR tiers, merge ruleset (2 approvals), refresh cadence |
-| [e2e-ci.md](e2e-ci.md) | Pre/post-merge E2E CI for common — composed PR gate, post-merge common suite, masked brew setup, quarantined scenarios |
-| [ci-tooling.md](ci-tooling.md) | Pre-commit floating-tag guard, skill-drift workflow, Renovate OCI digest tracking |
+| [e2e-ci.md](e2e-ci.md) | Pre/post-merge and promotion-candidate E2E CI for common — composed PR gate, testing-stream smoke/common checks, masked brew setup, quarantined scenarios |
+| [ci-tooling.md](ci-tooling.md) | Pre-commit floating-tag guard, live skill-drift workflow, Renovate OCI digest tracking |
 | [onboarding.md](onboarding.md) | Verified setup commands, correct pip/npm flags, and PR branch targets for all projectbluefin repos |
 | [submodule-boundary.md](submodule-boundary.md) | What is/isn't editable in this repo — `system_files/shared/` is read-only (aurorafin-shared submodule), `system_files/bluefin/` is editable |
 | [dconf-consistency.md](dconf-consistency.md) | GSettings override ↔ dconf lock file parity rules — must edit both files together for locked settings |

--- a/docs/skills/acmm-audit-level1.md
+++ b/docs/skills/acmm-audit-level1.md
@@ -19,13 +19,13 @@ The core mission — **Agentic OS Components / operating system factory** — mu
 
 These are the highest-probability regression sites where an AI without full codebase context will confidently generate broken changes.
 
-### BS-1.1 · `common` has no `skill-drift.yml` enforcement
+### BS-1.1 · `common` skill-drift enforcement was missing and is now live
 
 **Repo:** common  **Issue:** [#413](https://github.com/projectbluefin/common/issues/413)
 
-`bluefin`, `bluefin-lts`, and `dakota` all have `skill-drift.yml` wired. `common` — the **canonical skills hub** — does not. Implementation PRs can land here with no prompt to update docs, defeating the purpose of the hub. This is the highest-leverage gap in the entire factory.
+`bluefin`, `bluefin-lts`, and `dakota` already had `skill-drift.yml` wired. `common` — the **canonical skills hub** — was the holdout, so implementation PRs could land here with no prompt to update docs. That gap is now closed in `common`, but the lesson remains: the skills hub must enforce its own hygiene first.
 
-**Immediate fix:** Add `.github/workflows/skill-drift.yml` to `common` (and `knuckle`).
+**Immediate fix:** Land `.github/workflows/skill-drift.yml` in `common` (done) and continue parity work in the remaining repos.
 
 ---
 
@@ -109,23 +109,23 @@ Dakota uses **BuildStream 2 (BST)**. There are no `dnf5` commands, no Fedora RPM
 
 ---
 
-### BS-1.10 · Lifecycle bot fragmented across 5 repos
+### BS-1.10 · Lifecycle bot still fragmented across 5 repos
 
 **Repo:** org-wide  **Issue:** [#409](https://github.com/projectbluefin/common/issues/409)
 
-The `filed → approved → queued → claimed → done` state machine runs on three different engines across five repos: bonedigger (bluefin), actionadon (dakota, knuckle), and nothing (common, bluefin-lts). An AI claiming an issue in `common` or `bluefin-lts` will find no automation, no TTL, no heartbeat check — double-claiming and permanent orphans are possible. This is the single biggest operational risk to a multi-agent factory.
+The `filed → approved → queued → claimed → done` state machine still runs on three different engines across five repos: bonedigger (bluefin, common), actionadon (dakota, knuckle), and nothing (bluefin-lts). `common` is no longer missing lifecycle automation, but the factory is still fragmented and `bluefin-lts` remains uncovered. This is still one of the biggest operational risks to a multi-agent factory.
 
-**Immediate fix:** Add `bonedigger.yml` to `common` and `bluefin-lts`.
+**Immediate fix:** Add `bonedigger.yml` to `bluefin-lts`, then align the remaining engines on a single contract.
 
 ---
 
-### BS-1.11 · Floating GitHub Action tags — no pre-commit guard in `common`
+### BS-1.11 · Floating GitHub Action tags — parity still incomplete outside `common`
 
 **Repo:** common  **Issue:** [#477](https://github.com/projectbluefin/common/issues/477)
 
-`bluefin` has the `no-floating-action-tags` pre-commit hook. `common` does not. `actionlint` catches syntax errors but does not enforce SHA pinning. Any AI that adds a workflow step will default to the `@v3` / `@main` pattern shown in GitHub's own documentation.
+`common`, `bluefin`, `bluefin-lts`, and `actions` now have the `no-floating-action-tags` pre-commit hook. `actionlint` still only catches syntax errors, not SHA pinning, so repos without the hook remain vulnerable to `@v3` / `@main` regressions copied from GitHub examples.
 
-**Existing skill:** `docs/skills/ci-tooling.md` covers the hook pattern. The fix is mechanical: add the hook to `common/.pre-commit-config.yaml`.
+**Existing skill:** `docs/skills/ci-tooling.md` covers the hook pattern. The remaining work is parity in repos that still lack the hook.
 
 ---
 
@@ -153,10 +153,9 @@ These are the active feedback loops that currently arrest error cascades.
 ### Critical gaps
 
 - **No pre-merge composition test** for `common`: a `common` change lands before downstream bluefin/lts/dakota builds validate it (issue [#405](https://github.com/projectbluefin/common/issues/405)).
-- **No installability gate** before `testing → stable` promotion (issue [#423](https://github.com/projectbluefin/common/issues/423)).
+- **No full installability gate** before `testing → stable` promotion (issue [#423](https://github.com/projectbluefin/common/issues/423)). `common` now has scheduled `smoke,common` coverage on `bluefin:testing` and `bluefin:lts-testing`, but there is still no installer/bootc-install gate.
 - **No bonedigger signal** wired into promotion decisions (issue [#424](https://github.com/projectbluefin/common/issues/424)).
-- **`skill-drift.yml` missing from `common`** — the org brain has no enforcement that docs stay current (issue [#413](https://github.com/projectbluefin/common/issues/413)).
-- **`bluefin-lts` has no post-merge e2e** (issue [#425](https://github.com/projectbluefin/common/issues/425)).
+- **`bluefin-lts` still has no repo-local post-merge e2e** (issue [#425](https://github.com/projectbluefin/common/issues/425)). `common` now adds a common-side weekly smoke/common check on `:lts-testing`, but downstream parity is still incomplete.
 
 ---
 
@@ -238,7 +237,7 @@ Ordered by blast radius × probability of regression.
 
 **Target:** `common`, `bluefin-lts`  **Issue:** [#409](https://github.com/projectbluefin/common/issues/409)
 
-Add `bonedigger.yml` to `common` and `bluefin-lts`. Until this lands, an AI agent claiming an issue in either repo has no automated state management — double-claims and orphans are guaranteed at scale.
+`common` now has `bonedigger.yml`; `bluefin-lts` still does not. Finish the parity work there, then align the remaining lifecycle engines on one contract so agents do not have to memorize repo-specific claim behavior.
 
 ---
 
@@ -246,9 +245,9 @@ Add `bonedigger.yml` to `common` and `bluefin-lts`. Until this lands, an AI agen
 
 **Target:** `common`  **Issue:** [#413](https://github.com/projectbluefin/common/issues/413)
 
-`common` is the canonical skills hub. It must enforce its own documentation hygiene. Without `skill-drift.yml`, implementation PRs routinely land without updating the skills they affect.
+`common` is the canonical skills hub. It now enforces its own documentation hygiene with `skill-drift.yml`, so the next step is keeping the path mapping and adjacent skill docs current whenever workflow coverage changes.
 
-**New skill file needed:** `docs/skills/skill-drift.md` (how to satisfy the check; what counts as a skill update).
+**Supporting skill file:** `docs/skills/skill-drift.md` explains how to satisfy the check and what counts as a real skill update.
 
 ---
 
@@ -256,14 +255,7 @@ Add `bonedigger.yml` to `common` and `bluefin-lts`. Until this lands, an AI agen
 
 **Target:** `common`  **Issue:** [#477](https://github.com/projectbluefin/common/issues/477)
 
-Add to `.pre-commit-config.yaml`:
-```yaml
-- repo: https://github.com/projectbluefin/common
-  rev: <sha>
-  hooks:
-    - id: no-floating-action-tags
-```
-Or add the local pygrep hook directly (see `ci-tooling.md`).
+The local `pygrep`-based `no-floating-action-tags` hook is now present in `common/.pre-commit-config.yaml`. Keep the supporting docs and parity matrix accurate, and carry the same guard into any remaining repo that still lacks it.
 
 ---
 
@@ -356,12 +348,12 @@ Create `docs/factory/README.md` as the factory entry point. Every agent entering
 |---|---|---|---|---|---|---|
 | AGENTS.md | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | pre-commit | ✅ | ✅ | ✅ | ❌ | — | — |
-| skill-drift.yml | ❌ | ✅ | ✅ | ✅ | ✅ | — |
-| no-floating-action-tags hook | ❌ | ✅ | ✅ | ❌ | ✅ | — |
-| bonedigger lifecycle | ❌ | ✅ | ❌ | ❌ | — | — |
+| skill-drift.yml | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| no-floating-action-tags hook | ✅ | ✅ | ✅ | ❌ | ✅ | — |
+| bonedigger lifecycle | ✅ | ✅ | ❌ | ❌ | — | — |
 | Renovate config | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Post-merge e2e | ✅ | ✅ | ❌ | partial | — | — |
-| Installability gate | ❌ | ❌ | ❌ | ❌ | — | ❌ |
+| Installability gate | ⚠️ testing-stream smoke/common only | ❌ | ❌ | ❌ | — | ❌ |
 | CODEOWNERS active | ✅ | ✅ | ✅ | ✅ | — | — |
 | docs/skills/ populated | ✅ | ✅ | partial | ✅ | ✅ | ✅ |
 
@@ -373,9 +365,7 @@ Work these in order. Each builds on the one before.
 
 | Priority | Issue | Repo | Type | Unblocks |
 |---|---|---|---|---|
-| P0 | [#413](https://github.com/projectbluefin/common/issues/413) | common | skill-drift.yml | org brain hygiene |
 | P0 | [#409](https://github.com/projectbluefin/common/issues/409) | org-wide | lifecycle bot | all agent operations |
-| P1 | [#477](https://github.com/projectbluefin/common/issues/477) | common | no-floating-action-tags | CI hygiene |
 | P1 | [#468](https://github.com/projectbluefin/common/issues/468) | common | image-registry guard | prevents org-migration breaks |
 | P1 | [#476](https://github.com/projectbluefin/common/issues/476) | bluefin | pre-push hook | remote trap |
 | P1 | [#471](https://github.com/projectbluefin/common/issues/471) | bluefin | copr-security skill | security invariant |

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -2,7 +2,7 @@
 
 ## Floating-tag guard
 
-**Scope:** org-wide pre-commit hook in all `projectbluefin` repos (`common`, `bluefin`, `bluefin-lts`, `dakota`, `knuckle`, `actions`)
+**Scope:** shared pre-commit hook pattern for `projectbluefin` repos. It is currently live in `common`, `bluefin`, `bluefin-lts`, and `actions`; parity work remains in other repos.
 
 The `no-floating-action-tags` hook blocks GitHub Actions from being committed with floating refs in workflow files.
 
@@ -44,7 +44,7 @@ Use both. Renovate keeps pinned refs fresh; the hook enforces that refs are pinn
 
 **Workflow:** `.github/workflows/skill-drift.yml`
 
-`skill-drift.yml` is a PR gate used across projectbluefin repos. It calls the reusable workflow `projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1` to flag when implementation changes land without corresponding skill-doc updates.
+`skill-drift.yml` is a PR gate used across projectbluefin repos. In `common`, it calls the reusable workflow `projectbluefin/actions/.github/workflows/skill-drift-check.yml` at a pinned commit SHA so the local floating-tag guard does not reject the workflow.
 
 ### Repo path mapping
 
@@ -61,6 +61,8 @@ Use both. Renovate keeps pinned refs fresh; the hook enforces that refs are pinn
 A PR that touches any repo's `code-paths` without also touching one of its `skill-paths` triggers the check.
 
 This is advisory, not a hard merge block, but it should be treated as a prompt to update documentation while the implementation context is still fresh.
+
+For `common`, the workflow now lives at `.github/workflows/skill-drift.yml` and uses the exact path mapping shown above.
 
 ## Renovate OCI digest tracking
 

--- a/docs/skills/e2e-ci.md
+++ b/docs/skills/e2e-ci.md
@@ -5,7 +5,7 @@
 **File:** `.github/workflows/e2e.yml`
 
 - Runs after merges to `main`
-- Calls the reusable `projectbluefin/testsuite` E2E workflow with `suites: common`
+- Calls the local `.github/workflows/run-testsuite.yml` wrapper, which centralizes the pinned `projectbluefin/testsuite` SHA
 - Validates the common layer against three downstream images:
   - `ghcr.io/ublue-os/bluefin:latest`
   - `ghcr.io/ublue-os/bluefin:lts`
@@ -20,9 +20,23 @@
 - Builds the PR's `common` layer candidate first
 - Composes a downstream test image from `ghcr.io/ublue-os/bluefin:latest` by overlaying `/system_files/shared` and `/system_files/bluefin`
 - Recompiles GSettings schemas in the composed image
-- Pushes the composed image to GHCR and runs the reusable `projectbluefin/testsuite` workflow with `suites: common`
+- Pushes the composed image to GHCR and runs the local testsuite wrapper with `suites: common`
 
 This is the pre-merge gate for common-layer changes, so regressions can fail before merge instead of waiting for post-merge E2E.
+In branch protection today it is still an advisory/non-required signal; `build.yml` remains the required merge check.
+
+## Promotion-candidate feedback loop
+
+**File:** `.github/workflows/promotion-candidate-e2e.yml`
+
+- Runs weekly on Tuesdays before the downstream Bluefin promotion workflows
+- Tests the exact candidate tags used for promotion from common's side:
+  - `ghcr.io/projectbluefin/bluefin:testing`
+  - `ghcr.io/projectbluefin/bluefin:lts-testing`
+- Runs `smoke,common` to add a boot/basic-usage signal on top of the shared-layer checks
+- Uses the same local testsuite wrapper as PR/post-merge workflows, so the testsuite SHA stays aligned
+
+This is **not** a full installer gate. It is the smallest safe repo-local improvement common can make without editing downstream image repos or installer pipelines.
 
 ## Known CI caveats and quarantines
 
@@ -34,4 +48,4 @@ This is the pre-merge gate for common-layer changes, so regressions can fail bef
 
 ## Testsuite SHA pin
 
-`run-testsuite.yml` in `projectbluefin/bluefin` pins the testsuite SHA. When the pin lags behind `main`, quarantined scenarios may run and cause spurious failures. Renovate manages the pin automatically once it's set to a SHA (not `@main`). After any testsuite fix merges, approve the Renovate bump PR promptly.
+`common/.github/workflows/run-testsuite.yml` now pins the testsuite SHA for all repo-local callers. When the pin lags behind `main`, quarantined scenarios may run and cause spurious failures. `common` does not yet have Renovate config, so update this one wrapper file deliberately whenever testsuite fixes land.

--- a/docs/skills/image-registry.md
+++ b/docs/skills/image-registry.md
@@ -14,6 +14,8 @@ sign-off.** This would break OTA updates, E2E CI, and the rollback helper for al
 |---|---|---|
 | `ghcr.io/ublue-os/bluefin*` | ✅ Active production | All Bluefin image variants |
 | `ghcr.io/ublue-os/bluefin:lts` | ✅ Active production | LTS stream |
+| `ghcr.io/projectbluefin/bluefin:testing` | ✅ Active testing | Bluefin testing candidate tag |
+| `ghcr.io/projectbluefin/bluefin:lts-testing` | ✅ Active testing | Bluefin LTS testing candidate tag |
 | `ghcr.io/ublue-os/brew` | ✅ Active | Homebrew layer consumed by bluefin |
 | `ghcr.io/ublue-os/akmods-*` | ✅ Active | Kernel modules |
 | `ghcr.io/projectbluefin/common` | ✅ Active | Common shared layer (this repo) |
@@ -26,6 +28,15 @@ sign-off.** This would break OTA updates, E2E CI, and the rollback helper for al
 - `system_files/bluefin/usr/bin/ublue-rollback-helper` — reads `IMAGE_VENDOR` from
   `image-info.json` to construct the registry path; changing the vendor changes the OTA target
 - Any ujust recipe that references the image registry for rollback/rebase
+
+## Narrow exception for testing-stream gates
+
+`common/.github/workflows/promotion-candidate-e2e.yml` is allowed to reference:
+
+- `ghcr.io/projectbluefin/bluefin:testing`
+- `ghcr.io/projectbluefin/bluefin:lts-testing`
+
+Those are testing-only candidate tags used to add common-side promotion feedback. They are **not** production OTA targets. `validate.yml` explicitly whitelists only these two refs; all other `ghcr.io/projectbluefin/bluefin*` workflow refs remain blocked.
 
 ## How ublue-rollback-helper uses the registry
 

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -1,0 +1,57 @@
+# Common workflow map
+
+Load this when you need to understand **what each GitHub workflow in `projectbluefin/common` is for** and which one to edit.
+
+`common` is a **shared OCI layer repo**, not a standalone product image repo. Its workflows exist to protect the layer that flows into `bluefin`, `bluefin-lts`, and `dakota`.
+
+## Workflow groups
+
+| Workflow | Purpose | When to touch it |
+|---|---|---|
+| `validate.yml` | Main PR gate: submodule drift, `just check`, shellcheck, image-registry guard, dconf parity, pre-commit | Tightening repo-local validation or policy guards |
+| `validate-brewfiles.yaml` | Validates Brewfile correctness | Changing Brewfile structure or Brewfile validation rules |
+| `build.yml` | Builds and publishes the `common` OCI layer on merge | Changing how the shared layer is built or pushed |
+| `pr-e2e.yml` | Pre-merge composed-image gate for the PR's common layer | Changing how PR-time downstream composition is tested |
+| `e2e.yml` | Post-merge common-suite validation against Bluefin stable, Bluefin LTS, and Dakota | Changing shipped-layer validation after merge |
+| `run-testsuite.yml` | Local wrapper that centralizes the pinned `projectbluefin/testsuite` SHA | Updating the shared testsuite pin or common-side testsuite wiring |
+| `promotion-candidate-e2e.yml` | Weekly smoke/common check against `bluefin:testing` and `bluefin:lts-testing` | Adjusting common-side signal before downstream Tuesday promotions |
+| `skill-drift.yml` | Warns when implementation changes land without matching docs/skills updates | Adjusting doc-drift coverage or path mapping |
+| `sync-codeowners.yml` | Keeps CODEOWNERS/policy state in sync | Governance / CODEOWNERS automation work |
+| `release.yml` | Monthly/versioned OCI release flow | Changing versioned layer release behavior |
+| `bonedigger.yml` | Issue lifecycle / queue automation | Changing common's claim/queue automation |
+| `hive-progress-sync.yml` | Publishes common repo progress into Hive state | Changing Hive reporting or dashboard sync behavior |
+
+## Mental model
+
+### Validation and policy
+
+`validate.yml`, `validate-brewfiles.yaml`, and `skill-drift.yml` are about catching repo-local mistakes **before merge**.
+
+### Shared-layer build and release
+
+`build.yml` and `release.yml` are about shipping the `common` layer itself.
+
+### Downstream behavior checks
+
+`pr-e2e.yml`, `e2e.yml`, `run-testsuite.yml`, and `promotion-candidate-e2e.yml` exist because `common` only proves itself when composed into downstream images.
+
+### Factory operations
+
+`bonedigger.yml`, `sync-codeowners.yml`, and `hive-progress-sync.yml` are factory-policy workflows rather than image-test workflows.
+
+## Which skill to load next
+
+| If the work is about... | Load |
+|---|---|
+| Workflow pins, skill-drift, floating-tag guard | `ci-tooling.md` |
+| Pre/post-merge or promotion-candidate tests | `e2e-ci.md` |
+| CODEOWNERS or governance policy | `governance.md` |
+| Queue state / lifecycle | `queue-dashboard.md` and Hive context if needed |
+
+## Hard rule
+
+When editing workflows here, preserve the repo boundary:
+
+- `common` validates the **shared layer**
+- downstream image repos validate their **image-specific** behavior
+- reusable CI logic should live in `projectbluefin/actions`, not be duplicated inline unless the logic is truly `common`-specific


### PR DESCRIPTION
## What changed
- Add the repo-local ACMM / AI-safety guardrails prepared in this branch
- Update the matching docs/skills alongside the workflow or policy change

## Validation
- Ran the repo-appropriate existing validation commands locally for this change set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-PR skill-drift validation checks
  * Added weekly/manual promotion-candidate E2E testing for candidate images

* **Improvements**
  * Centralized and simplified E2E test orchestration across CI
  * Stricter image-reference validation to catch regressions early
  * Expanded CI and workflow documentation (README, agents/skills guides)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->