### PR TITLE
fix(test): add IMAGE_INFO_FILE override to changelog.just, fix changelog bats in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: find system_files -name '*.sh' -print0 | xargs -0 shellcheck -e SC1091
 
       - name: Run pytest (hooks.py)
-        run: python3 -m pytest tests/test_hooks.py -v --cov=tests --cov-report=term-missing
+        run: python3 -m pytest tests/test_hooks.py -v --cov=tests --cov-report=term-missing --cov-fail-under=80
 
       - name: Run bats (libsetup.sh)
         run: bats tests/test_libsetup.bats
@@ -67,3 +67,12 @@ jobs:
 
       - name: Run bats (luks-tpm2-autounlock)
         run: bats tests/test_luks_tpm2.bats
+
+      - name: Run bats (rechunker-group-fix)
+        run: bats tests/test_rechunker_group_fix.bats
+
+      - name: Run bats (ublue-bling-fastfetch)
+        run: bats tests/test_bling_fastfetch.bats
+
+      - name: Run bats (changelog.just)
+        run: bats tests/test_changelog.bats

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -131,6 +131,38 @@ This pattern is used in:
 - `ublue-system-setup`, `ublue-user-setup` → same
 - `luks-tpm2-autounlock` → `CMDLINE_FILE`, `DISK_BY_UUID_DIR`, `DEV_DIR`
 - `ublue-bling` → `BLING_CLI_DIRECTORY`, `BLING_ENV_SCRIPT`
+- `rechunker-group-fix` → `GSHADOW_FILE`, `GROUP_FILE` (**workaround**: script is itself a workaround for systemd/systemd#30852; remove overrides when script is deleted)
+
+### Testing just recipes
+
+Just recipes embed bash after a shebang line. Extract the body with `awk` for bats testing:
+
+```bash
+_extract_script() {
+    local out_file="$1"
+    awk '
+        /^    #!\/usr\/bin\/bash/ { found=1; next }
+        found { sub(/^    /, ""); print }
+    ' "${JUSTFILE}" > "${out_file}"
+}
+```
+
+Then run: `bash "${extracted_script}"` with mocked PATH binaries.
+
+### Pitfall: literal `*` in bats grep assertions
+
+`grep -q "^name:!*::"` treats `*` as a regex quantifier (zero-or-more `!`) — it will **not** match the literal string `name:!*::`. Always escape:
+
+```bash
+# WRONG — * is a quantifier, matches name::: or name:!:: etc.
+grep -q "^name:!*::" file
+
+# CORRECT — \* matches a literal asterisk
+grep -q "^name:!\*::" file
+
+# ALSO CORRECT — -F disables regex entirely
+grep -qF "name:!*::" file
+```
 
 ## Exemptions
 
@@ -154,11 +186,9 @@ Scripts exempt from behavioral testing (shellcheck-only):
 
 | Layer | Tool | Current target |
 |-------|------|---------------|
-| Python hooks | pytest-cov | Reported per-PR (threshold TBD — see [#561](https://github.com/projectbluefin/common/issues/561)) |
+| Python hooks | pytest-cov | ≥ 80% (gate active — `--cov-fail-under=80`) |
 | Shell scripts | shellcheck | 100% of all `.sh` + `usr/bin` scripts |
 | Shell behavior | bats | All `usr/bin` scripts with branching logic |
-
-Coverage reporting is visible in every PR's CI output. A hard `--cov-fail-under` threshold will be set in Phase 3 once baseline is established (tracked in [#561](https://github.com/projectbluefin/common/issues/561)).
 
 ## Test Files Reference
 
@@ -170,6 +200,9 @@ Coverage reporting is visible in every PR's CI output. A hard `--cov-fail-under`
 | `tests/test_privileged_setup.bats` | `ublue-privileged-setup` — privileged hook runner logic |
 | `tests/test_bling.bats` | `ublue-bling` — shell config injection install/uninstall |
 | `tests/test_luks_tpm2.bats` | `luks-tpm2-autounlock` — UUID parsing, device resolution, cryptenroll flag construction |
+| `tests/test_rechunker_group_fix.bats` | `rechunker-group-fix` — group/gshadow append, duplicate detection, format |
+| `tests/test_bling_fastfetch.bats` | `ublue-bling-fastfetch` — all 9 accent colors, dconf/gsettings fallback chain, FASTFETCH_FORCE_THEME override |
+| `tests/test_changelog.bats` | `changelog.just` — LTS/non-LTS repo selection, URL construction, exit behaviour |
 
 ## Quality Epic
 

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -361,3 +361,50 @@ gh run cancel <run-id> --repo projectbluefin/common
 ```
 
 If a stale in-progress run with `cancel-in-progress: true` is blocking new triggers, cancel it explicitly — the new push may have silently been queued but not started.
+
+---
+
+## ⛔ Branch-from-target rule (merge queue repos)
+
+Every projectbluefin repo runs a merge queue. A PR with merge conflicts or a dirty diff **cannot enter the queue** and stalls work for everyone on that branch.
+
+**Root cause of dirty diffs:** Creating a branch from `main` when the PR targets `testing`. The `testing` branch in `bluefin`, `bluefin-lts`, and `dakota` accumulates CI and release-pipeline commits that never land on `main`. A branch created from `main` is missing those commits — the PR diff shows them all as "deleted".
+
+### Branch targets
+
+| Repo | PR targets | Branch FROM |
+|---|---|---|
+| `bluefin`, `bluefin-lts`, `dakota` | `testing` | `testing` |
+| `common`, `actions`, `knuckle` | `main` | `main` |
+
+### Mandatory pre-open gate (every PR)
+
+```bash
+TARGET=testing   # or main — match the PR target
+git fetch origin
+
+# 1. Only your files in the diff
+git diff --name-only origin/${TARGET}..HEAD
+# If unintended files appear → wrong base. Recreate from origin/${TARGET}.
+
+# 2. No merge conflicts
+git merge --no-commit --no-ff origin/${TARGET}
+git merge --abort 2>/dev/null || true
+
+# 3. No known red CI
+# Do not open a PR if local tests fail. The merge queue will reject it.
+just check && pre-commit run --all-files
+```
+
+### Recreating a branch with the wrong base
+
+```bash
+# Identify your commits
+git log --oneline origin/${TARGET}..HEAD
+
+# Recreate from the correct base
+git checkout -b <branch>-clean origin/${TARGET}
+git cherry-pick <your-sha1> <your-sha2> ...
+```
+
+*Observed violation (2026-06-10):* `projectbluefin/dakota` PR #779 was created from `main` targeting `testing`. The `testing` branch had 20+ diverged commits — 12 workflow files, Justfile changes, and BST element updates all appeared as "deleted" in the diff. PR closed; clean PR #780 recreated from `testing`.

--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -9,16 +9,23 @@ changelogs:
     # Get Image Tag
     TAG="$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)"
 
-    # If stable or gts, get changelogs from Github Releases
-    if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
-        CONTENT="$(curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    # Select the correct upstream repo based on image stream
+    if [[ "$TAG" =~ ^lts ]]; then
+        REPO="projectbluefin/bluefin-lts"
+    else
+        REPO="projectbluefin/bluefin"
     fi
 
-    # Display Content with Glow, otherwise fallback to rpm-ostree changelogs (stable-daily/latest/desynced)
+    # If stable, gts, or lts, fetch from GitHub Releases
+    if [[ "$TAG" =~ gts$|stable$|^lts ]]; then
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
+        CONTENT="$(curl -Ls "https://api.github.com/repos/${REPO}/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    fi
+
+    # Display Content with Glow, otherwise fallback to latest release for this repo
     if [[ -n "${CONTENT:-}" ]]; then
         echo "$CONTENT" | glow -p
     else
         echo "WARN: Could not find a release specific to your image"
-        curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases/latest" | jq -r ".body" | glow -p
+        curl -Ls "https://api.github.com/repos/${REPO}/releases/latest" | jq -r ".body" | glow -p
     fi

--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -7,7 +7,8 @@ changelogs:
     #!/usr/bin/bash
 
     # Get Image Tag
-    TAG="$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)"
+    IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
+    TAG="$(jq -r '.["image-tag"]' < "${IMAGE_INFO_FILE}")"
 
     # Select the correct upstream repo based on image stream
     if [[ "$TAG" =~ ^lts ]]; then

--- a/system_files/shared/usr/bin/rechunker-group-fix
+++ b/system_files/shared/usr/bin/rechunker-group-fix
@@ -7,9 +7,16 @@
 # systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
 # This will populate /etc/group successfully, and then populate /etc/gshadow
 # with any missing groups that we nuked when we removed /etc/gshadow
-
-GSHADOW_FILE="/etc/gshadow"
-GROUP_FILE="/etc/group"
+#
+# TODO: This entire script is a workaround for systemd-sysusers not managing
+# /etc/gshadow on bootc images. Remove once upstream resolves it:
+# https://github.com/systemd/systemd/issues/30852
+#
+# GSHADOW_FILE / GROUP_FILE env-var overrides exist solely for unit-test
+# isolation (bats cannot write to /etc). Remove them when this script is
+# deleted.
+GSHADOW_FILE="${GSHADOW_FILE:-/etc/gshadow}"
+GROUP_FILE="${GROUP_FILE:-/etc/group}"
 
 (
     flock -x 9

--- a/tests/test_bling_fastfetch.bats
+++ b/tests/test_bling_fastfetch.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/ublue-bling-fastfetch
+#
+# Run: bats tests/test_bling_fastfetch.bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/ublue-bling-fastfetch"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    MOCKDIR="${WORKDIR}/bin"
+    mkdir -p "${MOCKDIR}"
+
+    # Mock dconf — returns empty string by default (simulates unset accent-color)
+    printf '#!/bin/bash\necho ""\n' > "${MOCKDIR}/dconf"
+    chmod +x "${MOCKDIR}/dconf"
+
+    # Mock gsettings — returns empty string by default
+    printf '#!/bin/bash\necho ""\n' > "${MOCKDIR}/gsettings"
+    chmod +x "${MOCKDIR}/gsettings"
+
+    export PATH="${MOCKDIR}:${PATH}"
+    unset FASTFETCH_FORCE_THEME
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# FASTFETCH_FORCE_THEME override — covers all 9 named colors
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling-fastfetch: blue returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=blue run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;53;132;228" ]
+}
+
+@test "ublue-bling-fastfetch: green returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=green run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;58;148;74" ]
+}
+
+@test "ublue-bling-fastfetch: orange returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=orange run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;237;91;0" ]
+}
+
+@test "ublue-bling-fastfetch: pink returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=pink run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;213;97;153" ]
+}
+
+@test "ublue-bling-fastfetch: purple returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=purple run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;139;62;165" ]
+}
+
+@test "ublue-bling-fastfetch: red returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=red run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;230;45;66" ]
+}
+
+@test "ublue-bling-fastfetch: slate returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=slate run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;111;131;150" ]
+}
+
+@test "ublue-bling-fastfetch: teal returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=teal run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;33;144;164" ]
+}
+
+@test "ublue-bling-fastfetch: yellow returns correct ANSI color" {
+    FASTFETCH_FORCE_THEME=yellow run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;200;136;0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Default / unknown theme fallback
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling-fastfetch: unknown theme falls back to blue default" {
+    FASTFETCH_FORCE_THEME=notacolor run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;53;132;228" ]
+}
+
+@test "ublue-bling-fastfetch: empty FASTFETCH_FORCE_THEME falls back to blue default" {
+    FASTFETCH_FORCE_THEME="" run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;53;132;228" ]
+}
+
+# ---------------------------------------------------------------------------
+# dconf / gsettings fallback chain
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling-fastfetch: reads theme from dconf when available" {
+    # dconf returns 'teal' — gsettings should not be called
+    printf "#!/bin/bash\necho 'teal'\n" > "${WORKDIR}/bin/dconf"
+    chmod +x "${WORKDIR}/bin/dconf"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;33;144;164" ]
+}
+
+@test "ublue-bling-fastfetch: falls through to gsettings when dconf returns empty" {
+    # dconf returns empty, gsettings returns 'orange'
+    printf "#!/bin/bash\necho ''\n" > "${WORKDIR}/bin/dconf"
+    printf "#!/bin/bash\necho 'orange'\n" > "${WORKDIR}/bin/gsettings"
+    chmod +x "${WORKDIR}/bin/dconf" "${WORKDIR}/bin/gsettings"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;237;91;0" ]
+}
+
+@test "ublue-bling-fastfetch: strips single quotes from dconf output" {
+    # dconf returns quoted value (common dconf output format)
+    printf "#!/bin/bash\necho \"'green'\"\n" > "${WORKDIR}/bin/dconf"
+    chmod +x "${WORKDIR}/bin/dconf"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;58;148;74" ]
+}
+
+@test "ublue-bling-fastfetch: FASTFETCH_FORCE_THEME takes precedence over dconf" {
+    # dconf would return 'red', but FASTFETCH_FORCE_THEME overrides it
+    printf "#!/bin/bash\necho 'red'\n" > "${WORKDIR}/bin/dconf"
+    chmod +x "${WORKDIR}/bin/dconf"
+
+    FASTFETCH_FORCE_THEME=purple run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "38;2;139;62;165" ]
+}
+
+# ---------------------------------------------------------------------------
+# Exit behaviour
+# ---------------------------------------------------------------------------
+
+@test "ublue-bling-fastfetch: exits 0 on success" {
+    FASTFETCH_FORCE_THEME=blue run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "ublue-bling-fastfetch: always prints exactly one line" {
+    FASTFETCH_FORCE_THEME=green run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ "$(echo "${output}" | wc -l)" -eq 1 ]
+}

--- a/tests/test_changelog.bats
+++ b/tests/test_changelog.bats
@@ -30,8 +30,15 @@ setup() {
     touch "${CURL_CALLS}"
     export CURL_CALLS
 
+    # Mock image-info.json — IMAGE_INFO_FILE env var override (see changelog.just)
+    # Without this, the shell redirect '< /usr/share/ublue-os/image-info.json'
+    # fails in CI before jq is invoked, leaving TAG empty.
+    IMAGE_INFO="${WORKDIR}/image-info.json"
+    echo '{"image-tag": "latest"}' > "${IMAGE_INFO}"
+    export IMAGE_INFO_FILE="${IMAGE_INFO}"
+
     # Mock jq:
-    #   - '.["image-tag"]' query  → returns $MOCK_TAG
+    #   - '.["image-tag"]' query  → returns $MOCK_TAG (ignores stdin — IMAGE_INFO_FILE set above)
     #   - all other invocations   → echo a mock changelog body
     cat > "${MOCKDIR}/jq" << 'EOF'
 #!/bin/bash
@@ -62,7 +69,7 @@ CURLEOF
     printf '#!/bin/bash\ncat\n' > "${MOCKDIR}/glow"
     chmod +x "${MOCKDIR}/glow"
 
-    # Mock grep: used for DATE extraction — return a fixed date string
+    # Mock grep: used for DATE extraction - return a fixed date string
     cat > "${MOCKDIR}/grep" << 'EOF'
 #!/bin/bash
 # If called with -oP for OSTREE_VERSION date extraction, return fixed date
@@ -86,7 +93,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Repo selection — LTS stream
+# Repo selection - LTS stream
 # ---------------------------------------------------------------------------
 
 @test "changelog: lts tag selects projectbluefin/bluefin-lts repo" {
@@ -109,7 +116,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Repo selection — non-LTS streams
+# Repo selection - non-LTS streams
 # ---------------------------------------------------------------------------
 
 @test "changelog: stable tag selects projectbluefin/bluefin repo" {
@@ -134,7 +141,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# URL construction — release fetch path
+# URL construction - release fetch path
 # ---------------------------------------------------------------------------
 
 @test "changelog: stable tag fetches from /releases endpoint (not /releases/latest)" {

--- a/tests/test_changelog.bats
+++ b/tests/test_changelog.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# Tests for the changelog.just repo-selection and fetch logic
+#
+# Run: bats tests/test_changelog.bats
+#
+# Strategy: extract the bash body from changelog.just, inject it into a
+# sub-shell with mocked binaries (jq, curl, glow, grep) and a mock
+# image-info.json so we never hit the network or the real filesystem.
+
+CHANGELOG_JUST="$BATS_TEST_DIRNAME/../system_files/bluefin/usr/share/ublue-os/just/changelog.just"
+WORKDIR=""
+
+# Extract the bash body from the just recipe (skip recipe header + shebang,
+# strip the 4-space just indentation) and write it to a temp file.
+_extract_script() {
+    local out_file="$1"
+    awk '
+        /^    #!\/usr\/bin\/bash/ { found=1; next }
+        found { sub(/^    /, ""); print }
+    ' "${CHANGELOG_JUST}" > "${out_file}"
+}
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    MOCKDIR="${WORKDIR}/bin"
+    mkdir -p "${MOCKDIR}"
+
+    # Capture file — curl writes each URL it receives here
+    CURL_CALLS="${WORKDIR}/curl_calls"
+    touch "${CURL_CALLS}"
+    export CURL_CALLS
+
+    # Mock jq:
+    #   - '.["image-tag"]' query  → returns $MOCK_TAG
+    #   - all other invocations   → echo a mock changelog body
+    cat > "${MOCKDIR}/jq" << 'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    if [[ "$arg" == *'image-tag'* ]]; then
+        echo "${MOCK_TAG:-latest}"
+        exit 0
+    fi
+done
+# Release body extraction or latest .body
+echo "mock changelog body"
+EOF
+    chmod +x "${MOCKDIR}/jq"
+
+    # Mock curl: record the URL, return a JSON array with one release entry
+    cat > "${MOCKDIR}/curl" << 'CURLEOF'
+#!/bin/bash
+for arg in "$@"; do
+    if [[ "$arg" =~ ^https:// ]]; then
+        echo "$arg" >> "${CURL_CALLS}"
+    fi
+done
+echo '[{"tag_name":"stable-20260601","body":"mock changelog"}]'
+CURLEOF
+    chmod +x "${MOCKDIR}/curl"
+
+    # Mock glow: passthrough (just print stdin)
+    printf '#!/bin/bash\ncat\n' > "${MOCKDIR}/glow"
+    chmod +x "${MOCKDIR}/glow"
+
+    # Mock grep: used for DATE extraction — return a fixed date string
+    cat > "${MOCKDIR}/grep" << 'EOF'
+#!/bin/bash
+# If called with -oP for OSTREE_VERSION date extraction, return fixed date
+if [[ "$*" == *OSTREE_VERSION* ]]; then
+    echo "20260601"
+    exit 0
+fi
+# Otherwise delegate to real grep
+/usr/bin/grep "$@"
+EOF
+    chmod +x "${MOCKDIR}/grep"
+
+    export PATH="${MOCKDIR}:${PATH}"
+
+    SCRIPT_FILE="${WORKDIR}/changelog.sh"
+    _extract_script "${SCRIPT_FILE}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Repo selection — LTS stream
+# ---------------------------------------------------------------------------
+
+@test "changelog: lts tag selects projectbluefin/bluefin-lts repo" {
+    MOCK_TAG="lts-20260601" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin-lts" "${CURL_CALLS}"
+}
+
+@test "changelog: lts tag does NOT query projectbluefin/bluefin" {
+    MOCK_TAG="lts-20260601" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    # The bluefin (non-lts) repo must not appear in any curl call
+    ! grep -q "projectbluefin/bluefin[^-]" "${CURL_CALLS}"
+}
+
+@test "changelog: lts-hwe tag selects projectbluefin/bluefin-lts repo" {
+    MOCK_TAG="lts-hwe" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin-lts" "${CURL_CALLS}"
+}
+
+# ---------------------------------------------------------------------------
+# Repo selection — non-LTS streams
+# ---------------------------------------------------------------------------
+
+@test "changelog: stable tag selects projectbluefin/bluefin repo" {
+    MOCK_TAG="stable" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin" "${CURL_CALLS}"
+    ! grep -q "bluefin-lts" "${CURL_CALLS}"
+}
+
+@test "changelog: gts tag selects projectbluefin/bluefin repo" {
+    MOCK_TAG="gts" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin" "${CURL_CALLS}"
+    ! grep -q "bluefin-lts" "${CURL_CALLS}"
+}
+
+@test "changelog: latest tag selects projectbluefin/bluefin repo (fallback)" {
+    MOCK_TAG="latest" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin" "${CURL_CALLS}"
+    ! grep -q "bluefin-lts" "${CURL_CALLS}"
+}
+
+# ---------------------------------------------------------------------------
+# URL construction — release fetch path
+# ---------------------------------------------------------------------------
+
+@test "changelog: stable tag fetches from /releases endpoint (not /releases/latest)" {
+    MOCK_TAG="stable" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    # Must hit the versioned releases list, not the latest shortcut
+    grep -q "api.github.com/repos/projectbluefin/bluefin/releases$" "${CURL_CALLS}" || \
+    grep -qP "api\.github\.com/repos/projectbluefin/bluefin/releases$" "${CURL_CALLS}"
+}
+
+@test "changelog: latest tag falls through to /releases/latest endpoint" {
+    MOCK_TAG="latest" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "releases/latest" "${CURL_CALLS}"
+}
+
+@test "changelog: lts tag fetches from bluefin-lts /releases endpoint" {
+    MOCK_TAG="lts-20260601" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "api.github.com/repos/projectbluefin/bluefin-lts/releases" "${CURL_CALLS}"
+}
+
+# ---------------------------------------------------------------------------
+# Exit behaviour
+# ---------------------------------------------------------------------------
+
+@test "changelog: exits 0 on stable tag" {
+    MOCK_TAG="stable" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "changelog: exits 0 on latest tag (fallback path)" {
+    MOCK_TAG="latest" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "changelog: exits 0 on lts tag" {
+    MOCK_TAG="lts-20260601" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/test_rechunker_group_fix.bats
+++ b/tests/test_rechunker_group_fix.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/rechunker-group-fix
+#
+# Run: bats tests/test_rechunker_group_fix.bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/rechunker-group-fix"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    export GROUP_FILE="${WORKDIR}/group"
+    export GSHADOW_FILE="${WORKDIR}/gshadow"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Basic behaviour
+# ---------------------------------------------------------------------------
+
+@test "rechunker-group-fix: appends missing group to empty gshadow" {
+    printf 'wheel:x:10:user\n' > "${GROUP_FILE}"
+    touch "${GSHADOW_FILE}"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^wheel:!\*::" "${GSHADOW_FILE}"
+}
+
+@test "rechunker-group-fix: does not duplicate entry already in gshadow" {
+    printf 'wheel:x:10:user\n' > "${GROUP_FILE}"
+    printf 'wheel:!*::\n' > "${GSHADOW_FILE}"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    count=$(grep -c "^wheel:" "${GSHADOW_FILE}")
+    [ "${count}" -eq 1 ]
+}
+
+@test "rechunker-group-fix: appends only missing entries in multi-group file" {
+    printf 'wheel:x:10:\ndocker:x:999:\nvideo:x:44:\n' > "${GROUP_FILE}"
+    printf 'wheel:!*::\n' > "${GSHADOW_FILE}"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^docker:!\*::" "${GSHADOW_FILE}"
+    grep -q "^video:!\*::" "${GSHADOW_FILE}"
+    count=$(grep -c "^wheel:" "${GSHADOW_FILE}")
+    [ "${count}" -eq 1 ]
+}
+
+@test "rechunker-group-fix: handles empty group file gracefully" {
+    touch "${GROUP_FILE}"
+    touch "${GSHADOW_FILE}"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ ! -s "${GSHADOW_FILE}" ]
+}
+
+@test "rechunker-group-fix: creates gshadow file if it does not exist" {
+    printf 'newgroup:x:500:\n' > "${GROUP_FILE}"
+    # GSHADOW_FILE does not exist yet
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [ -f "${GSHADOW_FILE}" ]
+    grep -q "^newgroup:!\*::" "${GSHADOW_FILE}"
+}
+
+@test "rechunker-group-fix: written entry has correct gshadow format (group:!*::)" {
+    printf 'testgrp:x:1234:alice,bob\n' > "${GROUP_FILE}"
+    touch "${GSHADOW_FILE}"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -qE "^testgrp:!\*::$" "${GSHADOW_FILE}"
+}
+
+@test "rechunker-group-fix: processes all groups from file with no pre-existing gshadow entries" {
+    printf 'alpha:x:1:\nbeta:x:2:\ngamma:x:3:\n' > "${GROUP_FILE}"
+    touch "${GSHADOW_FILE}"
+
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^alpha:" "${GSHADOW_FILE}"
+    grep -q "^beta:" "${GSHADOW_FILE}"
+    grep -q "^gamma:" "${GSHADOW_FILE}"
+}


### PR DESCRIPTION
## Summary

Fixes the CI failure on PR #573. Tests 1, 2, 3, 7, 9 in `test_changelog.bats` were failing.

## Root Cause

`changelog.just` reads the image tag via:
```bash
TAG="$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)"
```
In the GitHub Actions CI environment `/usr/share/ublue-os/image-info.json` does not exist. The bash shell fails the stdin redirect **before** jq is invoked, leaving `TAG` empty. With `TAG` empty:
- LTS branch is never taken → repo always defaults to `projectbluefin/bluefin`
- Tag-specific release lookup is skipped → always falls back to `/releases/latest`

Tests 4, 5, 6, 8 passed because they only asserted `projectbluefin/bluefin` (the fallback) was called — which it was.

## Fix

**`changelog.just`** — add `IMAGE_INFO_FILE` env-var override, matching the established pattern used by `ublue-privileged-setup`, `luks-tpm2-autounlock`, etc.:
```bash
IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
TAG="$(jq -r '.["image-tag"]' < "${IMAGE_INFO_FILE}")"
```

**`tests/test_changelog.bats`** — create a temp `image-info.json` in `WORKDIR` and export `IMAGE_INFO_FILE` in `setup()`, with a comment explaining why this is required.

## Verification

```
bats tests/test_changelog.bats   12/12 ✅
just check                         ✅
pre-commit run --all-files         ✅
```

This PR is intended to be squashed into PR #573 or merged first so #573's CI goes green.