### PR TITLE
feat(ghostty): add GNOME profile for new users

### DIFF
--- a/system_files/shared/etc/skel/.config/ghostty/config.ghostty
+++ b/system_files/shared/etc/skel/.config/ghostty/config.ghostty
@@ -1,0 +1,37 @@
+# Bluefin GNOME profile for Ghostty
+# To override the theme, add `theme = <name>` to your config.
+# Run `ghostty +list-themes` to see all available themes.
+theme = Catppuccin Mocha
+
+# Run as a single GTK instance, consistent with GNOME app conventions
+gtk-single-instance = true
+
+# Show current working directory in the window subtitle
+window-subtitle = working-directory
+
+# Extend the terminal background color into the window padding for a seamless look
+window-padding-color = extend
+window-padding-balance = true
+
+# Disable the resize overlay — GNOME apps don't show these
+resize-overlay = never
+
+# F11 is the GNOME standard for fullscreen (overrides Ghostty's Ctrl+Enter default)
+keybind = f11=toggle_fullscreen
+
+# Hide the mouse pointer while typing, matching GNOME Terminal and Ptyxis behavior
+mouse-hide-while-typing = true
+
+# Send a desktop notification when a command finishes in an unfocused window —
+# useful for long distrobox builds
+notify-on-command-finish = unfocused
+notify-on-command-finish-action = no-bell,notify
+
+# More comfortable padding — default of 2pt is very tight
+window-padding-x = 8
+window-padding-y = 4
+
+# Modern default window size — ensures the MOTD renders at the correct width
+# on first open instead of the legacy 80x24 default
+window-width = 132
+window-height = 36


### PR DESCRIPTION
Ships a skel default at ~/.config/ghostty/config.ghostty for all Bluefin variants. Provides a GNOME-native Ghostty experience out of the box:

- theme: Catppuccin Mocha, matching Bluefin's Ptyxis palette
- gtk-single-instance: true, GNOME app convention
- window-subtitle: working-directory, CWD in window subtitle
- window-padding-color: extend + balanced, seamless look
- window-padding: 8x4pt, comfortable breathing room
- window-width/height: 132x36, fixes MOTD race on first open
- resize-overlay: never, GNOME apps don't show these
- keybind f11: toggle_fullscreen, GNOME standard
- mouse-hide-while-typing: true, matches GNOME Terminal/Ptyxis
- notify-on-command-finish: unfocused desktop notification for builds

Placed in system_files/shared/ so all variants (bluefin, bluefin-lts, dakota) pick it up, maybe we can switch the other two at some point. 

Closes #296

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!--
## Thank you for contributing

Please [read the README](../README.md) and ensure your change goes to the correct directory.

### Changes related to Bluefin
If your change is gnome or bluefin change, make sure you put the change under the  system_files/bluefin/ folder.

## Global changes
Global changes that are not GNOME-specific should go in the `system_files/shared/` folder. This is also used by [Aurora](https://github.com/ublue-os/aurora), so ensure no GNOME-related changes end up here.

-->

## PR pipeline

```
opened ──▶ review ──▶ approved ──▶ merged
                    [lgtm]      auto-merge
                                when CI green
```

> Add `do-not-merge` at any time to block automation.
> `/approve` or `lgtm` from a maintainer triggers merge queue.

## What does this change?

<!-- Required: one sentence -->

## Why?

<!-- Link the issue this closes: "Closes #NNN" -->
Closes #

## Checklist

- [ ] `just check` passes
- [ ] `pre-commit run --all-files` passes
- [ ] PR title follows Conventional Commits (`fix:`, `feat:`, `chore:`, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ghostty terminal configuration with Catppuccin Mocha color theme
  * Configured F11 keybinding for fullscreen toggle
  * Enabled desktop notifications when commands complete in unfocused windows
  * Optimized window padding and default dimensions (132x36) for improved usability
  * Enhanced terminal behavior including mouse pointer hiding while typing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->