### PR TITLE
fix(ci): add bonedigger lifecycle workflow

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   bonedigger:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@2a734ae2095cdce9507b904d9fc83d836955c0f5
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@743f56403af826b148d2841524faa1edb68a4538
     with:
       brand_name: "Common"
       brand_emoji: "🧱"


### PR DESCRIPTION
## Summary
- align common's bonedigger workflow with the current bluefin reusable lifecycle workflow pin
- keep the common-specific brand name and emoji

## Test plan
- just check

Closes #409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow infrastructure to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->