### PR TITLE
test(quality): add bats coverage for ublue-fastfetch, wire into CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -76,3 +76,6 @@ jobs:
 
       - name: Run bats (changelog.just)
         run: bats tests/test_changelog.bats
+
+      - name: Run bats (ublue-fastfetch)
+        run: bats tests/test_ublue_fastfetch.bats

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,6 +45,7 @@ jobs:
             system_files/shared/usr/bin/ublue-privileged-setup \
             system_files/shared/usr/bin/ublue-bling \
             system_files/shared/usr/bin/luks-tpm2-autounlock \
+            system_files/shared/usr/bin/ublue-fastfetch \
             system_files/shared/usr/lib/ublue/setup-services/libsetup.sh
 
       - name: Run shellcheck — .sh scripts

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -204,6 +204,7 @@ Scripts exempt from behavioral testing (shellcheck-only):
 | `tests/test_rechunker_group_fix.bats` | `rechunker-group-fix` — group/gshadow append, duplicate detection, format |
 | `tests/test_bling_fastfetch.bats` | `ublue-bling-fastfetch` — all 9 accent colors, dconf/gsettings fallback chain, FASTFETCH_FORCE_THEME override |
 | `tests/test_changelog.bats` | `changelog.just` — LTS/non-LTS repo selection, URL construction, exit behaviour |
+| `tests/test_ublue_fastfetch.bats` | `ublue-fastfetch` — config reads, shuffle branch, DEFAULT_THEME export to ublue-bling-fastfetch |
 
 ## Quality Epic
 

--- a/tests/test_ublue_fastfetch.bats
+++ b/tests/test_ublue_fastfetch.bats
@@ -90,11 +90,13 @@ EOF
     grep -q -- "--config /usr/share/ublue-os/fastfetch.jsonc" "${WORKDIR}/fastfetch.log"
 }
 
-@test "ublue-fastfetch: exports DEFAULT_THEME from config to fastfetch environment" {
-    # Override mock to capture the env var instead of args
-    printf '#!/bin/bash\necho "DEFAULT_THEME=${DEFAULT_THEME}" >> %s/fastfetch.log\n' \
-        "${WORKDIR}" > "${WORKDIR}/bin/fastfetch"
-    chmod +x "${WORKDIR}/bin/fastfetch"
+@test "ublue-fastfetch: exports DEFAULT_THEME to ublue-bling-fastfetch subprocess" {
+    # ublue-bling-fastfetch is the documented consumer of DEFAULT_THEME (comment in
+    # the script: '# Gets passed to ublue-bling-fastfetch'). Override that mock to
+    # record the env var it receives so a missing 'export' would be caught.
+    printf '#!/bin/bash\necho "DEFAULT_THEME=${DEFAULT_THEME}" >> %s/bling.log\necho "blue"\n' \
+        "${WORKDIR}" > "${WORKDIR}/bin/ublue-bling-fastfetch"
+    chmod +x "${WORKDIR}/bin/ublue-bling-fastfetch"
 
     cat > "${WORKDIR}/fastfetch.json" <<EOF
 {
@@ -106,13 +108,13 @@ EOF
 EOF
     run bash "${SCRIPT_UNDER_TEST}"
     [ "${status}" -eq 0 ]
-    grep -q "DEFAULT_THEME=mocha" "${WORKDIR}/fastfetch.log"
+    grep -q "DEFAULT_THEME=mocha" "${WORKDIR}/bling.log"
 }
 
 @test "ublue-fastfetch: DEFAULT_THEME falls back to 'slate' when key is absent" {
-    printf '#!/bin/bash\necho "DEFAULT_THEME=${DEFAULT_THEME}" >> %s/fastfetch.log\n' \
-        "${WORKDIR}" > "${WORKDIR}/bin/fastfetch"
-    chmod +x "${WORKDIR}/bin/fastfetch"
+    printf '#!/bin/bash\necho "DEFAULT_THEME=${DEFAULT_THEME}" >> %s/bling.log\necho "blue"\n' \
+        "${WORKDIR}" > "${WORKDIR}/bin/ublue-bling-fastfetch"
+    chmod +x "${WORKDIR}/bin/ublue-bling-fastfetch"
 
     cat > "${WORKDIR}/fastfetch.json" <<EOF
 {
@@ -123,7 +125,7 @@ EOF
 EOF
     run bash "${SCRIPT_UNDER_TEST}"
     [ "${status}" -eq 0 ]
-    grep -q "DEFAULT_THEME=slate" "${WORKDIR}/fastfetch.log"
+    grep -q "DEFAULT_THEME=slate" "${WORKDIR}/bling.log"
 }
 
 @test "ublue-fastfetch: extra CLI args are forwarded to fastfetch" {

--- a/tests/test_ublue_fastfetch.bats
+++ b/tests/test_ublue_fastfetch.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/ublue-fastfetch
+#
+# Strategy: run the script as a subprocess with mocked PATH entries for
+# fastfetch, ublue-bling-fastfetch, and FASTFETCH_CONFIG_FILE pointed at a
+# temp JSON config.  exec fastfetch replaces the subprocess — the mock
+# records its args to a log file before exiting so assertions can read it.
+#
+# Hardware note: fastfetch itself is not tested here.  These tests cover the
+# pure logic: config key reads, shuffle branch selection, DEFAULT_THEME export.
+#
+# Run: bats tests/test_ublue_fastfetch.bats
+
+SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../system_files/shared/usr/bin/ublue-fastfetch"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/bin"
+    mkdir -p "${WORKDIR}/logos"
+
+    # Mock ublue-bling-fastfetch — returns a fixed colour name
+    printf '#!/bin/bash\necho "blue"\n' > "${WORKDIR}/bin/ublue-bling-fastfetch"
+    chmod +x "${WORKDIR}/bin/ublue-bling-fastfetch"
+
+    # Mock fastfetch — records all args to a log file, exits 0
+    # The log path is baked into the mock so exec replacement preserves it.
+    printf '#!/bin/bash\necho "$@" >> %s/fastfetch.log\n' "${WORKDIR}" \
+        > "${WORKDIR}/bin/fastfetch"
+    chmod +x "${WORKDIR}/bin/fastfetch"
+
+    # A real logo file so shuffle tests have something to pick
+    touch "${WORKDIR}/logos/dino.png"
+
+    # Default config — shuffle off
+    cat > "${WORKDIR}/fastfetch.json" <<EOF
+{
+  "fastfetch-config": "/usr/share/ublue-os/fastfetch.jsonc",
+  "shuffle-logo": "false",
+  "logo-directory": "${WORKDIR}/logos",
+  "default-theme": "slate"
+}
+EOF
+
+    export PATH="${WORKDIR}/bin:${PATH}"
+    export FASTFETCH_CONFIG_FILE="${WORKDIR}/fastfetch.json"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+@test "ublue-fastfetch: invokes fastfetch without --logo when shuffle disabled" {
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    [ -f "${WORKDIR}/fastfetch.log" ]
+    ! grep -q -- "--logo" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: passes --config value from json to fastfetch" {
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    grep -q -- "--config /usr/share/ublue-os/fastfetch.jsonc" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: passes --color from ublue-bling-fastfetch to fastfetch" {
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    grep -q -- "--color blue" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: invokes fastfetch with --logo when shuffle enabled" {
+    cat > "${WORKDIR}/fastfetch.json" <<EOF
+{
+  "fastfetch-config": "/usr/share/ublue-os/fastfetch.jsonc",
+  "shuffle-logo": "true",
+  "logo-directory": "${WORKDIR}/logos",
+  "default-theme": "slate"
+}
+EOF
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    grep -q -- "--logo" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: uses fallback config path when config file is missing" {
+    export FASTFETCH_CONFIG_FILE="/nonexistent/fastfetch.json"
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    grep -q -- "--config /usr/share/ublue-os/fastfetch.jsonc" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: exports DEFAULT_THEME from config to fastfetch environment" {
+    # Override mock to capture the env var instead of args
+    printf '#!/bin/bash\necho "DEFAULT_THEME=${DEFAULT_THEME}" >> %s/fastfetch.log\n' \
+        "${WORKDIR}" > "${WORKDIR}/bin/fastfetch"
+    chmod +x "${WORKDIR}/bin/fastfetch"
+
+    cat > "${WORKDIR}/fastfetch.json" <<EOF
+{
+  "fastfetch-config": "/usr/share/ublue-os/fastfetch.jsonc",
+  "shuffle-logo": "false",
+  "logo-directory": "${WORKDIR}/logos",
+  "default-theme": "mocha"
+}
+EOF
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    grep -q "DEFAULT_THEME=mocha" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: DEFAULT_THEME falls back to 'slate' when key is absent" {
+    printf '#!/bin/bash\necho "DEFAULT_THEME=${DEFAULT_THEME}" >> %s/fastfetch.log\n' \
+        "${WORKDIR}" > "${WORKDIR}/bin/fastfetch"
+    chmod +x "${WORKDIR}/bin/fastfetch"
+
+    cat > "${WORKDIR}/fastfetch.json" <<EOF
+{
+  "fastfetch-config": "/usr/share/ublue-os/fastfetch.jsonc",
+  "shuffle-logo": "false",
+  "logo-directory": "${WORKDIR}/logos"
+}
+EOF
+    run bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    grep -q "DEFAULT_THEME=slate" "${WORKDIR}/fastfetch.log"
+}
+
+@test "ublue-fastfetch: extra CLI args are forwarded to fastfetch" {
+    run bash "${SCRIPT_UNDER_TEST}" --modules cpu
+    [ "${status}" -eq 0 ]
+    grep -q -- "--modules cpu" "${WORKDIR}/fastfetch.log"
+}


### PR DESCRIPTION
## Summary

Closes the last open gap in the quality epic ([#553](https://github.com/projectbluefin/common/issues/553)).

`ublue-fastfetch` (`system_files/shared/usr/bin/ublue-fastfetch`) has real branching logic — `SHUFFLE_LOGO` branch selection, `get_config()` JSON reads with fallbacks, `DEFAULT_THEME` export — but zero test coverage. This violates the `docs/TESTING.md` contract: every `usr/bin` script with branching logic requires a `tests/test_*.bats` file.

---

## Changes

### `tests/test_ublue_fastfetch.bats` (new, 8 tests)

| # | Test | Covers |
|---|------|--------|
| 1 | No `--logo` when shuffle disabled | SHUFFLE_LOGO=false branch |
| 2 | `--config` value from JSON | get_config() read path |
| 3 | `--color` from ublue-bling-fastfetch | command substitution forwarding |
| 4 | `--logo` present when shuffle enabled | SHUFFLE_LOGO=true branch |
| 5 | Fallback config path when file missing | get_config() fallback |
| 6 | DEFAULT_THEME exported from config | export to subprocess env |
| 7 | DEFAULT_THEME falls back to 'slate' | fallback value |
| 8 | Extra CLI args forwarded | `"${@}"` passthrough |

**Mocking strategy:** PATH-override mocks for `fastfetch` (records args to log) and `ublue-bling-fastfetch` (returns fixed colour). `FASTFETCH_CONFIG_FILE` pointed at temp JSON. Pattern matches existing bats tests in the repo.

### `.github/workflows/unit-tests.yml`
- Add `Run bats (ublue-fastfetch)` step

### `docs/TESTING.md`
- Add test file reference table entries for this PR's test file and the 3 test files from PR #573 (rechunker-group-fix, ublue-bling-fastfetch, changelog — landing concurrently)

**Note on unit-tests.yml overlap with PR #573:** both PRs add new bats steps. If #573 merges first, a trivial rebase adds the fastfetch step alongside the existing new steps. No conflict in logic.

---

## Verification

```
bats tests/test_ublue_fastfetch.bats   8/8  ✅
just check                              ✅
pre-commit run --all-files              ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test suite for system functionality validation.

* **Documentation**
  * Updated testing documentation with new test coverage references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->