### PR TITLE
fix(brew): trust ublue-os taps for Homebrew 6.0 compatibility

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -136,10 +136,10 @@ toggle-devmode:
 
     # Taps are silent/fast — run before the progress bar
     if _dx_wants -E "VS Code|VSCodium|Antigravity|JetBrains"; then
-        brew tap ublue-os/tap 2>/dev/null || true
+        brew tap --trust ublue-os/tap
     fi
     if _dx_wants "Zed"; then
-        brew tap ublue-os/experimental-tap 2>/dev/null || true
+        brew tap --trust ublue-os/experimental-tap
     fi
 
     # Build install queue for the progress bar

--- a/system_files/shared/usr/share/ublue-os/homebrew/ai-tools.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/ai-tools.Brewfile
@@ -1,7 +1,7 @@
 tap "anomalyco/tap"
 tap "charmbracelet/tap"
-tap "ublue-os/tap"
-tap "ublue-os/experimental-tap"
+tap "ublue-os/tap", trusted: true
+tap "ublue-os/experimental-tap", trusted: true
 brew "aichat"
 brew "anomalyco/tap/opencode"
 brew "block-goose-cli"

--- a/system_files/shared/usr/share/ublue-os/homebrew/artwork.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/artwork.Brewfile
@@ -1,4 +1,4 @@
-tap "ublue-os/tap"
+tap "ublue-os/tap", trusted: true
 
 cask "aurora-wallpapers"
 cask "bazzite-wallpapers"

--- a/system_files/shared/usr/share/ublue-os/homebrew/experimental-ide.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/experimental-ide.Brewfile
@@ -1,4 +1,4 @@
-tap "ublue-os/experimental-tap"
+tap "ublue-os/experimental-tap", trusted: true
 cask "ublue-os/experimental-tap/cursor-linux"
 cask "ublue-os/experimental-tap/clion-linux"
 cask "ublue-os/experimental-tap/datagrip-linux"

--- a/system_files/shared/usr/share/ublue-os/homebrew/ide.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/ide.Brewfile
@@ -1,4 +1,4 @@
-tap "ublue-os/tap"
+tap "ublue-os/tap", trusted: true
 cask "ublue-os/tap/visual-studio-code-linux"
 cask "ublue-os/tap/visual-studio-code-linux@insiders"
 cask "ublue-os/tap/vscodium-linux"


### PR DESCRIPTION
Homebrew 6.0.0 (2026-06-11) requires taps to be explicitly trusted before their formulae/casks are usable. Without this, brew install from ublue-os/tap and ublue-os/experimental-tap silently fails for all users.

Affected installs: VS Code, VSCodium, JetBrains Toolbox, Antigravity, Zed, Cursor, framework_tool, asusctl-linux, rog-control-center-linux.

- system.just: brew tap --trust replaces brew tap 2>/dev/null || true
- ai-tools.Brewfile, artwork.Brewfile, experimental-ide.Brewfile, ide.Brewfile: trusted: true added to all ublue-os tap declarations

Reference: https://brew.sh/2026/06/11/homebrew-6.0.0/

Closes #665.