### PR TITLE
docs(factory): deprecate housekeeping repo — actions is canonical home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,8 @@ testsuite gates `:latest` promotion in all three image repos.
 
 | Repo | Role |
 |---|---|
-| [projectbluefin/housekeeping](https://github.com/projectbluefin/housekeeping) | Org-wide maintenance workflows |
 | [projectbluefin/testsuite](https://github.com/projectbluefin/testsuite) | QA pipeline — Argo + KubeVirt + AT-SPI |
+| [projectbluefin/housekeeping](https://github.com/projectbluefin/housekeeping) | Deprecated placeholder repo — org-wide automation now lives in `projectbluefin/actions` |
 | [projectbluefin/testing-lab](https://github.com/projectbluefin/testing-lab) | Homelab QA pipeline |
 | [projectbluefin/bluespeed](https://github.com/projectbluefin/bluespeed) | KubeStellar homelab factory |
 | [projectbluefin/iso](https://github.com/projectbluefin/iso) | ISO builds |

--- a/docs/factory/agentic-model.md
+++ b/docs/factory/agentic-model.md
@@ -7,6 +7,7 @@ Per-repo specifics live in that repo's `AGENTS.md` — start there, then load th
 
 - **AGENTS.md is the per-repo contract.** Read it before touching anything.
 - **One agentic whole.** `common` changes propagate to `bluefin`, `bluefin-lts`, and `dakota` at next build. High blast radius.
+- **Org-wide automation lives in `projectbluefin/actions`.** Treat `projectbluefin/housekeeping` as a deprecated placeholder repo, not an active home for maintenance workflows.
 - **No castrojo fork.** Push branches directly to `projectbluefin/*` repos, open PRs with `gh pr create --repo projectbluefin/<repo>`.
 - **Squash only.** All factory repos use squash merge. Never merge-commit or rebase-merge.
 - **Max 4 open PRs per agent at once.** No WIP PRs.

--- a/docs/factory/automation-audit/README.md
+++ b/docs/factory/automation-audit/README.md
@@ -14,7 +14,7 @@ When this principle conflicts with convenience, the principle wins. New workflow
 
 ## Executive Summary
 
-The projectbluefin factory is **~97% automated** across **124 workflows in 7 in-scope repos** (common 12, bluefin 27, bluefin-lts 17, dakota 23, actions 26, testsuite 10, iso 9; bonedigger 2 and housekeeping 0 are out of audit scope). All 7 phases are now deployed — except Phase 5 (ISO auto-rebuild, `iso` repo out of scope). Only the documented intentional human gates remain.
+The projectbluefin factory is **~97% automated** across **124 workflows in 7 in-scope repos** (common 12, bluefin 27, bluefin-lts 17, dakota 23, actions 26, testsuite 10, iso 9; bonedigger 2 is out of audit scope, and `housekeeping` is deprecated with 0 workflows because org-wide automation now lives in `actions`). All 7 phases are now deployed — except Phase 5 (ISO auto-rebuild, `iso` repo out of scope). Only the documented intentional human gates remain.
 
 **Deployed phases (as of 2026-06-11):**
 
@@ -141,8 +141,8 @@ This audit will bit-rot quickly if not maintained. Future agents picking up audi
 Run these checks against the live state. Compare results to the README's Executive Summary and the per-doc claims:
 
 ```bash
-# 1. Workflow counts (audit currently claims 116 / 7 in-scope repos)
-for r in bluefin bluefin-lts common dakota actions iso bonedigger housekeeping; do
+# 1. Workflow counts (audit currently claims 124 / 7 in-scope repos)
+for r in bluefin bluefin-lts common dakota actions iso bonedigger; do
   n=$(ls ~/src/$r/.github/workflows/*.yml 2>/dev/null | wc -l); echo "$r: $n"
 done
 

--- a/docs/factory/automation-audit/pipeline-map.md
+++ b/docs/factory/automation-audit/pipeline-map.md
@@ -2,7 +2,7 @@
 
 > Generated: 2026-06-09 | Refreshed: 2026-06-10 (counts verified live), 2026-06-10 (drift pass: workflow counts, #423/#513 resolved) | Scope: projectbluefin org (common, bluefin, bluefin-lts, dakota, actions, testsuite, iso)
 >
-> Out-of-scope siblings (not part of the publish loop): `bonedigger` (2 workflows), `housekeeping` (0 workflows).
+> Out-of-scope siblings (not part of the publish loop): `bonedigger` (2 workflows). `housekeeping` is deprecated, has 0 workflows, and remains out of scope because org-wide automation lives in `projectbluefin/actions`.
 
 ## End-to-End Publishing Pipeline
 


### PR DESCRIPTION
Closes #617.

## Summary
- mark `projectbluefin/housekeeping` as a deprecated placeholder repo and point factory docs at `projectbluefin/actions`
- update the automation audit docs so they no longer describe housekeeping as an active org-wide automation repo
- record the cross-repo rule in `docs/factory/agentic-model.md`
- file the housekeeping deprecation notice issue: projectbluefin/housekeeping#1

## Validation
- `just check`
- `pre-commit run --all-files`
