### PR TITLE
feat(nvidia): enable nvidia-cdi-refresh systemd preset for CDI GPU passthrough

### DIFF
--- a/system_files/nvidia/usr/lib/systemd/system-preset/80-nvidia-container-toolkit.preset
+++ b/system_files/nvidia/usr/lib/systemd/system-preset/80-nvidia-container-toolkit.preset
@@ -1,0 +1,10 @@
+# Enable CDI spec auto-generation so 'podman run --device nvidia.com/gpu=all' works
+# out of the box on nvidia image variants.
+#
+# nvidia-cdi-refresh.path watches /lib/modules/*/modules.dep and /usr/bin/nvidia-ctk
+# and re-triggers nvidia-cdi-refresh.service whenever the driver or toolkit changes.
+# The service runs 'nvidia-ctk cdi generate' and writes /var/run/cdi/nvidia.yaml.
+#
+# Mirrors the preset in projectbluefin/dakota elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
+enable nvidia-cdi-refresh.path
+enable nvidia-cdi-refresh.service


### PR DESCRIPTION
Closing as redundant with upstream RPM.

The `nvidia-container-toolkit-base` RPM (which Bluefin NVIDIA images already ship) includes `90-nvidia-container-toolkit.preset` in its `%package base` section, which enables the same `nvidia-cdi-refresh.path` and `nvidia-cdi-refresh.service` units that this PR targets.

Verified via: https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/packaging/rpm/SPECS/nvidia-container-toolkit.spec

Adding a custom `80-nvidia-container-toolkit.preset` would shadow the upstream preset, masking future upstream changes with no functional benefit.

hanthor review confirmed the gap — closing rather than merging.