### PR TITLE
feat(ci): supply chain hardening — keyless cosign, Trivy CVE gate, SBOM, SLSA L2 (Phase 6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
+      id-token: write      # keyless cosign signing via OIDC
+      attestations: write  # GitHub SBOM + SLSA provenance attestations
+      security-events: write  # SARIF upload for Trivy scan results
 
     steps:
       - name: Checkout
@@ -65,6 +67,14 @@ jobs:
             ${{ steps.generate-tags.outputs.sha_short }}
           oci: true
 
+      - name: Scan image for CVEs
+        uses: projectbluefin/actions/bootc-build/scan-image@e39c94703801a272245bf2a96416594f36fe6f93 # v1
+        with:
+          image: ${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.sha_short }}
+          severity-threshold: CRITICAL
+          exit-code: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         if: github.event_name != 'pull_request'
@@ -89,15 +99,14 @@ jobs:
           extra-args: |
             --compression-format=zstd:chunked
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign, generate SBOM, and attest
+        uses: projectbluefin/actions/bootc-build/sign-and-publish@e39c94703801a272245bf2a96416594f36fe6f93 # v1
         if: github.event_name != 'pull_request'
-
-      - name: Sign container image
-        if: github.event_name != 'pull_request'
-        run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${TAGS}"
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+        with:
+          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          digest: ${{ steps.push.outputs.digest }}
+          signing-mode: keyless
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          image-name: common
+          certificate-identity-regexp: >-
+            ^https://github\.com/projectbluefin/(common|actions)/\.github/workflows/


### PR DESCRIPTION
## Summary

Implements Phase 6 from [common#583](https://github.com/projectbluefin/common/issues/583), closes [common#513](https://github.com/projectbluefin/common/issues/513).

Adopts the shared supply chain composite actions from `projectbluefin/actions` (`bootc-build/scan-image` + `bootc-build/sign-and-publish`) to bring `common` up to the same supply chain posture as `bluefin` and `bluefin-lts`.

## Changes

### Removed
- `sigstore/cosign-installer` + inline `cosign sign --key` using `secrets.SIGNING_SECRET`

### Added

| Step | Action | What it does |
|---|---|---|
| Scan (pre-push) | `bootc-build/scan-image` (Trivy) | Fails on CRITICAL CVEs before image is published. PRs are report-only (`exit-code: 0`). |
| Sign + SBOM + attest | `bootc-build/sign-and-publish` | Keyless OIDC signing via Fulcio, Syft SBOM attached via ORAS, GitHub SBOM attestation, SLSA L2 build provenance |

### Permissions added
- `attestations: write` — required for `actions/attest` and `actions/attest-build-provenance`
- `security-events: write` — required for Trivy SARIF upload to GitHub Security tab

## Post-merge action required

**Remove `SIGNING_SECRET` from org secrets** — it is no longer referenced by any workflow in this repo. The old key-signed signatures on historical images remain verifiable; new images get keyless signatures.

## Security gate
This was explicitly approved before implementation. Key-to-keyless switch uses the same `sign-and-publish` action already in production for `bluefin` and `bluefin-lts`.

Closes: [common#513](https://github.com/projectbluefin/common/issues/513)
Parent: [common#583](https://github.com/projectbluefin/common/issues/583)