### PR TITLE
ci: bump testsuite SHA to ac71926 (rpm-ostree + AT-SPI fixes)

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@25c9ad0e8fe6ab13036646123d84641c00b7829b # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@ac71926fa7ee51781928fe72f0a1f21fcf8e81da # main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Bumps the pinned testsuite SHA from `25c9ad0e` (stale) to `ac71926` which includes all recent e2e workflow fixes:
- #321: dnf fallback for brew CLI tools
- #322: AT-SPI re-query after toolkit-accessibility (unblocks bluefin:lts)
- #323: rpm-ostree `--apply-live` fallback on ostree images (unblocks common suite on composed PR images)

This unblocks PRs #501 and #503 which were failing due to the stale SHA.