### PR TITLE
fix(ci): bump lifecycle-caller SHA to 3025b5d3 (matches bluefin-lts)

### DIFF
--- a/.github/workflows/lifecycle-caller.yml
+++ b/.github/workflows/lifecycle-caller.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@7df3176a8449ba1db2c2b38ea18c0d9b3687a4f0 # chore/lifecycle-from-common — update SHA after actions PR merges
+    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v0 — update SHA when actions bumps lifecycle.yml
     with:
       brand_name: "Common"
     secrets: inherit


### PR DESCRIPTION
## Summary

`lifecycle-caller.yml` was pointing at SHA `7df3176a` — the commit that first introduced `lifecycle.yml` to `projectbluefin/actions`. After that PR merged, `bluefin-lts` was bumped to the current actions tip (`3025b5d3`) via `chore/bump-actions-sha` (PR #157). `common` was left behind on the pre-merge SHA, causing runtime failures on `main`.

**Root cause:** SHA `7df3176a` is valid and accessible, but the workflow at that revision has subtle differences from the merged state. Runtime `failure` observed on `main` run [27308597057](https://github.com/projectbluefin/common/actions/runs/27308597057).

## Change

`.github/workflows/lifecycle-caller.yml`: `7df3176a...` → `3025b5d31f34...`

One-line change. All other workflow fields unchanged.

## Test plan

After merge, monitor the next scheduled or event-triggered run of `issue and PR lifecycle` on `main`. Should move from `failure` → `success` or `skipped` (skipped = no matching event, which is also correct).

Found during pre-production shipping verification audit (2026-06-10).