### PR TITLE
ci(factory): notify downstream repos when common publishes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,3 +120,28 @@ jobs:
           image-name: common
           certificate-identity-regexp: >-
             ^https://github\.com/projectbluefin/(common|actions)/\.github/workflows/
+
+      - name: Generate GitHub App token for downstream dispatch
+        id: app-token
+        if: github.event_name != 'pull_request'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          owner: projectbluefin
+          repositories: bluefin,bluefin-lts,dakota
+
+      - name: Notify downstream repos of common image update
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PAYLOAD=$(printf '{"digest":"%s","image":"%s"}' \
+            "${{ steps.push.outputs.digest }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}")
+          for repo in bluefin bluefin-lts dakota; do
+            gh api "repos/projectbluefin/${repo}/dispatches" \
+              --method POST \
+              -f event_type=common-updated \
+              -f "client_payload=${PAYLOAD}"
+          done


### PR DESCRIPTION
## Summary

Adds a `repository_dispatch` step to `build.yml` after the sign-and-publish step. On every successful image publish (non-PR run), dispatches a `common-updated` event to `bluefin`, `bluefin-lts`, and `dakota` so downstream builds can pick up the new common digest immediately instead of waiting for the weekly Renovate schedule (up to 7 days).

## Changes

Adds a GitHub App token step plus the dispatch step in the build job (non-PR gate on `if:` condition):

```yaml
- name: Generate GitHub App token for downstream dispatch
  id: app-token
  if: github.event_name != `pull_request`
  uses: actions/create-github-app-token@<sha> # v1
  with:
    app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
    private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
    owner: projectbluefin
    repositories: bluefin,bluefin-lts,dakota

- name: Notify downstream repos of common image update
  if: github.event_name != `pull_request`
  env:
    GH_TOKEN: ${{ steps.app-token.outputs.token }}
  run: |
    PAYLOAD=...
    for repo in bluefin bluefin-lts dakota; do
      gh api repos/projectbluefin/${repo}/dispatches ...
    done
```

## Required secrets / app setup

Uses the existing `MERGERAPTOR_APP_ID` + `MERGERAPTOR_PRIVATE_KEY` secrets instead of a PAT. The Mergeraptor GitHub App must be installed on `projectbluefin/bluefin`, `projectbluefin/bluefin-lts`, and `projectbluefin/dakota` so the generated token can dispatch to those repos.

## Out of scope

Downstream trigger handlers (adding `repository_dispatch` event listeners in bluefin/lts/dakota) are tracked in issue #623 and will be separate PRs in those repos.

Closes #623 (common-side)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD automation to automatically notify downstream repositories when the common image is updated, with improved authentication and delivery of image information including digest and full reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->