### PR TITLE
fix: add help: URI handler to redirect to GNOME help website

### DIFF
--- a/system_files/bluefin/usr/share/applications/bluefin-help.desktop
+++ b/system_files/bluefin/usr/share/applications/bluefin-help.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Bluefin Help
+Comment=Open GNOME help pages in the browser
+Exec=xdg-open https://help.gnome.org/
+Icon=help-browser
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/help;x-scheme-handler/ghelp;
+NoDisplay=true


### PR DESCRIPTION
Rebased from #501 — stale SHA bump commits stripped, only the fix remains.

Adds a `.desktop` file that registers `help:` URI handling to redirect to the GNOME help website.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>