### PR TITLE
fix(ci): update create-github-app-token to v3 in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Generate GitHub App token for downstream dispatch
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}


### PR DESCRIPTION
v1 (d72941d) uses Node.js 20, which fails with Invalid keyData on current runners (ubuntu24/20260607.184+). v3 (bcd2ba4) uses Node.js 24.

This fixes downstream dispatch — the token step that notifies bluefin, bluefin-lts, and dakota after a common build.

Same SHA already in use by sync-labels.yml and sync-codeowners.yml.

Supersedes the build.yml hunk in PR #681, which is now DIRTY due to the renovate-automerge.yml refactor in 225451f.