### PR TITLE
fix(update): detect layered rpm-ostree packages and block with guidance

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -14,12 +14,12 @@ update:
         echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
         exit 1
     fi
-    if [ -f /etc/rpm-ostreed.conf ] && grep -q -E -e "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*false([[:space:]]*(#.*)?)?$" /etc/rpm-ostreed.conf ; then
-        rpm-ostree upgrade
-    else
-        sudo bootc upgrade
+    if rpm-ostree status --booted 2>/dev/null | grep -q "Layered packages:"; then
+        echo "Status: Layered Packages Detected"
+        echo "Run an \`rpm-ostree reset\` and try again. This removes the Zero Maintenance guarantee, take appropriate precautions!"
+        exit 1
     fi
-    # rpm-ostree used due to bootc upgrade not supporting local layered packages
+    sudo bootc upgrade
     # Updates system Flatpaks
     if flatpak remotes | grep -q system; then
         flatpak update -y

--- a/tests/test_update_just.bats
+++ b/tests/test_update_just.bats
@@ -76,13 +76,25 @@ echo "sudo $*" >> "${COMMAND_LOG}"
 exec "$@"
 MOCK
 
-    for cmd in bootc rpm-ostree; do
+    for cmd in bootc; do
         cat > "${MOCKDIR}/${cmd}" <<MOCK
 #!/bin/bash
 echo "${cmd} \$*" >> "\${COMMAND_LOG}"
 MOCK
         chmod +x "${MOCKDIR}/${cmd}"
     done
+
+    _write_mock "rpm-ostree" <<'MOCK'
+#!/bin/bash
+echo "rpm-ostree $*" >> "${COMMAND_LOG}"
+if [[ "$1" == "status" && "$2" == "--booted" ]]; then
+    if [[ "${MOCK_HAS_LAYERED_PACKAGES:-0}" == "1" ]]; then
+        printf 'State: idle\nDeployments:\n* fedora:fedora/40/x86_64/silverblue\n  Layered packages: howdy\n'
+    else
+        printf 'State: idle\nDeployments:\n* fedora:fedora/40/x86_64/silverblue\n'
+    fi
+fi
+MOCK
 
     _write_mock "flatpak" <<'MOCK'
 #!/bin/bash
@@ -101,11 +113,6 @@ MOCK
 
     _write_mock "grep" <<'MOCK'
 #!/bin/bash
-for arg in "$@"; do
-    if [[ "$arg" == "/etc/rpm-ostreed.conf" ]]; then
-        [[ "${MOCK_LOCK_LAYERING_FALSE:-0}" == "1" ]] && exit 0 || exit 1
-    fi
-done
 exec /usr/bin/grep "$@"
 MOCK
 
@@ -125,7 +132,7 @@ _run() {
         MOCK_ENABLED_TIMER="${MOCK_ENABLED_TIMER:-}" \
         MOCK_FLATPAK_REMOTES="${MOCK_FLATPAK_REMOTES:-}" \
         MOCK_GUM_CHOICE="${MOCK_GUM_CHOICE:-}" \
-        MOCK_LOCK_LAYERING_FALSE="${MOCK_LOCK_LAYERING_FALSE:-0}" \
+        MOCK_HAS_LAYERED_PACKAGES="${MOCK_HAS_LAYERED_PACKAGES:-0}" \
         MOCK_BREW_BIN="${MOCK_BREW_BIN:-${WORKDIR}/missing-brew}" \
         bash "$@"
 }
@@ -149,11 +156,19 @@ _run() {
     ! grep -qF "bootc upgrade" "${COMMAND_LOG}"
 }
 
-@test "update: runs bootc upgrade when LockLayering=false is not detected" {
+@test "update: runs bootc upgrade when no layered packages are present" {
     _run "${UPDATE_SCRIPT}"
     [ "${status}" -eq 0 ]
     grep -qF "sudo bootc upgrade" "${COMMAND_LOG}"
     ! grep -qF "rpm-ostree upgrade" "${COMMAND_LOG}"
+}
+
+@test "update: exits early with layered-packages warning when rpm-ostree has layered packages" {
+    MOCK_HAS_LAYERED_PACKAGES=1 _run "${UPDATE_SCRIPT}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"Status: Layered Packages Detected"* ]]
+    [[ "${output}" == *"rpm-ostree reset"* ]]
+    ! grep -qF "sudo bootc upgrade" "${COMMAND_LOG}"
 }
 
 @test "update: updates system flatpaks when system remote exists" {


### PR DESCRIPTION
## What

Replaces the broken `/etc/rpm-ostreed.conf` grep with a direct check of `rpm-ostree status --booted`.

## Why the old approach was broken

The previous condition:
```bash
grep -q -E "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*false" /etc/rpm-ostreed.conf
```
is always false on bootc systems — the file is absent or lacks this setting. So the recipe silently fell through to `sudo bootc upgrade` even for users with layered packages (e.g. Howdy), leaving those packages unupgraded with no warning.

## New behaviour

```bash
if rpm-ostree status --booted 2>/dev/null | grep -q "Layered packages:"; then
    echo "Status: Layered Packages Detected"
    echo "Run an \`rpm-ostree reset\` and try again. This removes the Zero Maintenance guarantee, take appropriate precautions!"
    exit 1
fi
sudo bootc upgrade
```

Users with layered packages get a clear message and a path forward. Clean systems proceed as before.

## Tests

- Renamed stale test to reflect new detection logic
- Updated rpm-ostree mock to emit layered packages output on demand
- Simplified grep mock (no longer needs rpm-ostreed.conf special case)
- Added new test: layered packages present → exits 1 with correct message

Ref: https://github.com/ublue-os/bluefin/discussions/4751#discussioncomment-17252344