### PR TITLE
chore(ci): validate release-state.yaml against JSON schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # v4.6.0
     hooks:
         - id: check-json
           exclude: \.devcontainer\.json
@@ -12,9 +12,18 @@ repos:
         - id: detect-private-key
         - id: check-added-large-files
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: 03d0035246f3e81f36aed592ffb4bebf33a03106 # v1.7.7
     hooks:
       - id: actionlint
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: f805888065fdb6162e1f800e50bb9460cbd223d6 # 0.37.2
+    hooks:
+      - id: check-jsonschema
+        name: Validate release-state.yaml
+        files: ^\.github/release-state\.yaml$
+        args:
+          - --schemafile
+          - https://raw.githubusercontent.com/projectbluefin/actions/e39c94703801a272245bf2a96416594f36fe6f93/docs/schemas/release-state.schema.json
   - repo: local
     hooks:
       - id: no-floating-action-tags

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -117,6 +117,29 @@ Use both. The hook enforces that refs are pinned at commit time. Renovate keeps 
 
 ---
 
+## release-state.yaml schema validation
+
+`.github/release-state.yaml` should be validated with the `check-jsonschema` pre-commit hook against the shared schema in `projectbluefin/actions`.
+
+### Pin both the hook and the schema source
+
+Use an immutable hook revision **and** an immutable raw schema URL pinned to the `actions` commit that introduced the schema:
+
+```yaml
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: <commit-sha> # <version>
+  hooks:
+    - id: check-jsonschema
+      files: ^\.github/release-state\.yaml$
+      args:
+        - --schemafile
+        - https://raw.githubusercontent.com/projectbluefin/actions/<commit-sha>/docs/schemas/release-state.schema.json
+```
+
+Pinning the raw URL to a commit avoids silent schema drift on the next pre-commit run if `actions/main` changes. The hook is file-scoped, so `pre-commit run --all-files` is a no-op in repos that do not currently carry `.github/release-state.yaml`.
+
+---
+
 ## Skill drift detection
 
 **`common` does not run `skill-drift.yml`.** Do not add it.


### PR DESCRIPTION
Wires a check-jsonschema pre-commit hook to validate .github/release-state.yaml against the shared schema in projectbluefin/actions.

Implementation details:
- pin existing pre-commit hook repos and the new check-jsonschema hook to commit SHAs
- pin the schema URL to the actions commit that added release-state.schema.json
- document the pattern in docs/skills/ci-tooling.md

Validation:
- just check
- pre-commit run check-jsonschema --files .github/release-state.yaml with a valid sample: pass
- pre-commit run check-jsonschema --files .github/release-state.yaml with an invalid digest: fail as expected
- pre-commit run --all-files

Closes #588.