### PR TITLE
fix(governance): add knuckle to sync-codeowners matrix

### DIFF
--- a/.github/workflows/sync-codeowners.yml
+++ b/.github/workflows/sync-codeowners.yml
@@ -39,7 +39,7 @@ jobs:
             exit 0
           fi
 
-          for repo in bluefin bluefin-lts dakota; do
+          for repo in bluefin bluefin-lts dakota knuckle; do
             echo "--- Syncing $repo ---"
 
             # Fetch current file
@@ -83,7 +83,7 @@ jobs:
 
           echo "Desired triagers: $(echo "$DESIRED" | tr '\n' ' ')"
 
-          for repo in common bluefin bluefin-lts dakota; do
+          for repo in common bluefin bluefin-lts dakota knuckle; do
             echo "--- Reconciling permissions for $repo ---"
 
             CURRENT=$(gh api "repos/projectbluefin/$repo/collaborators?affiliation=direct" \

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -30,7 +30,7 @@ docs/**  @handle1 @handle2
 
 **To add/remove a triager:** edit the two active lines inside the sentinel block in
 `common/.github/CODEOWNERS` → commit to `main` → the sync workflow pushes the change to
-`bluefin`, `bluefin-lts`, and `dakota` automatically.
+`bluefin`, `bluefin-lts`, `dakota`, and `knuckle` automatically.
 
 ### Per-repo ownership (maintained in each repo separately)
 
@@ -40,13 +40,14 @@ docs/**  @handle1 @handle2
 | `bluefin` | `@castrojo @p5 @m2Giles @tulilirockz` | `.github/workflows/`, `Justfile`, `build_files/` |
 | `bluefin-lts` | same as bluefin | same + `image-versions.yml` exempt (Renovate) |
 | `dakota` | same as bluefin | same + `elements/` |
+| `knuckle` | same as bluefin | same as bluefin |
 
 ## Sync workflow
 
 **File:** `.github/workflows/sync-codeowners.yml` in `projectbluefin/common`
 
 - Triggers on `push` to `main` when `.github/CODEOWNERS` changes, plus `workflow_dispatch`
-- Extracts the `BEGIN/END TRIAGERS` block and replaces it in `bluefin`, `bluefin-lts`, `dakota`
+- Extracts the `BEGIN/END TRIAGERS` block and replaces it in `bluefin`, `bluefin-lts`, `dakota`, `knuckle`
 - Skips repos where the block is already identical (no noise commits)
 - Uses **mergeraptor** (`MERGERAPTOR_APP_ID` / `MERGERAPTOR_PRIVATE_KEY` org secrets) for cross-repo writes
 


### PR DESCRIPTION
Summary:
- add knuckle to the CODEOWNERS sync loop
- reconcile triager permissions for knuckle too
- update governance docs to include knuckle in the downstream sync set

Closes #414