### PR TITLE
fix(ujust,gnome): fix changelog repos + LTS support + BT auto-switch

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -9,16 +9,23 @@ changelogs:
     # Get Image Tag
     TAG="$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)"
 
-    # If stable or gts, get changelogs from Github Releases
-    if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
-        CONTENT="$(curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    # Select the correct upstream repo based on image stream
+    if [[ "$TAG" =~ ^lts ]]; then
+        REPO="projectbluefin/bluefin-lts"
+    else
+        REPO="projectbluefin/bluefin"
     fi
 
-    # Display Content with Glow, otherwise fallback to rpm-ostree changelogs (stable-daily/latest/desynced)
+    # If stable, gts, or lts, fetch from GitHub Releases
+    if [[ "$TAG" =~ gts$|stable$|^lts ]]; then
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
+        CONTENT="$(curl -Ls "https://api.github.com/repos/${REPO}/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    fi
+
+    # Display Content with Glow, otherwise fallback to latest release for this repo
     if [[ -n "${CONTENT:-}" ]]; then
         echo "$CONTENT" | glow -p
     else
         echo "WARN: Could not find a release specific to your image"
-        curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases/latest" | jq -r ".body" | glow -p
+        curl -Ls "https://api.github.com/repos/${REPO}/releases/latest" | jq -r ".body" | glow -p
     fi

--- a/system_files/shared/usr/share/pipewire/pipewire-pulse.conf.d/50-bluefin-bt-switch.conf
+++ b/system_files/shared/usr/share/pipewire/pipewire-pulse.conf.d/50-bluefin-bt-switch.conf
@@ -1,0 +1,5 @@
+# Auto-switch audio output to newly connected Bluetooth devices
+# and prefer A2DP (high-quality audio) over HFP/HSP (headset profile)
+pulse.cmd = [
+  { cmd = "load-module" args = "module-switch-on-connect" }
+]


### PR DESCRIPTION
Two independent bug fixes from issue triage.

## fix(ujust): changelog namespace + LTS support (Closes #16)

changelog.just had two bugs:
1. Hardcoded `ublue-os/bluefin` — wrong since org migration to projectbluefin
2. LTS users (`lts`, `lts-hwe`) always fetched releases from the non-LTS repo — they should use `projectbluefin/bluefin-lts`

Fix: select repo based on image tag (`lts*` -> `bluefin-lts`, else `bluefin`), and include `lts` tags in the release fetch path alongside `stable`/`gts`.

## feat(gnome): BT audio auto-switch on connect (Closes #268)

Add a pipewire-pulse drop-in at `/usr/share/pipewire/pipewire-pulse.conf.d/50-bluefin-bt-switch.conf` that loads `module-switch-on-connect`. This makes the system automatically select a newly connected Bluetooth device as audio output and prefer A2DP over HFP/HSP headset mode — no per-user config required.

## Verification
- changelog.just: logic tested manually (lts branch -> bluefin-lts, stable -> bluefin)
- pipewire config: matches the workaround documented in #268 with correct PipeWire conf.d syntax