### PR TITLE
fix: align rechunker-group-fix with bootc upstream recommendations

### DIFF
--- a/system_files/shared/usr/bin/rechunker-group-fix
+++ b/system_files/shared/usr/bin/rechunker-group-fix
@@ -11,7 +11,10 @@
 GSHADOW_FILE="/etc/gshadow"
 GROUP_FILE="/etc/group"
 
-while IFS=: read -r group_name _rest; do
-    grep -q "^${group_name}:" "$GSHADOW_FILE" 2>/dev/null || \
-        printf '%s:!*::\n' "$group_name" >> "$GSHADOW_FILE"
-done < "$GROUP_FILE"
+(
+    flock -x 9
+    while IFS=: read -r group_name _rest; do
+        grep -q "^${group_name}:" "$GSHADOW_FILE" 2>/dev/null || \
+            printf '%s:!*::\n' "$group_name" >> "$GSHADOW_FILE"
+    done < "$GROUP_FILE"
+) 9>>"${GSHADOW_FILE}"

--- a/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
+++ b/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
@@ -15,10 +15,11 @@
 [Unit]
 Description=Fix groups for Legacy rechunker
 ConditionPathExists=/run/ostree-booted
+DefaultDependencies=no
 Wants=local-fs.target
 After=local-fs.target
-Before=systemd-user-sessions.service
-# Before=systemd-sysusers.service
+After=bootc-sysusers-shadow-sync.service
+Before=systemd-sysusers.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## What

Two fixes to align with feedback from Colin Walters (bootc upstream maintainer):

**Service ordering** (`rechunker-group-fix.service`):
- `Before=systemd-sysusers.service` — intercept *before* sysusers fails, not after
- `After=bootc-sysusers-shadow-sync.service` — explicit ordering for coexistence when bootc ≥1.16 ships its own fix ([bootc#2207](https://github.com/bootc-dev/bootc/pull/2207), merged May 25)
- `DefaultDependencies=no` — correct for early-boot units

**File locking** (`rechunker-group-fix` script):
- Wrap gshadow writes in `flock` to prevent corruption from concurrent access

## Why

bootc upstream landed a proper fix in [bootc#2207](https://github.com/bootc-dev/bootc/pull/2207) as `bootc-sysusers-shadow-sync.service`. That service runs `Before=systemd-sysusers.service`. Our service was running `After=local-fs.target` (too late — after sysusers already failed) and had no file locking.

The upstream fix is not yet in a Fedora or EPEL release, so this service remains necessary as a bridge. These changes ensure correct behavior when bootc 1.16+ eventually ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated system service boot sequence dependencies and ordering to ensure proper initialization of group file synchronization services.

* **Chores**
  * Group and shadow file synchronization operations now implement exclusive file locking mechanisms during updates to maintain data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->