### PR TITLE
fix(gnome): restore Super+e Nautilus keybinding; auto-install ASUS tools on first boot

### DIFF
--- a/system_files/bluefin/etc/dconf/db/distro.d/02-bluefin-keybindings
+++ b/system_files/bluefin/etc/dconf/db/distro.d/02-bluefin-keybindings
@@ -30,3 +30,8 @@ name='Open up the emoji picker'
 binding='<Super>period'
 command="flatpak run it.mijorus.smile"
 name='Open up the emoji picker (Alt)'
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom7]
+binding='<Super>e'
+command='nautilus'
+name='Files'

--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -106,8 +106,7 @@ folder-children=['Games', 'GamingUtilities', 'Utilities', 'Containers', 'Wine', 
 
 # Modifying shortcut actions for custom0, custom1, custom2, etc. are recognized as relocatable schemas
 [org.gnome.settings-daemon.plugins.media-keys]
-custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/']
-home=['<Super>e']
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom7/']
 
 # Ptyxis color palette is recognized as a relocatable schema
 [org.gnome.Ptyxis]

--- a/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/11-asus.sh
+++ b/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/11-asus.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+SYS_VENDOR="$(cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null || true)"
+
+# Only run on ASUS hardware
+if [[ ! "$SYS_VENDOR" =~ ASUSTeK|ASUS ]]; then
+    exit 0
+fi
+
+# asusd is installed by the user-setup hook via brew on first login.
+# On subsequent boots, enable the system service once it exists.
+if ! systemctl list-unit-files asusd.service &>/dev/null; then
+    echo "asus-setup: asusd.service not present yet, skipping"
+    exit 0
+fi
+
+version-script asus system 1 || exit 0
+
+set -x
+
+echo "ASUS hardware detected, enabling system services..."
+
+systemctl enable --now asusd.service asus-shutdown.service || true
+udevadm control --reload
+udevadm trigger
+
+echo "ASUS system setup complete"

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/11-asus.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/11-asus.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+SYS_VENDOR="$(cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null || true)"
+
+# Only run on ASUS hardware
+if [[ ! "$SYS_VENDOR" =~ ASUSTeK|ASUS ]]; then
+    exit 0
+fi
+
+version-script asus user 1 || exit 0
+
+set -xeuo pipefail
+
+BREW_BIN="/var/home/linuxbrew/.linuxbrew/bin/brew"
+
+if [[ ! -x "${BREW_BIN}" ]]; then
+    echo "asus-setup: brew not found, skipping ASUS tool install"
+    exit 0
+fi
+
+eval "$("${BREW_BIN}" shellenv)"
+
+echo "ASUS hardware detected, installing ASUS tools..."
+
+brew tap --trust ublue-os/tap
+brew install --cask ublue-os/tap/asusctl-linux
+brew install --cask ublue-os/tap/rog-control-center-linux
+
+systemctl --user daemon-reload
+systemctl --user enable --now asusd-user.service || true
+
+echo "ASUS user setup complete"


### PR DESCRIPTION
Closing — this PR bundles two unrelated issues and was branched from a dirty main (before the AI stack revert). Replaced by:
- PR #690: fix(keybinding): restore Super+E (issue #686)
- PR #692: feat(oem): ASUS hardware hooks (issue #673)