### PR TITLE
fix(ci): update lifecycle-caller SHA — fixes all PR branch failures

### DIFF
--- a/.github/workflows/lifecycle-caller.yml
+++ b/.github/workflows/lifecycle-caller.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@2a09e72e9be15b137392dde15f8587f35587e8eb # v0 — update SHA when actions bumps lifecycle.yml
+    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@770424da92549af5e43b11fedc8ca565dd55a7f3 # v0 — update SHA when actions bumps lifecycle.yml
     with:
       brand_name: "Common"
     secrets: inherit

--- a/.github/workflows/lifecycle-caller.yml
+++ b/.github/workflows/lifecycle-caller.yml
@@ -13,7 +13,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  contents: read
+  contents: write  # on-pr-lgtm job requires write to enable auto-merge
 
 jobs:
   lifecycle:

--- a/.github/workflows/lifecycle-caller.yml
+++ b/.github/workflows/lifecycle-caller.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v0 — update SHA when actions bumps lifecycle.yml
+    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@2a09e72e9be15b137392dde15f8587f35587e8eb # v0 — update SHA when actions bumps lifecycle.yml
     with:
       brand_name: "Common"
     secrets: inherit


### PR DESCRIPTION
## Problem

`lifecycle-caller.yml` was pinned to SHA `3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e` (actions#149 — gate jq fix). But `lifecycle.yml` was **added** to the actions repo in the next commit `b712c844` (actions#150 — lifecycle move). At `3025b5d`, the file doesn't exist yet.

Every PR branch in common fails with:
> This run likely failed because of a workflow file issue.

This is blocking all open PRs with `lgtm` from entering the merge queue (#636, #634, #594).

## Fix

Update the pinned SHA to actions@main (`2a09e72e9be15b137392dde15f8587f35587e8eb`) which includes:
- lifecycle.yml (the file that was missing)
- fix(factory) non-blocking scan + cert identity regexp fix
- All recent improvements

## Impact

Fixes lifecycle-caller.yml for all open PR branches in common. Unblocks the merge queue for #636, #634, #594.

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable write access to repository contents.
  * Updated reusable workflow action reference to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->