### PR TITLE
fix(deps): add Renovate config for GHA version tracking

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,35 +1,27 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>ublue-os/renovate-config:org-inherited-config"
+    "config:recommended",
   ],
+  "baseBranchPatterns": ["main"],
+  "branchPrefix": "renovate/",
+  "schedule": ["* 0-3 * * 1"],
+  "enabledManagers": ["github-actions"],
 
-  "git-submodules": {
-    "enabled": true
-  },
+  // Do not rebase when the default branch is updated
+  "rebaseWhen": "never",
 
-  "dockerfile": {
-    "managerFilePatterns": ["^Containerfile$"]
-  },
-
-  "customManagers": [
+  "packageRules": [
     {
-      "customType": "regex",
-      "managerFilePatterns": ["^Containerfile$"],
-      "matchStrings": [
-        "https://github\\.com/ublue-os/artwork/releases/download/bluefin-v(?<currentValue>[0-9\\-]+)/bluefin-wallpapers\\.tar\\.zstd"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "ublue-os/artwork"
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "pinDigests": true
     },
     {
-      "customType": "regex",
-      "managerFilePatterns": ["^Containerfile$"],
-      "matchStrings": [
-        "COPY --from=(?<depName>ghcr\\.io/ublue-os/bluefin-wallpapers-gnome):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
+      "automerge": true,
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the inherited Renovate config with repo-local GitHub Actions tracking
- pin action updates to full SHAs
- automerge minor and patch action updates on a Monday schedule

Closes #410