### PR TITLE
fix: bug batch may23 — toggle-devmode tag, branding update

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -50,9 +50,10 @@ toggle-devmode:
     set -e
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
     IMAGE_NAME="$(jq -rc '."image-name"' "${IMAGE_INFO_FILE}")"
-    IMAGE_REF="$(jq -rc '."image-ref"' "${IMAGE_INFO_FILE}" | sed "s/.*ghcr/ghcr/")"
-    CURRENT_IMAGE="${IMAGE_REF}:$(jq -rc '."image-tag"' "${IMAGE_INFO_FILE}")"
     IMAGE_BASE_NAME="$(cut -f1 -d\- <<< "${IMAGE_NAME}")"
+    # Use the booted deployment reference so stable-daily images get the correct tag
+    # Strip transport prefix (ostree-image-signed:docker://, ostree-unverified-registry:, etc.)
+    CURRENT_IMAGE="$(rpm-ostree status -b --json | jq -rc '.deployments[0]."container-image-reference"' | sed -E 's|^.*://||; s|^[a-z-]+:||')"
     set +e
 
     if grep -q -E -e "dx$" <<< "${IMAGE_NAME}" ; then


### PR DESCRIPTION
Rebased from #346 (castrojo's fork PR). Carries the salvageable fixes:

- **toggle-devmode**: Use `rpm-ostree status` to derive `CURRENT_IMAGE` instead of parsing `image-info.json` — fixes stable-daily images getting wrong tag (#346)
- **bluefin-branding**: submodule bump

Dropped (moved to aurorafin-shared upstream):
- apps.just changes
- default.just changes

Readymade dock fix already landed via #353.

Closes #346

Co-authored-by: castrojo <castrojo@users.noreply.github.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>