### PR TITLE
fix: set summer wallpaper default and run on first login

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -5,8 +5,8 @@ favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop
 enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'custom-command-list@storageb.github.com', 'dash-to-dock@micxgx.gmail.com', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io']
 
 [org.gnome.desktop.background]
-picture-uri='file:///usr/share/backgrounds/bluefin/12-bluefin.xml'
-picture-uri-dark='file:///usr/share/backgrounds/bluefin/12-bluefin.xml'
+picture-uri='file:///usr/share/backgrounds/bluefin/06-bluefin.xml'
+picture-uri-dark='file:///usr/share/backgrounds/bluefin/06-bluefin.xml'
 picture-options='zoom'
 primary-color='000000'
 secondary-color='FFFFFF'

--- a/system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh
+++ b/system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh
@@ -8,3 +8,6 @@ version-script dynamic-wallpaper user 1 || exit 0
 
 echo "Enabling dynamic wallpaper timer"
 systemctl --user enable --now bluefin-dynamic-wallpaper.timer
+
+echo "Setting initial dynamic wallpaper"
+/usr/libexec/bluefin-dynamic-wallpaper || true


### PR DESCRIPTION
## Problem

New install ISOs were showing the December winter wallpaper. Root cause: **two issues**:

### 1. Hardcoded December default in gschema override

When wallpapers were first added in PR #34 (December 2025), the gschema override was correctly set to `12-bluefin.xml`. It was never updated after that. PR #349 added the dynamic wallpaper timer but didn't update the static default — so every fresh install still shows December wallpaper as the initial value.

### 2. 1-minute delay before timer fires

The user-setup hook only enabled the timer (`OnBootSec=1min`), meaning there was a visible window where the wrong wallpaper was shown on first login.

## Fix

1. **Update gschema default** to `06-bluefin.xml` for the current summer season
2. **Run `bluefin-dynamic-wallpaper` immediately** in the user-setup hook (in addition to enabling the timer), so the correct season wallpaper is applied the moment the hook runs — no delay, no wrong wallpaper flash

The script already handles geoclue failures gracefully (falls back to northern hemisphere), so running it eagerly is safe.