### PR TITLE
chore: add Renovate automerge rule for digest/pin/patch/minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>projectbluefin/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",
+      "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the automerge packageRule to `renovate.json` so Renovate PRs for digest/pin/patch/minor updates are automatically merged when CI passes.

Matches the pattern already in `projectbluefin/bluefin` and `projectbluefin/testsuite`.