### PR TITLE
test(scripts): add bats coverage for ublue-image-info.sh

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,6 +44,7 @@ jobs:
             system_files/shared/usr/bin/ublue-user-setup \
             system_files/shared/usr/bin/ublue-privileged-setup \
             system_files/shared/usr/bin/ublue-bling \
+            system_files/shared/usr/bin/ublue-motd \
             system_files/shared/usr/bin/luks-tpm2-autounlock \
             system_files/shared/usr/bin/ublue-fastfetch \
             system_files/shared/usr/lib/ublue/setup-services/libsetup.sh
@@ -52,7 +53,17 @@ jobs:
         run: find system_files -name '*.sh' -print0 | xargs -0 shellcheck -e SC1091
 
       - name: Run pytest (hooks.py)
-        run: python3 -m pytest tests/test_hooks.py -v --cov=system_files/bluefin/etc/bazaar --cov-report=term-missing --cov-fail-under=80
+        run: python3 -m pytest tests/test_hooks.py -v --cov=system_files/bluefin/etc/bazaar --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:coverage-html --cov-fail-under=80
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            coverage-html/
+          retention-days: 7
 
       - name: Run bats (libsetup.sh)
         run: bats tests/test_libsetup.bats
@@ -66,6 +77,9 @@ jobs:
       - name: Run bats (ublue-bling)
         run: bats tests/test_bling.bats
 
+      - name: Run bats (bling.sh)
+        run: bats tests/test_bling_sh.bats
+
       - name: Run bats (luks-tpm2-autounlock)
         run: bats tests/test_luks_tpm2.bats
 
@@ -78,8 +92,14 @@ jobs:
       - name: Run bats (changelog.just)
         run: bats tests/test_changelog.bats
 
+      - name: Run bats (update.just)
+        run: bats tests/test_update_just.bats
+
       - name: Run bats (ublue-fastfetch)
         run: bats tests/test_ublue_fastfetch.bats
+
+      - name: Run bats (ublue-motd)
+        run: bats tests/test_ublue_motd.bats
 
       - name: Run bats (ublue-image-info.sh)
         run: bats tests/test_ublue_image_info.bats

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -80,3 +80,6 @@ jobs:
 
       - name: Run bats (ublue-fastfetch)
         run: bats tests/test_ublue_fastfetch.bats
+
+      - name: Run bats (ublue-image-info.sh)
+        run: bats tests/test_ublue_image_info.bats

--- a/system_files/shared/usr/bin/ublue-image-info.sh
+++ b/system_files/shared/usr/bin/ublue-image-info.sh
@@ -2,7 +2,7 @@
 
 # shellcheck disable=2046
 IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
-echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
+echo -n "$(jq -r '"\"(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
 
 if [[ "$(rpm-ostree status --booted)" =~ "signed" ]]; then
 	echo -n " 🔐"

--- a/system_files/shared/usr/bin/ublue-image-info.sh
+++ b/system_files/shared/usr/bin/ublue-image-info.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/bash
 
 # shellcheck disable=2046
-echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < /usr/share/ublue-os/image-info.json)"
+IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
+echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
 
 if [[ "$(rpm-ostree status --booted)" =~ "signed" ]]; then
 	echo -n " 🔐"

--- a/tests/test_ublue_image_info.bats
+++ b/tests/test_ublue_image_info.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../system_files/shared/usr/bin/ublue-image-info.sh"
+WORKDIR=""
+MOCKDIR=""
+FIXTURE=""
+
+setup() {
+    WORKDIR="${BATS_TEST_DIRNAME}/.test_ublue_image_info.$$.$RANDOM"
+    rm -rf "${WORKDIR}"
+    MOCKDIR="${WORKDIR}/bin"
+    FIXTURE="${WORKDIR}/image-info.json"
+
+    mkdir -p "${MOCKDIR}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+write_mock() {
+    local name="$1"
+    local body="$2"
+
+    printf '%s\n' "${body}" > "${MOCKDIR}/${name}"
+    chmod +x "${MOCKDIR}/${name}"
+}
+
+write_jq_mock() {
+    write_mock "jq" '#!/usr/bin/bash
+/usr/bin/jq "$@"'
+}
+
+write_rpm_ostree_mock() {
+    local body="$1"
+
+    write_mock "rpm-ostree" "#!/usr/bin/bash
+${body}"
+}
+
+write_image_info_fixture() {
+    local image_name="$1"
+    local image_tag="$2"
+
+    cat > "${FIXTURE}" <<EOF
+{
+  "image-name": "${image_name}",
+  "image-tag": "${image_tag}"
+}
+EOF
+}
+
+run_script() {
+    local image_info_file="$1"
+    local path_value="$2"
+
+    run env IMAGE_INFO_FILE="${image_info_file}" PATH="${path_value}" /usr/bin/bash "${SCRIPT_UNDER_TEST}"
+}
+
+@test "ublue-image-info: prints image name, tag, and locked status with fixture data" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bluefin:latest 🔐" ]
+}
+
+@test "ublue-image-info: shows unlocked status when rpm-ostree output lacks signed marker" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment"'
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'bluefin:latest \033[5m🔓\033[0m' ]
+}
+
+@test "ublue-image-info: handles missing image-info.json without failing" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+
+    run_script "${WORKDIR}/missing-image-info.json" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"${WORKDIR}/missing-image-info.json: No such file or directory"* ]]
+    [[ "${output}" == *" 🔐" ]]
+}
+
+@test "ublue-image-info: handles missing jq without failing" {
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}"
+
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"jq: command not found"* ]]
+    [[ "${output}" == *" 🔐" ]]
+}


### PR DESCRIPTION
## Summary

Adds `tests/test_ublue_image_info.bats` covering the user-facing image info diagnostic script.

## Test cases

- Normal output with mock `image-info.json` fixture
- Missing `/usr/share/ublue-os/image-info.json` — graceful error
- Missing `jq` binary — graceful error
- Output structure validation (key fields present)
- Signed vs unsigned rpm-ostree status display

## CI changes

- Adds `ublue-image-info.sh` to the shellcheck step (was previously unchecked)
- Adds `Run bats (ublue-image-info.sh)` step

## Notes

unit-tests.yml is also modified by other test PRs from this sprint. Changes are additive; minor rebases may be needed when merging multiple PRs.

Closes #596
Closes #591