### PR TITLE
feat(testing): expand shellcheck + add bats

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,21 +34,36 @@ jobs:
         run: |
           sudo apt-get install -y bats
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install pytest and pytest-cov
+        run: pip install pytest pytest-cov
 
-      - name: Run shellcheck
+      - name: Run shellcheck — extensionless scripts
         run: |
           shellcheck \
             system_files/shared/usr/bin/ublue-system-setup \
             system_files/shared/usr/bin/ublue-user-setup \
+            system_files/shared/usr/bin/ublue-privileged-setup \
+            system_files/shared/usr/bin/ublue-bling \
+            system_files/shared/usr/bin/luks-tpm2-autounlock \
             system_files/shared/usr/lib/ublue/setup-services/libsetup.sh
 
+      - name: Run shellcheck — .sh scripts
+        run: find system_files -name '*.sh' -print0 | xargs -0 shellcheck -e SC1091
+
       - name: Run pytest (hooks.py)
-        run: python3 -m pytest tests/test_hooks.py -v
+        run: python3 -m pytest tests/test_hooks.py -v --cov=tests --cov-report=term-missing
 
       - name: Run bats (libsetup.sh)
         run: bats tests/test_libsetup.bats
 
       - name: Run bats (setup scripts)
         run: bats tests/test_setup_scripts.bats
+
+      - name: Run bats (privileged setup)
+        run: bats tests/test_privileged_setup.bats
+
+      - name: Run bats (ublue-bling)
+        run: bats tests/test_bling.bats
+
+      - name: Run bats (luks-tpm2-autounlock)
+        run: bats tests/test_luks_tpm2.bats

--- a/Justfile
+++ b/Justfile
@@ -2,9 +2,12 @@ just := just_executable()
 
 # Run unit tests (pytest for hooks.py, bats for shell scripts)
 test:
-    python3 -m pytest tests/test_hooks.py -v
+    python3 -m pytest tests/test_hooks.py -v --cov=tests --cov-report=term-missing
     bats tests/test_libsetup.bats
     bats tests/test_setup_scripts.bats
+    bats tests/test_privileged_setup.bats
+    bats tests/test_bling.bats
+    bats tests/test_luks_tpm2.bats
 
 # Build the bluefin-common container locally
 build:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,176 @@
+# Testing in `projectbluefin/common`
+
+This document is the testing contract for the `common` repo. Read it before adding a new script to `system_files/`.
+
+## Quick Start
+
+```bash
+just test          # run full test suite (pytest + bats)
+just check         # lint Justfile
+pre-commit run --all-files  # hygiene checks (shellcheck, yaml, sha-pinning)
+```
+
+## What Must Be Tested
+
+### Rule: new script in `system_files/*/usr/bin/` → new test file in `tests/`
+
+Every script added to `system_files/*/usr/bin/` must have either:
+1. A `tests/test_<scriptname>.bats` file covering its branching logic, OR
+2. A documented exemption in this file explaining why tests are not feasible.
+
+Profile scripts (`etc/profile.d/*.sh`) are **shellcheck-only** — they run on login and have no testable logic beyond syntax.
+
+## Test Frameworks
+
+| Language | Framework | File pattern |
+|----------|-----------|-------------|
+| Shell scripts | [bats-core](https://bats-core.readthedocs.io/) | `tests/test_*.bats` |
+| Python hooks | pytest | `tests/test_*.py` |
+
+**Do not introduce additional frameworks.** `bats` for shell, `pytest` for Python. One convention, no exceptions.
+
+## Hardware Gate Boundary
+
+Some scripts interact with hardware that cannot be present in CI:
+
+| Script | Hardware dependency | Test boundary |
+|--------|--------------------|--------------------|
+| `luks-tpm2-autounlock` | TPM2 chip | Test UUID parsing, device resolution, flag construction. Mock `gum` and `systemd-cryptenroll` via PATH. Full integration: `projectbluefin/testsuite`. |
+| Any script using `gum` | Interactive TTY | Mock `gum` via PATH stub in `tests/` setup. |
+
+**Never block CI on hardware.** Extract hardware-dependent calls behind mocked system boundaries.
+
+## Bats Patterns
+
+### Standard test file structure
+
+```bash
+#!/usr/bin/env bats
+# Description of what's tested
+
+SCRIPT_UNDER_TEST="$BATS_TEST_DIRNAME/../path/to/script"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    # Mock any interactive commands via PATH
+    mkdir -p "${WORKDIR}/bin"
+    printf '#!/bin/bash\nexit 0\n' > "${WORKDIR}/bin/gum"
+    chmod +x "${WORKDIR}/bin/gum"
+    export PATH="${WORKDIR}/bin:${PATH}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+@test "script: describes expected behavior precisely" {
+    export SOME_CONFIG_FILE="${WORKDIR}/config.json"
+    echo '{"key": "value"}' > "${SOME_CONFIG_FILE}"
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "expected output" ]
+}
+```
+
+### Mocking system commands via PATH
+
+The canonical pattern for mocking any command (`gum`, `systemd-cryptenroll`, `bootc`, `rpm-ostree`):
+
+```bash
+setup() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/bin"
+
+    # Mock that always succeeds
+    printf '#!/bin/bash\nexit 0\n' > "${WORKDIR}/bin/gum"
+    chmod +x "${WORKDIR}/bin/gum"
+
+    # Mock that records its arguments for assertions
+    printf '#!/bin/bash\necho "$*" >> %s/calls.log\nexit 0\n' "${WORKDIR}" \
+        > "${WORKDIR}/bin/systemd-cryptenroll"
+    chmod +x "${WORKDIR}/bin/systemd-cryptenroll"
+
+    export PATH="${WORKDIR}/bin:${PATH}"
+}
+```
+
+Then in tests: `grep -q "expected-flag" "${WORKDIR}/calls.log"`
+
+### Making scripts testable via BASH_SOURCE guard
+
+For scripts with top-level interactive code, wrap the main flow:
+
+```bash
+# Functions defined here are always loaded
+get_foo() { ... }
+check_bar() { ... }
+
+# Main flow only runs when executed directly (not sourced for testing)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    gum confirm ...
+    # rest of main flow
+fi
+```
+
+Then in bats: `source "${SCRIPT}"` loads functions only. The interactive main flow does not run.
+
+### Testability overrides via environment variables
+
+For scripts that access system paths, use env-var overrides following the `:-` idiom:
+
+```bash
+CMDLINE_FILE="${CMDLINE_FILE:-/proc/cmdline}"
+CONFIG_FILE="${CONFIG_FILE:-/etc/config.json}"
+```
+
+In tests: `export CMDLINE_FILE="${WORKDIR}/cmdline"` before running or sourcing.
+
+This pattern is used in:
+- `ublue-privileged-setup` → `SETUP_CONFIG_FILE`, `HOOKS_VERBOSE`
+- `ublue-system-setup`, `ublue-user-setup` → same
+- `luks-tpm2-autounlock` → `CMDLINE_FILE`, `DISK_BY_UUID_DIR`, `DEV_DIR`
+- `ublue-bling` → `BLING_CLI_DIRECTORY`, `BLING_ENV_SCRIPT`
+
+## Exemptions
+
+Scripts exempt from behavioral testing (shellcheck-only):
+
+| Script | Reason |
+|--------|--------|
+| `etc/profile.d/caffeinate.sh` | Profile.d sourced script — sets aliases only, no branching logic |
+| `etc/profile.d/open.sh` | Profile.d sourced script — alias definition only |
+| `etc/profile.d/uutils.sh` | Profile.d sourced script — PATH manipulation only |
+| `etc/profile.d/ublue-fastfetch.sh` | Profile.d sourced script — display only |
+| `etc/profile.d/ublue-motd.sh` | Profile.d sourced script — display only |
+| `etc/profile.d/umotd.sh` | Profile.d sourced script — display only |
+| `usr/share/ublue-os/bling/bling.sh` | Sourced helper — sets aliases/functions, no side effects |
+| `usr/share/ublue-os/bling/env.sh` | Sourced helper — sets env vars only |
+| `usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh` | One-shot hook — logic tested indirectly via setup integration tests |
+
+**Adding an exemption:** add a row to this table with a one-sentence justification. Do not add exemptions for scripts with branching logic.
+
+## Coverage Targets
+
+| Layer | Tool | Current target |
+|-------|------|---------------|
+| Python hooks | pytest-cov | Reported per-PR (threshold TBD — see [#561](https://github.com/projectbluefin/common/issues/561)) |
+| Shell scripts | shellcheck | 100% of all `.sh` + `usr/bin` scripts |
+| Shell behavior | bats | All `usr/bin` scripts with branching logic |
+
+Coverage reporting is visible in every PR's CI output. A hard `--cov-fail-under` threshold will be set in Phase 3 once baseline is established (tracked in [#561](https://github.com/projectbluefin/common/issues/561)).
+
+## Test Files Reference
+
+| File | What it covers |
+|------|---------------|
+| `tests/test_hooks.py` | `system_files/bluefin/etc/bazaar/hooks.py` — Bazaar transaction hooks |
+| `tests/test_libsetup.bats` | `libsetup.sh` — `version-script()` function |
+| `tests/test_setup_scripts.bats` | `ublue-system-setup`, `ublue-user-setup` — hook runner logic |
+| `tests/test_privileged_setup.bats` | `ublue-privileged-setup` — privileged hook runner logic |
+| `tests/test_bling.bats` | `ublue-bling` — shell config injection install/uninstall |
+| `tests/test_luks_tpm2.bats` | `luks-tpm2-autounlock` — UUID parsing, device resolution, cryptenroll flag construction |
+
+## Quality Epic
+
+Ongoing test coverage improvement is tracked in [#553](https://github.com/projectbluefin/common/issues/553).

--- a/docs/quality/ARCHITECTURE-REVIEW.md
+++ b/docs/quality/ARCHITECTURE-REVIEW.md
@@ -1,8 +1,8 @@
 # Architecture Review: Quality Improvement — projectbluefin/common
 
-**Author:** Principal Architecture Review  
-**Date:** 2026-06-10  
-**Scope:** Testing strategy, issue deduplication, phased roadmap, acceptance criteria  
+**Author:** Principal Architecture Review
+**Date:** 2026-06-10
+**Scope:** Testing strategy, issue deduplication, phased roadmap, acceptance criteria
 **Status:** DRAFT — for maintainer review
 
 ---
@@ -302,11 +302,11 @@ The common repo is quality-healthy when all of the following are true:
 
 ## 7. Issue Consolidation Summary
 
-**Close as invalid:** #559, #564 (ublue-rollback-helper ghost issues)  
-**Close as duplicate (merge into #562):** #563  
-**Close as duplicate (merge into #561):** #566  
-**Close as partially resolved:** #551 (libsetup + setup scripts done; remainder tracked by #552)  
-**Repurpose as quality epic:** #553  
+**Close as invalid:** #559, #564 (ublue-rollback-helper ghost issues)
+**Close as duplicate (merge into #562):** #563
+**Close as duplicate (merge into #561):** #566
+**Close as partially resolved:** #551 (libsetup + setup scripts done; remainder tracked by #552)
+**Repurpose as quality epic:** #553
 
 **Remaining work items (6 distinct, actionable):**
 

--- a/docs/quality/ARCHITECTURE-REVIEW.md
+++ b/docs/quality/ARCHITECTURE-REVIEW.md
@@ -1,0 +1,346 @@
+# Architecture Review: Quality Improvement — projectbluefin/common
+
+**Author:** Principal Architecture Review  
+**Date:** 2026-06-10  
+**Scope:** Testing strategy, issue deduplication, phased roadmap, acceptance criteria  
+**Status:** DRAFT — for maintainer review
+
+---
+
+## Executive Summary
+
+The 11 open `[quality]` issues collectively point to a single systemic gap: **a testing philosophy was never written down**, so coverage accreted unevenly — the dispatcher pattern (`libsetup`, `ublue-system-setup`, `ublue-user-setup`) received solid bats coverage, while adjacent scripts of the same or lower complexity received none. Two of the 11 issues are ghost issues targeting a script that does not exist in this repo. One is a dead CI reference in `validate.yml`. The real remediation is smaller than the issue list implies, and three of the remaining issues can close with a single PR.
+
+---
+
+## 1. Systemic Root Cause
+
+This repo is an OCI image layer factory, not an application. Its shell scripts fall into four structural categories:
+
+| Category | Scripts | Complexity | Testability |
+|---|---|---|---|
+| **Dispatcher** | `ublue-privileged-setup`, `ublue-system-setup`, `ublue-user-setup` | Low — read config, loop over hooks | High — pure function logic, no hardware |
+| **Config injector** | `ublue-bling`, `bling.sh`, profile.d/* | Medium — file mutation with sentinels | High — mock filesystem + `$SHELL` |
+| **Interactive tool** | `luks-tpm2-autounlock` | Medium — gum TUI + hardware paths | Partial — control flow testable, device paths hardware-gated |
+| **Trivial utility** | `ujust`, `ublue-motd`, `ublue-image-info.sh`, `rechunker-group-fix`, `ublue-bling-fastfetch`, `ublue-fastfetch` | Low | High — env mocking or temp dirs |
+
+The pattern of missing tests is not a motivation or culture problem. It is a **structural one**: when `libsetup` + `ublue-system-setup` + `ublue-user-setup` got coverage, the team established a working pattern. The remaining scripts were never explicitly categorized as "needs tests" or "hardware-gated" — they fell through the gap.
+
+The root cause is the absence of a written testing contract: *what types of scripts require tests, what technique to use, and what the hardware-gated boundary is.*
+
+---
+
+## 2. Duplication Analysis and Issue Disposition
+
+### Ghost Issues — Close Immediately
+
+**`ublue-rollback-helper` does not exist in this repo.** There is no file at `system_files/shared/usr/bin/ublue-rollback-helper` or `system_files/bluefin/usr/bin/ublue-rollback-helper`. The `validate.yml` workflow references it in both a shellcheck step and an image-ref check — these are dead references that silently no-op or fail without output.
+
+| Issue | Action |
+|---|---|
+| [#559](https://github.com/projectbluefin/common/issues/559) — ublue-rollback-helper zero behavior tests | **Close as invalid** — script does not exist |
+| [#564](https://github.com/projectbluefin/common/issues/564) — ublue-rollback-helper complex branching logic untested | **Close as duplicate/invalid** — same ghost script |
+
+A separate issue should track the dead `validate.yml` references. Do not leave them — they erode trust in the CI output.
+
+### True Duplicates — Consolidate
+
+| Issue A | Issue B | Disposition |
+|---|---|---|
+| [#562](https://github.com/projectbluefin/common/issues/562) — Add bats tests for ublue-privileged-setup | [#563](https://github.com/projectbluefin/common/issues/563) — ublue-privileged-setup lacks unit tests despite elevated privileges | **Merge into #562.** Same deliverable, one filed as "add tests", one filed as "security risk". The risk framing belongs in the body of #562, not as a separate issue. |
+| [#561](https://github.com/projectbluefin/common/issues/561) — Add coverage reporting and threshold gate | [#566](https://github.com/projectbluefin/common/issues/566) — Add coverage reporting and regression detection | **Merge into #561.** These are the same infrastructure ask at different levels of abstraction. |
+| [#551](https://github.com/projectbluefin/common/issues/551) — Add shellcheck CI and bats tests for libsetup.sh and shell scripts | [#552](https://github.com/projectbluefin/common/issues/552) — Expand shellcheck CI to all 11 scripts | **Partially done.** libsetup, ublue-system-setup, ublue-user-setup now have shellcheck. Close #551 as partially resolved; keep #552 as the remaining expansion task. |
+
+### Genuinely Distinct Issues (Keep)
+
+| Issue | Distinct Concern |
+|---|---|
+| [#552](https://github.com/projectbluefin/common/issues/552) | Shellcheck expansion to remaining 8 scripts |
+| [#553](https://github.com/projectbluefin/common/issues/553) | Tracking issue for overall coverage — repurpose as the epic |
+| [#558](https://github.com/projectbluefin/common/issues/558) | ublue-bling injection behavior tests |
+| [#562](https://github.com/projectbluefin/common/issues/562) | ublue-privileged-setup tests (absorbs #563) |
+| [#561](https://github.com/projectbluefin/common/issues/561) | Coverage reporting infrastructure (absorbs #566) |
+| [#565](https://github.com/projectbluefin/common/issues/565) | luks-tpm2-autounlock testable logic coverage |
+
+**Net distinct work items after deduplication: 6** (down from 11). The 11-issue list was ~45% noise.
+
+---
+
+## 3. Testing Philosophy for a Shell-Script OCI Image Factory
+
+### What SHOULD be tested vs. what CAN be tested
+
+The two categories are not the same and conflating them is what generates ghost issues.
+
+**Should + Can (mandatory coverage):**
+- All pure-logic functions: config parsing, version gating, fallbacks
+- File mutation logic: injection/removal with sentinel patterns, idempotency
+- Control flow with hardware dependencies: mock the hardware boundary, test the logic
+- Exit codes and error handling: missing files, malformed JSON, unknown shell types
+
+**Can but lower priority (shellcheck is sufficient):**
+- Single-line aliases and PATH manipulations (`open.sh`, `uutils.sh`, `ublue-fastfetch.sh`)
+- Template rendering scripts with no branching (`ublue-motd` — 5 lines, one env substitution)
+- Trivial wrappers (`ujust` — 2 lines, passes args to `just`)
+
+**Cannot test in CI without hardware (document this explicitly):**
+- `systemd-cryptenroll` device enrollment — requires real TPM2 chip
+- `gum confirm` interactive prompts — requires TTY (mock the boundary instead)
+- `bootc` rebase operations — requires booted ostree system
+- Systemctl user session operations — requires running systemd user session
+
+**The hardware-gated boundary rule:** When a script calls hardware APIs, extract the decision logic into testable functions before the hardware call. Test the decision tree. Mark the hardware path with a comment: `# hardware-gated: not testable in CI`. Do not file issues for the hardware-gated portion — it is deliberate, not a gap.
+
+### Framework Decision: bats is the right long-term choice
+
+The repo has bats infrastructure, institutional knowledge, and working examples. bats + PATH-manipulation mocking (already used effectively in `qa-test-pr.bats` in the knuckle tests) is the correct pattern for this codebase.
+
+**Reject** shellspec: different syntax, no existing usage, higher learning curve for no measurable benefit at this scale.
+
+**Keep** pytest for Python hooks (`hooks.py`). It is the right tool for Python, and the existing `test_hooks.py` is high quality.
+
+**Add** `bats-assert` and `bats-file` helper libraries when writing the bling injection tests — `[ -f ... ]` assertions scale poorly for file content verification.
+
+### How to test privileged operations without root in CI
+
+`ublue-privileged-setup` runs hook scripts with `bash $script`. In CI:
+1. Create a temp hooks directory with non-privileged test scripts
+2. Point `SETUP_CONFIG_FILE` at a test JSON overriding the hooks directory
+3. Verify hook execution via side effects (marker files, exit codes)
+
+This is identical to the existing `test_setup_scripts.bats` pattern for `ublue-system-setup`. No root is required. The privilege comes from what the *hooks themselves* do — not from the dispatcher.
+
+### How to test luks-tpm2-autounlock without hardware
+
+The script is 1322 bytes. Its testable surface is:
+- `/proc/cmdline` parsing → `rd.luks.uuid` extraction (pure string logic)
+- `/dev/disk/by-uuid/` existence check (mock `/dev` path)
+- `gum confirm` boundary (mock `gum` via PATH)
+- `sudo systemd-cryptenroll` invocation with correct arguments (mock via PATH, capture args)
+- The wipe-slot vs. enroll branch based on `$EXIT_CODE`
+
+The script as written **cannot be tested** because it mixes all of this in a flat script. The fix is a one-time refactoring into functions (`find_luks_device`, `enroll_tpm2`, `wipe_tpm2`) before writing the tests. This is a 20-minute structural change that unlocks full logic coverage. This belongs in Phase 2, not Phase 1.
+
+---
+
+## 4. Phased Roadmap
+
+### Phase 1: Foundation — Low Risk, High Leverage (1–2 PRs)
+
+**Goal:** Close the obvious gaps with zero architectural change required.
+
+**P1.1 — Close ghost issues and fix dead CI reference (PR 1 of Phase 1)**
+- Close issues #559 and #564 (ublue-rollback-helper doesn't exist)
+- Remove the dead `ublue-rollback-helper` references from `validate.yml` shellcheck step and image-ref check
+- File a separate tracking issue: *"Determine whether ublue-rollback-helper was planned, removed, or belongs in a different repo"*
+
+**P1.2 — Add ublue-privileged-setup tests and shellcheck expansion (PR 2 of Phase 1)**
+
+`ublue-privileged-setup` is structurally identical to `ublue-system-setup`. The tests write themselves:
+- Copy the `test_setup_scripts.bats` pattern (get_config fallback, JSON reads, hook execution, missing directory)
+- Add `ublue-privileged-setup` to the shellcheck step in `unit-tests.yml`
+
+At the same time, add shellcheck for the remaining scripts where it passes without suppressions:
+- `system_files/bluefin/etc/profile.d/uutils.sh`
+- `system_files/bluefin/etc/profile.d/caffeinate.sh`
+- `system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh`
+- `system_files/shared/usr/bin/rechunker-group-fix`
+- `system_files/shared/usr/bin/ublue-bling`
+
+Scripts where shellcheck would require `# shellcheck disable` for every line (POSIX sourced fragments, aliases, template outputs): add them to shellcheck with explicit inline suppression comments and a note explaining why. Do not simply skip them — the CI record should be explicit.
+
+**Closes after Phase 1:** #551 (retroactively), #552, #562, #563 (merged)
+
+**Risk:** Low. No architectural change. Same test patterns already proven.
+
+---
+
+### Phase 2: Coverage — Systematic Expansion (2–3 PRs)
+
+**Goal:** Cover all non-trivial logic. Establish the hardware-gated boundary in code.
+
+**P2.1 — ublue-bling injection behavior tests**
+
+`ublue-bling` has real logic worth testing:
+- `is-bling-installed` returns false when config file is absent
+- `is-bling-installed` returns false when no sentinel line exists
+- `is-bling-installed` returns true when sentinel line is present
+- Install path: appends correct sentinel block to config file
+- Install idempotency: second install does not append a second block (current code has no idempotency guard — this test will reveal a bug)
+- Uninstall path: sed removal correctly removes the sentinel block and not adjacent content
+- Unknown shell: exits 1 with error message
+- `gum` boundary: mock `gum confirm` via PATH override
+
+Test technique: create temp `$HOME` in `$BATS_TEST_TMPDIR`, set `$SHELL` env var, override `$XDG_CONFIG_HOME`.
+
+**P2.2 — luks-tpm2-autounlock — refactor then test**
+
+Perform a minimal structural refactoring:
+1. Extract `/proc/cmdline` parsing into `find_luks_uuid()`
+2. Extract the device path resolution into `find_crypt_disk()`
+3. Extract `systemd-cryptenroll` invocation into `enroll_tpm2()` and `wipe_tpm2()`
+4. Keep the gum interaction at the top-level (hardware-gated, document it)
+
+After refactoring, write bats tests:
+- `find_luks_uuid` parses `rd.luks.uuid=` correctly from mock `/proc/cmdline`
+- `find_luks_uuid` parses `rd.luks.name=luks-<uuid>` format
+- `find_luks_uuid` returns empty when no luks entry in cmdline
+- Device-not-found path exits 1 with correct message (mock `/dev`)
+- Enroll path calls cryptenroll with `--tpm2-device=auto` and correct disk arg
+- Wipe path calls cryptenroll with `--wipe-slot=tpm2` and correct disk arg
+- PIN arg is included when user confirms PIN setup
+
+This is the most complex testing work in Phase 2 because it requires the refactoring first. Do not write tests against the flat script — the refactoring is the prerequisite.
+
+**P2.3 — Dynamic wallpaper hook test**
+
+`20-dynamic-wallpaper.sh` uses `version-script` from libsetup and calls `systemctl --user`. Mock systemctl via PATH. Test:
+- First run invokes systemctl enable
+- Second run (same version) exits 0 early via `version-script`
+
+**Closes after Phase 2:** #553, #558, #565
+
+---
+
+### Phase 3: Maturity — Gates, Regression Detection, Refactoring (1–2 PRs)
+
+**Goal:** Make quality self-reinforcing. New scripts cannot ship without tests.
+
+**P3.1 — Coverage reporting and threshold gate**
+
+bats does not natively produce coverage reports. Options:
+- `kcov` wraps bats execution and produces LCOV output — works for bash scripts
+- GitHub Actions step: `kcov --include-path=system_files/ coverage/ bats tests/`
+- Upload to Codecov or post as PR comment via `gh pr comment`
+
+Set an initial threshold of **70% line coverage** for `system_files/shared/usr/bin/*` and `system_files/bluefin/usr/bin/*`. Ratchet upward over time.
+
+For Python: `pytest --cov=system_files/bluefin/etc/bazaar/hooks.py --cov-fail-under=80` — this is trivially addable to the existing pytest step.
+
+**P3.2 — Add a TESTING.md contract to the repo**
+
+Document in `docs/TESTING.md`:
+1. Which test file covers which script
+2. The hardware-gated boundary rule (what goes in bats vs. what is intentionally untested)
+3. The mock pattern (PATH manipulation for external commands)
+4. Coverage threshold targets
+5. Required test additions for any new script in `system_files/`
+
+This document is the enforcement mechanism for future scripts not falling through the same gap.
+
+**P3.3 — Add shellcheck to the Containerfile build validation**
+
+Run shellcheck as a build-time lint step in `just check` (not just in CI) so contributors get immediate feedback. Add all remaining scripts to a `shellcheck.includes` file, checked in CI.
+
+**Closes after Phase 3:** #561, #566 (merged)
+
+---
+
+## 5. Architectural Risks
+
+### Risk 1: ublue-privileged-setup hooks ship without validation — CRITICAL
+
+`ublue-privileged-setup` runs every script in `privileged-setup.hooks.d/` as `bash $script` (note: unquoted `$script` — shellcheck would have caught this). The hook scripts run with elevated privileges. There are **zero tests** for the dispatcher and no validation that the hooks directory contents are safe to execute.
+
+**Current mitigations:** none in code. The hooks are installed from the OCI image, so the trust boundary is the image build — but a malformed hook script would execute silently with no error propagation.
+
+**Impact:** 100% of Bluefin users who run first boot. A regression in any privileged hook ships to every new installation.
+
+**Fix:** The dispatcher tests (Phase 1.2) address the dispatcher logic. A separate review of the hook scripts themselves for error propagation (missing `set -e`, missing exit code checks) is warranted.
+
+### Risk 2: ublue-bling injection is not idempotent — HIGH
+
+The `is-bling-installed` function checks for the presence of a `source ...` line. The install path appends the sentinel block. The uninstall path removes the sentinel block. However: `is-bling-installed` checks for `source $BLING_CLI_DIRECTORY/$BLING_SCRIPT_SOURCE` but the install path writes `test -f ... && source ...`. These are **not the same string**. A user who installs bling with `ublue-bling`, then runs `ublue-bling` again, may get a second injection instead of triggering the uninstall path.
+
+This is a latent bug that the Phase 2 bats tests will surface. The fix is trivial (check for the sentinel comment, not the source line) but must be made alongside the tests.
+
+### Risk 3: validate.yml references a nonexistent script — MEDIUM
+
+`system_files/bluefin/usr/bin/ublue-rollback-helper` appears in:
+1. The shellcheck step of `validate.yml` — if the file path is checked before execution, this fails silently or produces a misleading error
+2. The image-ref regression check in the same workflow
+
+If CI passes despite this, it indicates either the step is silently skipping the missing file or the path is never reached. Either way, the CI record cannot be trusted for this check. Fix: remove both dead references and file a separate issue for the rollback helper's status.
+
+### Risk 4: No test coverage threshold — LOW (but compounds)
+
+Without a threshold gate, the current good coverage can erode. A new script can ship with zero tests, a new author can remove tests in a refactoring, and CI will stay green. The Phase 3 kcov + threshold addresses this, but it is the lowest-priority item in the roadmap. The manual `TESTING.md` contract (Phase 3.2) is a cheaper interim control.
+
+### Risk 5: luks-tpm2-autounlock control flow has no tests — CRITICAL (for security users)
+
+This script manages disk encryption enrollment. It affects users who have enabled FDE. The script has no function decomposition, making the control flow opaque. The wipe-slot path (`--wipe-slot=tpm2`) is invoked based on a `gum confirm` exit code — if the exit code mapping is wrong, a user could inadvertently disable TPM2 auto-unlock when intending to enable it (or vice versa).
+
+The Phase 2.2 refactoring + tests directly address this. Until then, this script is a security-adjacent black box.
+
+---
+
+## 6. What "Quality-Healthy" Looks Like — Acceptance Criteria
+
+The common repo is quality-healthy when all of the following are true:
+
+**Test coverage (measurable):**
+- [ ] All scripts in `system_files/shared/usr/bin/` have either (a) bats behavior tests or (b) a documented `# hardware-gated` exemption in `docs/TESTING.md`
+- [ ] All scripts in `system_files/bluefin/usr/bin/` same criteria
+- [ ] All profile.d and env.sh scripts pass shellcheck with zero suppressions (or documented suppressions with justification)
+- [ ] Python hook coverage ≥ 80% (`pytest --cov-fail-under=80`)
+- [ ] Shell script line coverage ≥ 70% via kcov across `/usr/bin/` scripts
+
+**Process (structural):**
+- [ ] `docs/TESTING.md` exists and covers hardware-gated boundary, mock pattern, and threshold targets
+- [ ] `unit-tests.yml` fails if shellcheck covers fewer files than the declared baseline (no silent regression)
+- [ ] Any PR adding a new file to `system_files/*/usr/bin/` requires either a test file in `tests/` or a documented exemption
+
+**Issue hygiene:**
+- [ ] Zero open `[quality]` issues more than 90 days old without a `status/blocked` label and a documented blocker reason
+- [ ] No ghost issues (issues for scripts that don't exist)
+
+**CI health:**
+- [ ] `validate.yml` contains no dead file references
+- [ ] Every shellcheck step covers a file that actually exists at the referenced path
+
+---
+
+## 7. Issue Consolidation Summary
+
+**Close as invalid:** #559, #564 (ublue-rollback-helper ghost issues)  
+**Close as duplicate (merge into #562):** #563  
+**Close as duplicate (merge into #561):** #566  
+**Close as partially resolved:** #551 (libsetup + setup scripts done; remainder tracked by #552)  
+**Repurpose as quality epic:** #553  
+
+**Remaining work items (6 distinct, actionable):**
+
+| Issue | Phase | Effort | Owner |
+|---|---|---|---|
+| [#552](https://github.com/projectbluefin/common/issues/552) — Shellcheck expansion + dead validate.yml refs | Phase 1 | Small | Any |
+| [#562](https://github.com/projectbluefin/common/issues/562) — ublue-privileged-setup tests | Phase 1 | Small | Any |
+| [#558](https://github.com/projectbluefin/common/issues/558) — ublue-bling behavior tests | Phase 2 | Medium | Any |
+| [#565](https://github.com/projectbluefin/common/issues/565) — luks-tpm2-autounlock refactor + tests | Phase 2 | Medium | Experienced contributor |
+| [#561](https://github.com/projectbluefin/common/issues/561) — Coverage reporting + threshold | Phase 3 | Small | Any |
+| [#553](https://github.com/projectbluefin/common/issues/553) — Epic tracking | Ongoing | Triage | Maintainer |
+
+---
+
+## Appendix: Script Inventory with Test Status
+
+| Script | Lines | Type | Shellcheck | Bats/pytest | Notes |
+|---|---|---|---|---|---|
+| `libsetup.sh` | 34 | Library | ✅ | ✅ 9 tests | Solid |
+| `ublue-system-setup` | ~30 | Dispatcher | ✅ | ✅ 5 tests | Solid |
+| `ublue-user-setup` | ~30 | Dispatcher | ✅ | ✅ 4 tests | Solid |
+| `ublue-privileged-setup` | ~25 | Dispatcher | ❌ | ❌ | Same pattern as above — gap |
+| `ublue-bling` | ~60 | Config injector | ❌ | ❌ | Has a latent idempotency bug |
+| `bling.sh` | 68 | Shell source | ❌ | ❌ | Low-risk, shellcheck sufficient |
+| `luks-tpm2-autounlock` | ~50 | Interactive tool | ❌ | ❌ | Needs refactoring first |
+| `rechunker-group-fix` | ~20 | Utility | ❌ | ❌ | Low-risk |
+| `caffeinate.sh` | 10 | Profile function | ❌ | — | Shellcheck only needed |
+| `open.sh` | 1 | Alias | ❌ | — | Shellcheck only needed |
+| `uutils.sh` | 10 | PATH setup | ❌ | — | Shellcheck only needed |
+| `20-dynamic-wallpaper.sh` | 13 | Hook | ❌ | ❌ | Uses libsetup — testable |
+| `ublue-fastfetch.sh` | 3 | Wrapper | ❌ | — | Trivial |
+| `ublue-motd.sh` | 3 | Wrapper | ❌ | — | Trivial |
+| `umotd.sh` | 3 | Alias | ❌ | — | Trivial |
+| `ublue-image-info.sh` | 10 | Utility | ❌* | — | `shellcheck disable=2046` present |
+| `hooks.py` | — | Python | — | ✅ | Good pytest coverage |
+
+*`ublue-image-info.sh` already has a shellcheck suppress; this is intentional — the existing suppress is for a legitimate word-splitting use with jq.

--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -5,41 +5,72 @@
 #  https://www.reddit.com/r/Fedora/comments/uo4ufq/any_way_to_get_systemdcryptenroll_working_on/
 #  https://0pointer.net/blog/unlocking-luks2-volumes-with-tpm2-fido2-pkcs11-security-hardware-on-systemd-248.html
 
-gum confirm --affirmative="Enable" --negative="Disable" "Toggle TPM2 auto-unlock"
-EXIT_CODE="$?"
-case "${EXIT_CODE}" in
-  0|1)
-    ;;
-  *)
-    exit 0
-esac
+# Testability overrides — set in tests to avoid /proc and /dev access.
+CMDLINE_FILE="${CMDLINE_FILE:-/proc/cmdline}"
+DISK_BY_UUID_DIR="${DISK_BY_UUID_DIR:-/dev/disk/by-uuid}"
+DEV_DIR="${DEV_DIR:-/dev}"
 
-RD_LUKS_UUID="$(xargs -n1 -a /proc/cmdline | grep -E -e "rd.luks.(uuid|name)" | head -n 1 | cut -d= -f 2 | sed "s/^luks-//" )"
-CRYPT_DISK="$(realpath "/dev/disk/by-uuid/${RD_LUKS_UUID}")"
+# Extract the LUKS UUID from the kernel command line.
+# Handles both rd.luks.uuid=<uuid> and rd.luks.name=luks-<uuid> formats.
+get_luks_uuid() {
+    xargs -n1 -a "${CMDLINE_FILE}" \
+        | grep -E -e "rd.luks.(uuid|name)" \
+        | head -n 1 \
+        | cut -d= -f 2 \
+        | sed "s/^luks-//"
+}
 
-if ! find /dev -iname "${RD_LUKS_UUID:-INVALIDINVALID}" | grep -F -e "${RD_LUKS_UUID}" &>/dev/null; then
-  echo "Could not find LUKS device used to boot system on system mount table. Is your drive encrypted?"
-  exit 1
-fi
+# Resolve the LUKS block device path from a UUID via /dev/disk/by-uuid.
+resolve_crypt_disk() {
+    local uuid="$1"
+    realpath "${DISK_BY_UUID_DIR}/${uuid}"
+}
 
-if [ "${EXIT_CODE}" == 1 ] ; then
-  sudo systemd-cryptenroll --wipe-slot=tpm2 "${CRYPT_DISK}"
-  exit 0
-fi
+# Return 0 if the LUKS device UUID appears in DEV_DIR, 1 otherwise.
+check_luks_device() {
+    local uuid="$1"
+    find "${DEV_DIR}" -iname "${uuid:-INVALIDINVALID}" | grep -qF "${uuid}"
+}
 
-gum confirm "Would you like to set up a PIN?"
-EXIT_CODE="$?"
-SET_PIN_ARG=""
-case "${EXIT_CODE}" in
-  0)
-    export SET_PIN_ARG="--tpm2-with-pin=yes"
-    ;;
-  1)
-    ;;
-  *)
-    exit 0
-esac
+# Only run when executed directly; sourcing this file loads only functions.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    gum confirm --affirmative="Enable" --negative="Disable" "Toggle TPM2 auto-unlock"
+    EXIT_CODE="$?"
+    case "${EXIT_CODE}" in
+      0|1)
+        ;;
+      *)
+        exit 0
+    esac
 
-if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='' ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
-  echo "TPM2 LUKS auto-unlock configured for next reboot."
+    RD_LUKS_UUID="$(get_luks_uuid)"
+    CRYPT_DISK="$(resolve_crypt_disk "${RD_LUKS_UUID}")"
+
+    if ! check_luks_device "${RD_LUKS_UUID}"; then
+        echo "Could not find LUKS device used to boot system on system mount table. Is your drive encrypted?"
+        exit 1
+    fi
+
+    if [ "${EXIT_CODE}" == 1 ] ; then
+        sudo systemd-cryptenroll --wipe-slot=tpm2 "${CRYPT_DISK}"
+        exit 0
+    fi
+
+    gum confirm "Would you like to set up a PIN?"
+    EXIT_CODE="$?"
+    SET_PIN_ARG=""
+    case "${EXIT_CODE}" in
+        0)
+            export SET_PIN_ARG="--tpm2-with-pin=yes"
+            ;;
+        1)
+            ;;
+        *)
+            exit 0
+    esac
+
+    # shellcheck disable=SC2086
+    if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='' ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
+        echo "TPM2 LUKS auto-unlock configured for next reboot."
+    fi
 fi

--- a/system_files/shared/usr/bin/ublue-bling
+++ b/system_files/shared/usr/bin/ublue-bling
@@ -2,7 +2,7 @@
 
 set -eoux pipefail
 
-BLING_CLI_DIRECTORY="/usr/share/ublue-os/bling"
+BLING_CLI_DIRECTORY="${BLING_CLI_DIRECTORY:-/usr/share/ublue-os/bling}"
 
 BLING_SCRIPT_SOURCE=""
 TARGET_CONFIG_FILE=""
@@ -27,15 +27,15 @@ case "${shell}" in
 esac
 
 function is-bling-installed() {
-    echo "hello"
     [ -f "$TARGET_CONFIG_FILE" ] || return 1
 
-    if [ -n "$(grep -n "source $BLING_CLI_DIRECTORY/$BLING_SCRIPT_SOURCE" "$TARGET_CONFIG_FILE" | grep -Eo '^[^:]+')" ]; then
+    if grep -q "source $BLING_CLI_DIRECTORY/$BLING_SCRIPT_SOURCE" "$TARGET_CONFIG_FILE"; then
         return 0
     fi
     return 1
 }
 
+# shellcheck source=/dev/null
 [ -f "${BLING_ENV_SCRIPT:-/usr/share/ublue-os/bling/env.sh}" ] && . "${BLING_ENV_SCRIPT:-/usr/share/ublue-os/bling/env.sh}"
 
 BLING_MESSAGE_ENABLE="${BLING_MESSAGE_ENABLE:-Enable bling for ${shell}?}"

--- a/system_files/shared/usr/bin/ublue-privileged-setup
+++ b/system_files/shared/usr/bin/ublue-privileged-setup
@@ -22,7 +22,7 @@ if [ "${HOOKS_VERBOSE}" == "true" ] ; then
 fi
 
 if [ -d "${PRIVILEGED_HOOKS_DIRECTORY}" ] ; then
-	for script in $PRIVILEGED_HOOKS_DIRECTORY/* ; do
-		bash $script
+	for script in "${PRIVILEGED_HOOKS_DIRECTORY}"/* ; do
+		bash "$script"
 	done
 fi

--- a/tests/test_bling.bats
+++ b/tests/test_bling.bats
@@ -24,8 +24,10 @@ setup() {
     export BLING_ENV_SCRIPT="${WORKDIR}/env.sh"
     printf '# mock env\n' > "${BLING_ENV_SCRIPT}"
 
-    # Isolated home directory
+    # Isolated home directory — unset XDG_CONFIG_HOME so the script uses
+    # the HOME-based fallback rather than the CI runner's real XDG path
     export HOME="${WORKDIR}/home"
+    unset XDG_CONFIG_HOME
     mkdir -p "${HOME}"
 }
 
@@ -74,9 +76,6 @@ teardown() {
     mkdir -p "${HOME}/.config/fish"
     export SHELL="/bin/fish"
     run bash "${BLING_SCRIPT}"
-    echo "--- script output ---"
-    echo "${output}"
-    echo "--- status: ${status} ---"
     [ "${status}" -eq 0 ]
     [ -f "${HOME}/.config/fish/config.fish" ]
     grep -qF "### bling.fish source start" "${HOME}/.config/fish/config.fish"

--- a/tests/test_bling.bats
+++ b/tests/test_bling.bats
@@ -74,6 +74,9 @@ teardown() {
     mkdir -p "${HOME}/.config/fish"
     export SHELL="/bin/fish"
     run bash "${BLING_SCRIPT}"
+    echo "--- script output ---"
+    echo "${output}"
+    echo "--- status: ${status} ---"
     [ "${status}" -eq 0 ]
     [ -f "${HOME}/.config/fish/config.fish" ]
     grep -qF "### bling.fish source start" "${HOME}/.config/fish/config.fish"

--- a/tests/test_bling.bats
+++ b/tests/test_bling.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/ublue-bling
+#
+# Run: bats tests/test_bling.bats
+
+BLING_SCRIPT="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/ublue-bling"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    # Mock gum — default: auto-confirm (exit 0)
+    mkdir -p "${WORKDIR}/bin"
+    printf '#!/bin/bash\nexit 0\n' > "${WORKDIR}/bin/gum"
+    chmod +x "${WORKDIR}/bin/gum"
+    export PATH="${WORKDIR}/bin:${PATH}"
+
+    # Use an isolated BLING_CLI_DIRECTORY so tests don't require /usr/share
+    export BLING_CLI_DIRECTORY="${WORKDIR}/bling"
+    mkdir -p "${BLING_CLI_DIRECTORY}"
+    printf '# mock bling.sh\n' > "${BLING_CLI_DIRECTORY}/bling.sh"
+    printf '# mock bling.fish\n' > "${BLING_CLI_DIRECTORY}/bling.fish"
+
+    # Skip env.sh sourcing
+    export BLING_ENV_SCRIPT="${WORKDIR}/env.sh"
+    printf '# mock env\n' > "${BLING_ENV_SCRIPT}"
+
+    # Isolated home directory
+    export HOME="${WORKDIR}/home"
+    mkdir -p "${HOME}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Install — bash
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: bash install creates sentinel block in .bashrc" {
+    export SHELL="/bin/bash"
+    run bash "${BLING_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ -f "${HOME}/.bashrc" ]
+    grep -qF "### bling.sh source start" "${HOME}/.bashrc"
+    grep -qF "### bling.sh source end" "${HOME}/.bashrc"
+}
+
+@test "ublue-bling: bash install writes source line in .bashrc" {
+    export SHELL="/bin/bash"
+    run bash "${BLING_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -qF "source ${BLING_CLI_DIRECTORY}/bling.sh" "${HOME}/.bashrc"
+}
+
+# ---------------------------------------------------------------------------
+# Install — zsh
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: zsh install creates sentinel block in .zshrc" {
+    export SHELL="/bin/zsh"
+    export ZDOTDIR="${HOME}"
+    run bash "${BLING_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ -f "${HOME}/.zshrc" ]
+    grep -qF "### bling.sh source start" "${HOME}/.zshrc"
+}
+
+# ---------------------------------------------------------------------------
+# Install — fish
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: fish install creates sentinel block in config.fish" {
+    mkdir -p "${HOME}/.config/fish"
+    export SHELL="/bin/fish"
+    run bash "${BLING_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ -f "${HOME}/.config/fish/config.fish" ]
+    grep -qF "### bling.fish source start" "${HOME}/.config/fish/config.fish"
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall (idempotency)
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: second run uninstalls (removes sentinel block)" {
+    export SHELL="/bin/bash"
+    # First run: install
+    bash "${BLING_SCRIPT}"
+    grep -qF "### bling.sh source start" "${HOME}/.bashrc"
+
+    # Second run: detect installed → gum confirm to uninstall → sed removes block
+    run bash "${BLING_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    ! grep -qF "### bling.sh source start" "${HOME}/.bashrc"
+}
+
+@test "ublue-bling: no duplicate block on repeated install-uninstall-install" {
+    export SHELL="/bin/bash"
+    bash "${BLING_SCRIPT}"   # install
+    bash "${BLING_SCRIPT}"   # uninstall
+    bash "${BLING_SCRIPT}"   # reinstall
+    block_count="$(grep -cF "### bling.sh source start" "${HOME}/.bashrc" || echo 0)"
+    [ "${block_count}" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Decline / cancel
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: declining install (gum exits 1) does not modify .bashrc" {
+    export SHELL="/bin/bash"
+    # Mock gum to decline
+    printf '#!/bin/bash\nexit 1\n' > "${WORKDIR}/bin/gum"
+    run bash "${BLING_SCRIPT}"
+    # Script exits non-zero (set -e + gum returning 1)
+    [ "${status}" -ne 0 ]
+    [ ! -f "${HOME}/.bashrc" ]
+}
+
+# ---------------------------------------------------------------------------
+# Unknown shell
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: exits non-zero for unsupported shell" {
+    export SHELL="/bin/unknownshell_xyz"
+    run bash "${BLING_SCRIPT}"
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# is-bling-installed produces no debug output
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling: is-bling-installed produces no stray stdout" {
+    export SHELL="/bin/bash"
+    run bash "${BLING_SCRIPT}"
+    # Should not contain the debug 'hello' leak
+    [[ "${output}" != *"hello"* ]]
+}

--- a/tests/test_bling.bats
+++ b/tests/test_bling.bats
@@ -71,7 +71,6 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "ublue-bling: fish install creates sentinel block in config.fish" {
-    export XDG_CONFIG_HOME="${HOME}/.config"
     mkdir -p "${HOME}/.config/fish"
     export SHELL="/bin/fish"
     run bash "${BLING_SCRIPT}"

--- a/tests/test_bling.bats
+++ b/tests/test_bling.bats
@@ -71,6 +71,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "ublue-bling: fish install creates sentinel block in config.fish" {
+    export XDG_CONFIG_HOME="${HOME}/.config"
     mkdir -p "${HOME}/.config/fish"
     export SHELL="/bin/fish"
     run bash "${BLING_SCRIPT}"

--- a/tests/test_luks_tpm2.bats
+++ b/tests/test_luks_tpm2.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/luks-tpm2-autounlock
+#
+# Strategy: source the script to load its functions (the BASH_SOURCE guard
+# prevents the interactive main flow from running when sourced).
+# System calls (gum, systemd-cryptenroll, sudo) are mocked via PATH.
+#
+# Hardware note: full TPM2 integration tests live in projectbluefin/testsuite.
+# These tests cover the pure logic: UUID parsing, device resolution, error paths.
+#
+# Run: bats tests/test_luks_tpm2.bats
+
+LUKS_SCRIPT="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/luks-tpm2-autounlock"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/bin" "${WORKDIR}/disks" "${WORKDIR}/dev"
+
+    # Mock gum — default: confirm/enable (exit 0)
+    printf '#!/bin/bash\nexit 0\n' > "${WORKDIR}/bin/gum"
+    chmod +x "${WORKDIR}/bin/gum"
+
+    # Mock sudo — pass through to the command
+    printf '#!/bin/bash\n"$@"\n' > "${WORKDIR}/bin/sudo"
+    chmod +x "${WORKDIR}/bin/sudo"
+
+    # Mock systemd-cryptenroll — records args, exits 0
+    printf '#!/bin/bash\necho "cryptenroll: $*" >> %s/cryptenroll.log\nexit 0\n' "${WORKDIR}" \
+        > "${WORKDIR}/bin/systemd-cryptenroll"
+    chmod +x "${WORKDIR}/bin/systemd-cryptenroll"
+
+    export PATH="${WORKDIR}/bin:${PATH}"
+
+    # Testability overrides matching the script's env vars
+    export CMDLINE_FILE="${WORKDIR}/cmdline"
+    export DISK_BY_UUID_DIR="${WORKDIR}/disks"
+    export DEV_DIR="${WORKDIR}/dev"
+
+    # shellcheck source=/dev/null
+    source "${LUKS_SCRIPT}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# get_luks_uuid — UUID parsing
+# ---------------------------------------------------------------------------
+
+@test "get_luks_uuid: parses rd.luks.uuid= format" {
+    echo "quiet splash rd.luks.uuid=abc123-def456-7890" > "${CMDLINE_FILE}"
+    result="$(get_luks_uuid)"
+    [ "${result}" = "abc123-def456-7890" ]
+}
+
+@test "get_luks_uuid: strips luks- prefix from rd.luks.name= format" {
+    echo "quiet splash rd.luks.name=luks-abc123-def456" > "${CMDLINE_FILE}"
+    result="$(get_luks_uuid)"
+    [ "${result}" = "abc123-def456" ]
+}
+
+@test "get_luks_uuid: returns first match when multiple luks entries present" {
+    printf 'rd.luks.uuid=first-uuid rd.luks.uuid=second-uuid\n' > "${CMDLINE_FILE}"
+    result="$(get_luks_uuid)"
+    [ "${result}" = "first-uuid" ]
+}
+
+@test "get_luks_uuid: returns empty string when no luks entry present" {
+    echo "quiet splash root=/dev/mapper/root" > "${CMDLINE_FILE}"
+    result="$(get_luks_uuid)"
+    [ -z "${result}" ]
+}
+
+# ---------------------------------------------------------------------------
+# resolve_crypt_disk — device path resolution
+# ---------------------------------------------------------------------------
+
+@test "resolve_crypt_disk: returns resolved path for existing disk entry" {
+    local uuid="test-uuid-1234"
+    local fake_device="${WORKDIR}/dev/sda2"
+    touch "${fake_device}"
+    # Create the by-uuid symlink pointing to our fake device
+    ln -s "${fake_device}" "${DISK_BY_UUID_DIR}/${uuid}"
+
+    result="$(resolve_crypt_disk "${uuid}")"
+    [ "${result}" = "${fake_device}" ]
+}
+
+# ---------------------------------------------------------------------------
+# check_luks_device — device existence check
+# ---------------------------------------------------------------------------
+
+@test "check_luks_device: returns 0 when device found in DEV_DIR" {
+    local uuid="found-uuid-5678"
+    touch "${DEV_DIR}/${uuid}"
+    run check_luks_device "${uuid}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "check_luks_device: returns 1 when device not found in DEV_DIR" {
+    run check_luks_device "nonexistent-uuid-0000"
+    [ "${status}" -ne 0 ]
+}
+
+@test "check_luks_device: handles empty UUID safely (uses INVALIDINVALID guard)" {
+    run check_luks_device ""
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end — full script with mocked commands
+# ---------------------------------------------------------------------------
+
+@test "luks: exits with error message when LUKS device not found in cmdline" {
+    echo "quiet splash root=/dev/mapper/root" > "${CMDLINE_FILE}"
+    # gum auto-confirms (enable path)
+    run bash "${LUKS_SCRIPT}"
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"Could not find LUKS device"* ]]
+}
+
+@test "luks: wipe path calls systemd-cryptenroll --wipe-slot=tpm2 (disable)" {
+    local uuid="disable-uuid-abcd"
+    touch "${DEV_DIR}/${uuid}"
+    local fake_dev="${WORKDIR}/dev/sda2"
+    touch "${fake_dev}"
+    ln -s "${fake_dev}" "${DISK_BY_UUID_DIR}/${uuid}"
+    echo "rd.luks.uuid=${uuid}" > "${CMDLINE_FILE}"
+
+    # Mock gum to return 1 (Disable)
+    printf '#!/bin/bash\nexit 1\n' > "${WORKDIR}/bin/gum"
+
+    run bash "${LUKS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "\-\-wipe-slot=tpm2" "${WORKDIR}/cryptenroll.log"
+    # Must NOT pass --tpm2-device (disable path only wipes)
+    ! grep -q "\-\-tpm2-device" "${WORKDIR}/cryptenroll.log"
+}
+
+@test "luks: enroll path calls systemd-cryptenroll with tpm2-device (enable, no pin)" {
+    local uuid="enable-uuid-efgh"
+    touch "${DEV_DIR}/${uuid}"
+    local fake_dev="${WORKDIR}/dev/sdb2"
+    touch "${fake_dev}"
+    ln -s "${fake_dev}" "${DISK_BY_UUID_DIR}/${uuid}"
+    echo "rd.luks.uuid=${uuid}" > "${CMDLINE_FILE}"
+
+    # gum: first call (Toggle) returns 0 (Enable), second call (PIN) returns 1 (No PIN)
+    call_count=0
+    printf '#!/bin/bash\ncount_file=%s/gum_calls\ncount=$(($(cat "${count_file}" 2>/dev/null || echo 0) + 1))\necho "${count}" > "${count_file}"\nif [ "${count}" -eq 2 ]; then exit 1; fi\nexit 0\n' \
+        "${WORKDIR}" > "${WORKDIR}/bin/gum"
+
+    run bash "${LUKS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "\-\-tpm2-device=auto" "${WORKDIR}/cryptenroll.log"
+}
+
+@test "luks: enroll with PIN passes --tpm2-with-pin=yes" {
+    local uuid="pin-uuid-ijkl"
+    touch "${DEV_DIR}/${uuid}"
+    local fake_dev="${WORKDIR}/dev/sdc2"
+    touch "${fake_dev}"
+    ln -s "${fake_dev}" "${DISK_BY_UUID_DIR}/${uuid}"
+    echo "rd.luks.uuid=${uuid}" > "${CMDLINE_FILE}"
+
+    # gum: both calls return 0 (Enable + Yes to PIN)
+    printf '#!/bin/bash\nexit 0\n' > "${WORKDIR}/bin/gum"
+
+    run bash "${LUKS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "\-\-tpm2-with-pin=yes" "${WORKDIR}/cryptenroll.log"
+}

--- a/tests/test_privileged_setup.bats
+++ b/tests/test_privileged_setup.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/ublue-privileged-setup
+#
+# Run: bats tests/test_privileged_setup.bats
+
+PRIVILEGED_SETUP="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/ublue-privileged-setup"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+@test "ublue-privileged-setup: get_config returns fallback when config file missing" {
+    export SETUP_CONFIG_FILE="${WORKDIR}/nonexistent.json"
+    result="$(bash -c "
+        source ${PRIVILEGED_SETUP@Q}
+        get_config '.\"privileged-hooks-directory\"' '/default/privileged/path'
+    ")"
+    [ "${result}" = "/default/privileged/path" ]
+}
+
+@test "ublue-privileged-setup: get_config reads privileged-hooks-directory from json" {
+    export SETUP_CONFIG_FILE="${WORKDIR}/setup.json"
+    echo '{"privileged-hooks-directory": "/custom/privileged/hooks"}' > "${SETUP_CONFIG_FILE}"
+    result="$(bash -c "
+        source ${PRIVILEGED_SETUP@Q}
+        get_config '.\"privileged-hooks-directory\"' '/default/privileged/path'
+    ")"
+    [ "${result}" = "/custom/privileged/hooks" ]
+}
+
+@test "ublue-privileged-setup: get_config returns fallback for null json value" {
+    export SETUP_CONFIG_FILE="${WORKDIR}/setup.json"
+    echo '{"privileged-hooks-directory": null}' > "${SETUP_CONFIG_FILE}"
+    result="$(bash -c "
+        source ${PRIVILEGED_SETUP@Q}
+        get_config '.\"privileged-hooks-directory\"' '/default/privileged/path'
+    ")"
+    [ "${result}" = "/default/privileged/path" ]
+}
+
+@test "ublue-privileged-setup: executes hooks in configured directory" {
+    export HOOKS_DIR="${WORKDIR}/privileged-hooks"
+    mkdir -p "${HOOKS_DIR}"
+    echo "#!/bin/bash" > "${HOOKS_DIR}/01-test.sh"
+    echo "echo privileged_hook_ran > ${WORKDIR}/result" >> "${HOOKS_DIR}/01-test.sh"
+    chmod +x "${HOOKS_DIR}/01-test.sh"
+
+    export SETUP_CONFIG_FILE="${WORKDIR}/setup.json"
+    echo "{\"privileged-hooks-directory\": \"${HOOKS_DIR}\"}" > "${SETUP_CONFIG_FILE}"
+
+    bash "${PRIVILEGED_SETUP}"
+    [ -f "${WORKDIR}/result" ]
+}
+
+@test "ublue-privileged-setup: exits cleanly when hooks directory is missing" {
+    export SETUP_CONFIG_FILE="${WORKDIR}/setup.json"
+    echo '{"privileged-hooks-directory": "/nonexistent/privileged/hooks"}' > "${SETUP_CONFIG_FILE}"
+    run bash "${PRIVILEGED_SETUP}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "ublue-privileged-setup: hook paths with spaces are handled safely" {
+    export HOOKS_DIR="${WORKDIR}/privileged hooks dir"
+    mkdir -p "${HOOKS_DIR}"
+    echo "#!/bin/bash" > "${HOOKS_DIR}/01-space-test.sh"
+    echo "echo space_hook_ran > ${WORKDIR}/space_result" >> "${HOOKS_DIR}/01-space-test.sh"
+    chmod +x "${HOOKS_DIR}/01-space-test.sh"
+
+    export SETUP_CONFIG_FILE="${WORKDIR}/setup.json"
+    printf '{"privileged-hooks-directory": "%s"}' "${HOOKS_DIR}" > "${SETUP_CONFIG_FILE}"
+
+    bash "${PRIVILEGED_SETUP}"
+    [ -f "${WORKDIR}/space_result" ]
+}


### PR DESCRIPTION
More shell crap all over the place ... 


Phase 1 + Phase 2 of quality epic (#553).

Bug fixes:
- ublue-privileged-setup: quote $script and hooks directory in for loop (bash $script → bash "$script"; unquoted dir caused word-split on spaces)
- ublue-bling: remove echo 'hello' debug leak from is-bling-installed()
- ublue-bling: refactor is-bling-installed to use grep -q (SC2143)
- luks-tpm2-autounlock: fix shellcheck disable comment syntax

Shellcheck expansion (3 → 11 scripts):
- Add all extensionless usr/bin scripts to shellcheck step in unit-tests.yml
- Add find-based shellcheck for all .sh files (-e SC1091 for sourced files)
- Add # shellcheck shell=bash to profile.d scripts without shebangs
- Add # shellcheck source=/dev/null for dynamic source directives

New test coverage (27 new bats tests):
- tests/test_privileged_setup.bats — 6 tests incl. spaces-in-path regression
- tests/test_bling.bats — 9 tests: install/uninstall/idempotency/decline/no-stray-stdout
- tests/test_luks_tpm2.bats — 12 tests: UUID parsing, device resolution, e2e flows

Testability improvements:
- luks-tpm2-autounlock: extract get_luks_uuid(), resolve_crypt_disk(), check_luks_device() functions + BASH_SOURCE guard + env-var overrides (CMDLINE_FILE, DISK_BY_UUID_DIR, DEV_DIR) for mocking
- ublue-bling: BLING_CLI_DIRECTORY uses :- default for test override
- All mocked via PATH stub pattern (gum, systemd-cryptenroll, sudo)

CI (unit-tests.yml):
- Split shellcheck into two named steps: extensionless + .sh files
- Add pytest-cov with --cov-report=term-missing per PR
- Add bats steps for 3 new test files

Documentation:
- docs/TESTING.md: testing contract, framework decision, hardware gate boundary, bats patterns, shellcheck exemption table, coverage targets

Test results: 27/27 bats (new) + 18/18 bats (existing) + 20/20 pytest
Shellcheck: 0 errors across all 11 scripts

Closes #562
Closes #558
Closes #565
Relates-to #553
Relates-to #552
Relates-to #561
Relates-to #564

Assisted-by: Claude Sonnet 4.5 via pi

<!--
## Thank you for contributing

Please [read the README](../README.md) and ensure your change goes to the correct directory.

### Changes related to Bluefin
If your change is gnome or bluefin change, make sure you put the change under the  system_files/bluefin/ folder.

## Global changes
Global changes that are not GNOME-specific should go in the `system_files/shared/` folder. This is also used by [Aurora](https://github.com/ublue-os/aurora), so ensure no GNOME-related changes end up here.

-->

## PR pipeline

```
opened ──▶ review ──▶ approved ──▶ merged
                    [lgtm]      auto-merge
                                when CI green
```

> Add `do-not-merge` at any time to block automation.
> `/approve` or `lgtm` from a maintainer triggers merge queue.

## What does this change?

<!-- Required: one sentence -->

## Why?

<!-- Link the issue this closes: "Closes #NNN" -->
Closes #

## Checklist

- [ ] `just check` passes
- [ ] `pre-commit run --all-files` passes
- [ ] PR title follows Conventional Commits (`fix:`, `feat:`, `chore:`, etc.)
