### PR TITLE
test(scripts): add bats coverage for ublue-image-info.sh

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -100,3 +100,6 @@ jobs:
 
       - name: Run bats (ublue-motd)
         run: bats tests/test_ublue_motd.bats
+
+      - name: Run bats (ublue-image-info.sh)
+        run: bats tests/test_ublue_image_info.bats

--- a/system_files/shared/usr/bin/ublue-image-info.sh
+++ b/system_files/shared/usr/bin/ublue-image-info.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/bash
 
 # shellcheck disable=2046
-echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < /usr/share/ublue-os/image-info.json)"
+IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
+echo -n "$(jq -r '"\"(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
 
 if [[ "$(rpm-ostree status --booted)" =~ "signed" ]]; then
 	echo -n " 🔐"

--- a/tests/test_ublue_image_info.bats
+++ b/tests/test_ublue_image_info.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../system_files/shared/usr/bin/ublue-image-info.sh"
+WORKDIR=""
+MOCKDIR=""
+FIXTURE=""
+
+setup() {
+    WORKDIR="${BATS_TEST_DIRNAME}/.test_ublue_image_info.$$.$RANDOM"
+    rm -rf "${WORKDIR}"
+    MOCKDIR="${WORKDIR}/bin"
+    FIXTURE="${WORKDIR}/image-info.json"
+
+    mkdir -p "${MOCKDIR}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+write_mock() {
+    local name="$1"
+    local body="$2"
+
+    printf '%s\n' "${body}" > "${MOCKDIR}/${name}"
+    chmod +x "${MOCKDIR}/${name}"
+}
+
+write_jq_mock() {
+    write_mock "jq" '#!/usr/bin/bash
+/usr/bin/jq "$@"'
+}
+
+write_rpm_ostree_mock() {
+    local body="$1"
+
+    write_mock "rpm-ostree" "#!/usr/bin/bash
+${body}"
+}
+
+write_image_info_fixture() {
+    local image_name="$1"
+    local image_tag="$2"
+
+    cat > "${FIXTURE}" <<EOF
+{
+  "image-name": "${image_name}",
+  "image-tag": "${image_tag}"
+}
+EOF
+}
+
+run_script() {
+    local image_info_file="$1"
+    local path_value="$2"
+
+    run env IMAGE_INFO_FILE="${image_info_file}" PATH="${path_value}" /usr/bin/bash "${SCRIPT_UNDER_TEST}"
+}
+
+@test "ublue-image-info: prints image name, tag, and locked status with fixture data" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bluefin:latest 🔐" ]
+}
+
+@test "ublue-image-info: shows unlocked status when rpm-ostree output lacks signed marker" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment"'
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'bluefin:latest \033[5m🔓\033[0m' ]
+}
+
+@test "ublue-image-info: handles missing image-info.json without failing" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+
+    run_script "${WORKDIR}/missing-image-info.json" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"${WORKDIR}/missing-image-info.json: No such file or directory"* ]]
+    [[ "${output}" == *" 🔐" ]]
+}
+
+@test "ublue-image-info: handles missing jq without failing" {
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}"
+
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"jq: command not found"* ]]
+    [[ "${output}" == *" 🔐" ]]
+}


### PR DESCRIPTION
## Summary

Replaces #627 (which had a merge conflict due to main diverging after the branch was cut).

### Changes

- **`system_files/shared/usr/bin/ublue-image-info.sh`**: Add `IMAGE_INFO_FILE` env var override so the script can be tested without root/system paths. Defaults to the production path.

- **`tests/test_ublue_image_info.bats`**: 4 bats test cases covering:
  - Normal output with mock `image-info.json` fixture
  - Signed vs unsigned `rpm-ostree` display (🔐 / 🔓)
  - Graceful error when `image-info.json` is missing
  - Graceful error when `jq` is not on PATH

- **`.github/workflows/unit-tests.yml`**: Wire up the new test file in CI.

Closes #596
Closes #591