### PR TITLE
fix(ujust): route lts/lts-hwe tags to projectbluefin/bluefin-lts in changelogs

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -1,7 +1,5 @@
 # vim: set ft=make :
 
-alias changelog := changelogs
-
 # Show the changelog
 changelogs:
     #!/usr/bin/bash
@@ -9,16 +7,23 @@ changelogs:
     # Get Image Tag
     TAG="$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)"
 
-    # If stable or gts, get changelogs from Github Releases
-    if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
-        CONTENT="$(curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    # Select the correct upstream repo based on image stream
+    if [[ "$TAG" =~ ^lts ]]; then
+        REPO="projectbluefin/bluefin-lts"
+    else
+        REPO="projectbluefin/bluefin"
     fi
 
-    # Display Content with Glow, otherwise fallback to rpm-ostree changelogs (stable-daily/latest/desynced)
+    # If stable, gts, or lts, fetch from GitHub Releases
+    if [[ "$TAG" =~ gts$|stable$|^lts ]]; then
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
+        CONTENT="$(curl -Ls "https://api.github.com/repos/${REPO}/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    fi
+
+    # Display Content with Glow, otherwise fallback to latest release for this repo
     if [[ -n "${CONTENT:-}" ]]; then
         echo "$CONTENT" | glow -p
     else
         echo "WARN: Could not find a release specific to your image"
-        curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases/latest" | jq -r ".body" | glow -p
+        curl -Ls "https://api.github.com/repos/${REPO}/releases/latest" | jq -r ".body" | glow -p
     fi


### PR DESCRIPTION
## Summary

`changelog.just` had two bugs:

1. **Wrong repo name:** `ublue-os/bluefin` → `projectbluefin/bluefin` (repo was renamed; users were hitting the old org's API)
2. **Missing LTS routing:** tags matching `^lts` (e.g. `lts`, `lts-hwe`, `lts-20260601`) fell through to the Fedora bluefin fallback, showing CentOS Stream LTS users the wrong changelogs

## Change

```diff
-    if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(grep -oP ...)"
-        CONTENT="$(curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases" ...)"
+    # Select the correct upstream repo based on image stream
+    if [[ "$TAG" =~ ^lts ]]; then
+        REPO="projectbluefin/bluefin-lts"
+    else
+        REPO="projectbluefin/bluefin"
+    fi
+    # If stable, gts, or lts, fetch from GitHub Releases
+    if [[ "$TAG" =~ gts$|stable$|^lts ]]; then
+        DATE="$(grep -oP ...)"
+        CONTENT="$(curl -Ls "https://api.github.com/repos/${REPO}/releases" ...)"
     fi
-    ...
-    curl -Ls "https://api.github.com/repos/ublue-os/bluefin/releases/latest" ...
+    ...
+    curl -Ls "https://api.github.com/repos/${REPO}/releases/latest" ...
```

## Test plan

- The bats tests in PR #573 (`quality/bats-tests-and-coverage-gate`) will pass once this lands and that PR is rebased on main
- Manual: on a bluefin-lts image, run `ujust changelogs` — should now show bluefin-lts release notes, not Fedora bluefin notes

Found during pre-production shipping verification audit (2026-06-10).

Related: #573