### PR TITLE
fix(ci): restore btrfs storage backend so push-image can find built image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup runner
         uses: projectbluefin/actions/bootc-build/setup-runner@dc35eb231998ba93244072ec72781e36f373a4a3 # v1
         with:
-          storage-backend: remove-software
+          storage-backend: btrfs
           update-podman: "true"
 
       - name: Generate tags


### PR DESCRIPTION
## What

One-line fix: `storage-backend: remove-software` → `storage-backend: btrfs` in `.github/workflows/build.yml`.

## Why it's broken

`push-image` composite action uses `sudo -E podman push`. That runs podman as root, which looks in `/var/lib/containers/storage`. Meanwhile `redhat-actions/buildah-build` runs rootless and stores the image in `~/.local/share/containers/storage`.

With the `remove-software` backend, no BTRFS volume is mounted at `/var/lib/containers`, so the two stores are independent. Older podman used to bridge them; newer podman from Ubuntu resolute (25.04) no longer does. Result: `Error: common:XXXXXX-amd64: image not known` at push time — every push to main fails.

## Why btrfs fixes it

The `btrfs` backend mounts a BTRFS loopback at `/var/lib/containers` via `ublue-os/container-storage-action`, which the action configures as the shared graphroot for both user and root. Both rootless buildah and `sudo podman` then use the same store, so the image is always findable at push time.

`btrfs` is also the designed default for `setup-runner` — `remove-software` is explicitly documented as the non-BTRFS fallback (no shared graphroot, less disk space freed).

## Evidence

All 8 push-to-main Build runs today fail with identical `image not known` errors. `fix/changelog-bt-fixes` builds appear green because PRs skip the push step (`if: github.event_name != 'pull_request'`), masking the failure.

P0 — main has been unshippable all day.