### PR TITLE
chore(renovate): group projectbluefin/actions ref updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,20 @@
   "packageRules": [
     {
       "description": "Automerge chore dep updates (digest, pin, patch, minor) when CI passes",
-      "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
+      "matchUpdateTypes": [
+        "digest",
+        "pin",
+        "patch",
+        "minor"
+      ],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
+    },
+    {
+      "description": "Group all projectbluefin/actions ref updates into one PR for atomic SHA bumps (consistency C3)",
+      "matchDepPatterns": ["projectbluefin/actions"],
+      "groupName": "projectbluefin/actions"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Consistency audit C3: adds a Renovate grouping rule so all `projectbluefin/actions` SHA ref updates land in one atomic PR rather than N individual PRs.

**Problem:** When `projectbluefin/actions` releases, Renovate currently creates separate update PRs for each file that references an actions SHA. This means SHAs can drift across files within the same repo.

**Solution:** Group rule in `renovate.json` ensures all `projectbluefin/actions` refs update together in one PR.

```json
{
  "description": "Group all projectbluefin/actions ref updates into one PR for atomic SHA bumps (consistency C3)",
  "matchDepPatterns": ["projectbluefin/actions"],
  "groupName": "projectbluefin/actions"
}
```

Closes #587.

Assisted-by: Claude Sonnet 4.5 via pi