### PR TITLE
ci: bump testsuite SHA to fcbfd6a (fix smoke exit code)

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@25c9ad0e8fe6ab13036646123d84641c00b7829b # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@303e7163a3777510b2bed048f3e6a3a86b57523d # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9c7490f24fd9240f0dab048a331da3abdb226238 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@3e8cc0d959810f7d59ce3364234b728ed779354c # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@3e8cc0d959810f7d59ce3364234b728ed779354c # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@f7d8bd9d3bf41d265b9a4cbf11cc5d1e3e35bb44 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@cdc9891c0da58fa385d4b06194d1d79e384d45bd # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9c7490f24fd9240f0dab048a331da3abdb226238 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@51b2c54f3c28bf34675f95e2a14eeb5e52d89829 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@cdc9891c0da58fa385d4b06194d1d79e384d45bd # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@fcbfd6ac4f5d7ae5c41e4da2abc30e6de70deb61 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@51b2c54f3c28bf34675f95e2a14eeb5e52d89829 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@303e7163a3777510b2bed048f3e6a3a86b57523d # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@fcbfd6ac4f5d7ae5c41e4da2abc30e6de70deb61 # main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@f7d8bd9d3bf41d265b9a4cbf11cc5d1e3e35bb44 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9392c9ec9e048a24f406e3fcde7a92c33f9e18f6 # main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Bumps testsuite SHA to `fcbfd6a` (was `303e716`) which adds all e2e workflow fixes including the critical **Patch 5** that wraps `stop_display_manager()` in try/except.

Without this fix, E2E smoke always exits code 1 (CalledProcessError on `sudo systemctl stop gdm` inside the container — no systemd PID 1), masking all 50 passing scenarios.

Fixes included since `25c9ad0` (previous pin):
- #321: dnf fallback for brew CLI tools
- #322: AT-SPI re-query after toolkit-accessibility
- #323: rpm-ostree `--apply-live` fallback on ostree images
- #324: stop bootc/rpm-ostree lock before install
- #325: ignore fwupd-refresh.service in VM health check
- **#327: wrap stop_display_manager() in try/except (critical — fixes exit code 1)**

This is the minimum required to get green E2E smoke runs in all consumer repos.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow reference to a newer pinned revision of a downstream reusable workflow. This is an internal CI maintenance change with no changes to runtime behavior or public interfaces. User-facing impact is minimal; tests and automation consume the updated workflow reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->