### PR TITLE
feat(oem): add ASUS hardware auto-install hooks

### DIFF
--- a/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/11-asus.sh
+++ b/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/11-asus.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+SYS_VENDOR="$(cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null || true)"
+
+# Only run on ASUS hardware
+if [[ ! "$SYS_VENDOR" =~ ASUSTeK|ASUS ]]; then
+    exit 0
+fi
+
+# asusd is installed by the user-setup hook via brew on first login.
+# On subsequent boots, enable the system service once it exists.
+if ! systemctl list-unit-files asusd.service &>/dev/null; then
+    echo "asus-setup: asusd.service not present yet, skipping"
+    exit 0
+fi
+
+version-script asus system 1 || exit 0
+
+set -x
+
+echo "ASUS hardware detected, enabling system services..."
+
+systemctl enable --now asusd.service asus-shutdown.service || true
+udevadm control --reload
+udevadm trigger
+
+echo "ASUS system setup complete"

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/11-asus.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/11-asus.sh
@@ -3,6 +3,8 @@
 # shellcheck disable=SC1091
 source /usr/lib/ublue/setup-services/libsetup.sh
 
+set -euo pipefail
+
 SYS_VENDOR="$(cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null || true)"
 
 # Only run on ASUS hardware
@@ -22,7 +24,7 @@ fi
 
 version-script asus user 1 || exit 0
 
-set -x
+set -x  # trace from here; set -euo pipefail already active from top
 
 eval "$("${BREW_BIN}" shellenv)"
 

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/11-asus.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/11-asus.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+SYS_VENDOR="$(cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null || true)"
+
+# Only run on ASUS hardware
+if [[ ! "$SYS_VENDOR" =~ ASUSTeK|ASUS ]]; then
+    exit 0
+fi
+
+# Check brew before version-script: if brew is absent on first login we must
+# not record completion — version-script cannot be undone once it writes,
+# and the hook would permanently skip on all future logins.
+BREW_BIN="/var/home/linuxbrew/.linuxbrew/bin/brew"
+
+if [[ ! -x "${BREW_BIN}" ]]; then
+    echo "asus-setup: brew not found, will retry on next login"
+    exit 0
+fi
+
+version-script asus user 1 || exit 0
+
+set -x
+
+eval "$("${BREW_BIN}" shellenv)"
+
+echo "ASUS hardware detected, installing ASUS tools..."
+
+brew tap --trust ublue-os/tap
+brew install --cask ublue-os/tap/asusctl-linux
+brew install --cask ublue-os/tap/rog-control-center-linux
+
+systemctl --user daemon-reload
+systemctl --user enable --now asusd-user.service || true
+
+echo "ASUS user setup complete"


### PR DESCRIPTION
Adds one-shot first-boot hooks for ASUSTeK hardware detected via DMI sys_vendor.

user-setup.hooks.d/11-asus.sh: checks brew exists BEFORE calling version-script (prevents permanent skip if brew absent on first login), installs asusctl-linux + rog-control-center-linux from ublue-os/tap, enables asusd-user.service.

system-setup.hooks.d/11-asus.sh: enables asusd.service + asus-shutdown.service once unit files are present. Skips on first boot (before user hook has installed them).

Closes #673.