### PR TITLE
fix: add help: URI handler to redirect to GNOME help website

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@7380aceca089f5ade835f3f5497ab6e39a2eac88 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@ac71926fa7ee51781928fe72f0a1f21fcf8e81da # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@ac71926fa7ee51781928fe72f0a1f21fcf8e81da # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@303e7163a3777510b2bed048f3e6a3a86b57523d # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@25c9ad0e8fe6ab13036646123d84641c00b7829b # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@29847177e8fbeb5a251e09d9bd84439b319eb695 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@29847177e8fbeb5a251e09d9bd84439b319eb695 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@7380aceca089f5ade835f3f5497ab6e39a2eac88 # main
     permissions:
       contents: read
       packages: write

--- a/system_files/bluefin/usr/share/applications/bluefin-help.desktop
+++ b/system_files/bluefin/usr/share/applications/bluefin-help.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Bluefin Help
+Comment=Open GNOME help pages in the browser
+Exec=xdg-open https://help.gnome.org/
+Icon=help-browser
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/help;x-scheme-handler/ghelp;
+NoDisplay=true


### PR DESCRIPTION
Bluefin removes `yelp`, leaving no registered handler for `help:` and `ghelp:` URI schemes. This breaks the Nautilus Templates folder tooltip's **Learn More** button (`help:gnome-help/files-templates`).

Adds a minimal `.desktop` file that registers as the `x-scheme-handler/help` and `x-scheme-handler/ghelp` handler, redirecting to `https://help.gnome.org/`.

Closes projectbluefin/bluefin#306

Supersedes #494 (which had accumulated 613 commits of divergence from main).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>