### PR TITLE
feat(fonts): set Adwaita Mono as default monospace, move opendyslexic to Homebrew

### DIFF
--- a/docs/factory/agentic-model.md
+++ b/docs/factory/agentic-model.md
@@ -42,6 +42,23 @@ Per-repo specifics live in that repo's `AGENTS.md` — start there, then load th
 | `testsuite` | `main` | Test repo — no testing branch |
 | `actions` | `main` | Shared actions — no testing branch |
 
+**Branch creation rule:** Always cut feature branches from the PR target, not from whatever is currently checked out.
+
+```bash
+# Before creating a branch, always fetch and branch from the target:
+git fetch projectbluefin <target>
+git checkout -b feat/my-change projectbluefin/<target>
+# Example for bluefin (target = testing):
+git fetch projectbluefin testing
+git checkout -b feat/my-change projectbluefin/testing
+```
+
+Branching from the wrong base (e.g. `testing` when target is `main`, or vice versa) will cause the PR to show every diverged commit as new, polluting the diff and making review impossible. Verify before pushing:
+
+```bash
+git log feat/my-change ^projectbluefin/<target> --oneline  # must show ONLY your commits
+```
+
 ## Sensitive paths
 
 Changes to these paths require maintainer review before merge:

--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -17,6 +17,7 @@ clock-show-weekday=true
 font-antialiasing="rgba"
 font-name="Adwaita Sans 11"
 document-font-name="Adwaita Sans 12"
+monospace-font-name="Adwaita Mono 11"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]

--- a/system_files/shared/usr/share/ublue-os/homebrew/fonts.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/fonts.Brewfile
@@ -1,3 +1,4 @@
+cask "font-opendyslexic"
 cask "font-caskaydia-mono-nerd-font"
 cask "font-comic-shanns-mono-nerd-font"
 cask "font-droid-sans-mono-nerd-font"


### PR DESCRIPTION
## Summary

Set Adwaita Mono as the explicit default monospace font and move opendyslexic to Homebrew-managed fonts.

## Changes

- Add `monospace-font-name="Adwaita Mono 11"` to gschema override — without this, GNOME picks the highest-priority installed monospace font, which may not be Adwaita Mono when JetBrains Mono or nerd-fonts are present
- Add `font-opendyslexic` Homebrew cask to `fonts.Brewfile` — the RPM `opendyslexic-fonts` is being removed from the bluefin image; this keeps the accessibility font available to users via Homebrew

## Part of font cleanup

This is part of a broader effort to default all desktop fonts to Adwaita/Adwaita Mono and move font management to Homebrew. Companion PR in projectbluefin/bluefin removes `opendyslexic-fonts`, `jetbrains-mono-fonts-all`, and the `nerd-fonts` COPR install from the OCI image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive developer experience setup with configurable options for Docker, Podman, virtual machines, incus, and development tools
  * Virtual machine management capabilities
  * Incus container environment setup
  * Added OpenDyslexic font support

* **Settings**
  * Updated default monospace font to Adwaita Mono

<!-- end of auto-generated comment: release notes by coderabbit.ai -->