### PR TITLE
feat(just): add ujust install-asus for ASUS laptop tools

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@25c9ad0e8fe6ab13036646123d84641c00b7829b # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@ac71926fa7ee51781928fe72f0a1f21fcf8e81da # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@ac71926fa7ee51781928fe72f0a1f21fcf8e81da # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@303e7163a3777510b2bed048f3e6a3a86b57523d # main
     permissions:
       contents: read
       packages: write

--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -74,3 +74,23 @@ cncf:
     fi
     bbrew -f "/usr/share/ublue-os/homebrew/cncf.Brewfile"
     [[ -t 0 ]] && ujust --choose || true
+
+# Install ASUS laptop tools (asusctl daemon + ROG Control Center) | https://gitlab.com/asus-linux/asusctl
+[group('Apps')]
+install-asus:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Installing ASUS laptop tools..."
+    brew install --cask ublue-os/tap/asusctl-linux
+    brew install --cask ublue-os/tap/rog-control-center-linux
+    echo ""
+    echo "Enabling system services..."
+    sudo systemctl enable --now asusd.service asus-shutdown.service
+    sudo udevadm control --reload
+    sudo udevadm trigger
+    echo ""
+    echo "Enabling user daemon..."
+    systemctl --user daemon-reload
+    systemctl --user enable --now asusd-user.service
+    echo ""
+    echo "ASUS tools installed! Run 'rog-control-center' or find it in your app launcher."


### PR DESCRIPTION
## Summary

Adds `ujust install-asus` recipe to install ASUS laptop tools:
- **asusctl** — daemon for ASUS system management (fan curves, LEDs, power profiles)
- **ROG Control Center** — GUI for ASUS ROG features

Both are installed via the `ublue-os/tap` Homebrew cask. The recipe also enables the required system services (`asusd`, `asus-shutdown`) and user daemon (`asusd-user`).

## Background
Cherry-pick of castrojo/common#339 which could not run CI due to fork ghcr.io package permission restriction. Same code, same outcome.

Closes #339

🔗 ASUS Linux project: https://gitlab.com/asus-linux/asusctl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ASUS laptop support with a new installation option that deploys ASUS control software and utilities. The installation process automatically configures system services, device drivers, and user-level integrations to ensure proper operation and access to ASUS-specific hardware features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->