### PR TITLE
fix(ci): close factory determinism gaps in pipeline workflows

### DIFF
--- a/.github/workflows/promotion-candidate-e2e.yml
+++ b/.github/workflows/promotion-candidate-e2e.yml
@@ -27,3 +27,25 @@ jobs:
     with:
       image: ${{ matrix.image }}
       suites: ${{ matrix.suites }}
+
+  notify-on-failure:
+    name: "File issue on E2E failure"
+    needs: [e2e]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File promotion-blocker issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+          gh issue create \
+            --repo "$REPO" \
+            --title "🚨 Promotion candidate E2E failed — ${DATE}" \
+            --body "The Tuesday promotion-candidate E2E suite failed before the weekly promotion window. **Do NOT promote** \`bluefin:testing\` or \`bluefin:lts-testing\` until resolved. Workflow run: ${RUN_URL}" \
+            --label "kind/bug" \
+            --label "kind/github-action"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,5 @@ jobs:
           draft: false
           prerelease: false
           makeLatest: true
+          allowUpdates: true
+          skipIfReleaseExists: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,17 @@ jobs:
           submodules: true
 
 
+      - name: Check submodule drift
+        shell: bash
+        run: |
+          if git submodule status | grep -E '^[+-]'; then
+            echo ""
+            echo "ERROR: A submodule is dirty (+) or uninitialized (-)."
+            echo "Ensure all submodules are committed at a clean ref."
+            exit 1
+          fi
+          echo "All submodules are clean."
+
       - name: Install just
         uses: taiki-e/install-action@3bcad52036b48c4f9e2249c2ebd39a428ef3d98f # just
         with:


### PR DESCRIPTION
## Summary

Addresses four architectural gaps found during a factory determinism review.

## Changes

### 1. `promotion-candidate-e2e.yml` — wire the gate to hive-status

The Tuesday promotion-candidate suite was described as a promotion gate but had no signal path: failures were visible only to someone actively watching the Actions tab. Adds a `notify-on-failure` job that auto-files a `kind/bug` issue when the suite fails, so `hive-status` surfaces the blocker before the promotion window.

### 2. `validate.yml` — add the missing submodule drift check

`AGENTS.md` claimed `validate.yml` checked submodule drift, but the step didn't exist. A PR could silently move the `bluefin-branding` submodule pointer to an unreviewed commit and pass all CI gates. Adds a `git submodule status` check that fails if any submodule is dirty (`+`) or uninitialized (`-`).

### 3. `release.yml` — idempotent tag creation

Tag is `v$(date +'%Y.%m')`. A mid-month `workflow_dispatch` followed by the 1st-of-month cron generates the same tag twice, causing the cron run to fail. Adds `allowUpdates: true` so duplicate-tag runs succeed silently.

---

Companion PR for the org-level policy gap: projectbluefin/.github#6

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved E2E test failure detection with automated issue creation for promotion-candidate failures
  * Enhanced release workflow to support updating existing releases
  * Added submodule validation checks to the CI pipeline to ensure repository integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->