### PR TITLE
fix(ci): remove emoji from promotion-candidate E2E failure issue title

### DIFF
--- a/.github/workflows/promotion-candidate-e2e.yml
+++ b/.github/workflows/promotion-candidate-e2e.yml
@@ -45,7 +45,7 @@ jobs:
           DATE=$(date +'%Y-%m-%d')
           gh issue create \
             --repo "$REPO" \
-            --title "🚨 Promotion candidate E2E failed — ${DATE}" \
+            --title "ci: promotion candidate E2E failed — ${DATE}" \
             --body "The Tuesday promotion-candidate E2E suite failed before the weekly promotion window. **Do NOT promote** \`bluefin:testing\` or \`bluefin:lts-testing\` until resolved. Workflow run: ${RUN_URL}" \
             --label "kind/bug" \
             --label "kind/github-action"


### PR DESCRIPTION
Org style (AGENTS.md) prohibits emoji in issue titles. The auto-filed failure issue from `promotion-candidate-e2e.yml` was using an emoji prefix.

Before: `🚨 Promotion candidate E2E failed — ${DATE}`
After: `ci: promotion candidate E2E failed — ${DATE}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for test failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->