### PR TITLE
fix(ci): skip CVE scan in merge queue to fix SARIF upload ref error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
           oci: true
 
       - name: Export image for scanning
+        if: github.event_name != 'merge_group'
         shell: bash
         run: |
           set -eoux pipefail
@@ -90,6 +91,7 @@ jobs:
             "docker-archive:/tmp/scan-image.tar:${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.local_tag }}"
 
       - name: Scan image for CVEs
+        if: github.event_name != 'merge_group'
         uses: projectbluefin/actions/bootc-build/scan-image@e39c94703801a272245bf2a96416594f36fe6f93 # v1
         with:
           input: /tmp/scan-image.tar


### PR DESCRIPTION
## Problem

The `upload-sarif` step inside `projectbluefin/actions/bootc-build/scan-image` fails in `merge_group` events:

```
##[error]ref 'refs/heads/gh-readonly-queue/main/pr-543-...' not found in this repository
```

The ephemeral `gh-readonly-queue/...` ref is not resolvable by `codeql-action/upload-sarif`, causing the Build job to fail and blocking every PR in the merge queue (currently blocking #543).

## Fix

Add `if: github.event_name != 'merge_group'` to both:
- `Export image for scanning`
- `Scan image for CVEs`

PR builds already run the full Trivy scan. The merge queue build is redundant for CVE checking — its purpose is to verify the combined commit builds cleanly, not re-scan for CVEs.

## Testing

- Existing PR builds: unchanged (scan still runs on `pull_request`)
- Merge queue builds: skip scan, proceed to manifest creation if on main
- Main push builds: unchanged (scan still runs)

Closes #543 (unblocks the stuck merge queue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated so image export and vulnerability scanning steps run only for non-merge_group events.
  * Reduces unnecessary scanning in grouped merge scenarios, improving pipeline efficiency and resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->