### PR TITLE
fix(tests): remove orphaned uutils.sh tests from test_profile_d.bats

### DIFF
--- a/tests/test_profile_d.bats
+++ b/tests/test_profile_d.bats
@@ -1,11 +1,9 @@
 #!/usr/bin/env bats
 # Tests for system_files/bluefin/etc/profile.d/caffeinate.sh
-#          system_files/bluefin/etc/profile.d/uutils.sh
 #
 # Run: bats tests/test_profile_d.bats
 
 CAFFEINATE_SCRIPT="$BATS_TEST_DIRNAME/../system_files/bluefin/etc/profile.d/caffeinate.sh"
-UUTILS_SCRIPT="$BATS_TEST_DIRNAME/../system_files/bluefin/etc/profile.d/uutils.sh"
 WORKDIR=""
 
 setup() {
@@ -87,105 +85,4 @@ teardown() {
     [[ "${output}" == *"--what=idle"* ]]
     [[ "${output}" == *"--who=caffeinate"* ]]
     [[ "${output}" == *"make test"* ]]
-}
-
-# ---------------------------------------------------------------------------
-# uutils.sh — non-interactive shell (PATH must not be modified)
-#
-# Use a sanitised PATH (no pre-existing uubin from the host) so tests are
-# reproducible even on machines where linuxbrew is installed.
-# ---------------------------------------------------------------------------
-
-@test "uutils: PATH is unchanged when sourced in a non-interactive shell" {
-    run bash -c "PATH='/usr/bin:/bin'; source '${UUTILS_SCRIPT}'; printf '%s\n' \"\${PATH}\""
-    [ "${status}" -eq 0 ]
-    [ "${output}" = "/usr/bin:/bin" ]
-}
-
-@test "uutils: uubin prefix is absent from PATH in non-interactive shell" {
-    run bash -c "PATH='/usr/bin:/bin'; source '${UUTILS_SCRIPT}'; printf '%s\n' \"\${PATH}\""
-    [ "${status}" -eq 0 ]
-    [[ "${output}" != */uubin* ]]
-}
-
-# ---------------------------------------------------------------------------
-# uutils.sh — dirs absent (PATH must not be modified)
-# ---------------------------------------------------------------------------
-
-@test "uutils: PATH is unchanged when uubin dirs are absent" {
-    # Patch directory path to a temp location where the dirs do NOT exist,
-    # and bypass the interactive-shell check so the only guard is the -d test.
-    PATCHED="${WORKDIR}/uutils_nodirs.sh"
-    sed -e "s|/home/linuxbrew|${WORKDIR}/linuxbrew|g" \
-        -e 's/\$- == \*i\*/true/' \
-        "${UUTILS_SCRIPT}" > "${PATCHED}"
-
-    run bash -c "PATH='/usr/bin:/bin'; source '${PATCHED}'; printf '%s\n' \"\${PATH}\""
-    [ "${status}" -eq 0 ]
-    [ "${output}" = "/usr/bin:/bin" ]
-}
-
-# ---------------------------------------------------------------------------
-# uutils.sh — dirs present (PATH must be prepended)
-#
-# We test the PATH-modification logic without relying on bash -i (which
-# triggers .bashrc / MOTD noise).  Instead we patch both the hard-coded
-# linuxbrew path AND the \$- interactive check so the block always runs.
-# ---------------------------------------------------------------------------
-
-_patch_uutils_active() {
-    # Produce a patched copy where:
-    #   /home/linuxbrew  →  ${WORKDIR}/linuxbrew  (controllable dirs)
-    #   $- == *i*        →  true                  (always enter the block)
-    local patched="${WORKDIR}/uutils_active.sh"
-    sed -e "s|/home/linuxbrew|${WORKDIR}/linuxbrew|g" \
-        -e 's/\$- == \*i\*/true/' \
-        "${UUTILS_SCRIPT}" > "${patched}"
-    echo "${patched}"
-}
-
-_create_uubin_dirs() {
-    mkdir -p "${WORKDIR}/linuxbrew/.linuxbrew/opt/uutils-coreutils/libexec/uubin"
-    mkdir -p "${WORKDIR}/linuxbrew/.linuxbrew/opt/uutils-diffutils/libexec/uubin"
-    mkdir -p "${WORKDIR}/linuxbrew/.linuxbrew/opt/uutils-findutils/libexec/uubin"
-}
-
-@test "uutils: PATH is prepended with all three uubin dirs when dirs exist" {
-    _create_uubin_dirs
-    PATCHED="$(_patch_uutils_active)"
-
-    run bash -c "PATH='/usr/bin:/bin'; source '${PATCHED}'; printf '%s\n' \"\${PATH}\""
-    [ "${status}" -eq 0 ]
-    [[ "${output}" == *"uutils-coreutils/libexec/uubin"* ]]
-    [[ "${output}" == *"uutils-diffutils/libexec/uubin"* ]]
-    [[ "${output}" == *"uutils-findutils/libexec/uubin"* ]]
-}
-
-@test "uutils: uubin dirs appear before original PATH entries" {
-    _create_uubin_dirs
-    PATCHED="$(_patch_uutils_active)"
-
-    run bash -c "PATH='/usr/bin:/bin'; source '${PATCHED}'; printf '%s\n' \"\${PATH}\""
-    [ "${status}" -eq 0 ]
-    # uubin must appear before /usr/bin in the colon-separated PATH
-    [[ "${output}" =~ uubin.*:/usr/bin ]]
-}
-
-@test "uutils: stty alias is set to /usr/bin/stty when dirs exist" {
-    _create_uubin_dirs
-    PATCHED="$(_patch_uutils_active)"
-
-    run bash -c "source '${PATCHED}'; alias stty 2>/dev/null"
-    [ "${status}" -eq 0 ]
-    [[ "${output}" == *"/usr/bin/stty"* ]]
-}
-
-@test "uutils: only coreutils dir existence gates the block" {
-    # Only create the coreutils dir — the script checks only this path
-    mkdir -p "${WORKDIR}/linuxbrew/.linuxbrew/opt/uutils-coreutils/libexec/uubin"
-    PATCHED="$(_patch_uutils_active)"
-
-    run bash -c "PATH='/usr/bin:/bin'; source '${PATCHED}'; printf '%s\n' \"\${PATH}\""
-    [ "${status}" -eq 0 ]
-    [[ "${output}" == *"uutils-coreutils/libexec/uubin"* ]]
 }


### PR DESCRIPTION
## What

Removes 8 `@test` blocks and the `UUTILS_SCRIPT` variable from `tests/test_profile_d.bats` that tested `system_files/bluefin/etc/profile.d/uutils.sh`.

## Why

`uutils.sh` was deleted in `5e5c6f3` as part of the brew-preinstall commit:

> Remove uutils.sh. Dakota ships uutils natively via BuildStream.

The tests referencing it were added in `6642931` **after** that deletion and have been causing the Unit Tests job to fail on main ever since:

```
`sed -e "s|/home/linuxbrew|${WORKDIR}/linuxbrew|g" \` failed with status 2
`[[ "${output}" == *"uutils-coreutils/libexec/uubin"* ]]` failed
```

`sed` exits 2 because the source file doesn't exist. The tests can never pass without `uutils.sh` present.

## Verification

- [ ] CI passes (Unit Tests job should go green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test suite for a specific utility script, consolidating test coverage to focus on core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->