### PR TITLE
fix(ci): promote rootless buildah image to root storage before push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,18 @@ jobs:
             "${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.local_tag }}" \
             "docker-archive:/tmp/scan-image.tar:${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.local_tag }}"
 
+      - name: Promote image to root storage for push
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -eoux pipefail
+          # buildah-build stores in rootless user storage; push-image uses
+          # sudo podman push which reads root storage (/var/lib/containers).
+          # Import the already-exported scan archive into root storage.
+          sudo skopeo copy \
+            "docker-archive:/tmp/scan-image.tar:${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.local_tag }}" \
+            "containers-storage:${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.local_tag }}"
+
       - name: Scan image for CVEs
         if: github.event_name != 'merge_group'
         uses: projectbluefin/actions/bootc-build/scan-image@74c4356b36dd94c0eadf15bbe63a26b58a0e7468 # v1


### PR DESCRIPTION
buildah-build stores images in rootless user storage. push-image uses sudo podman push which reads root storage. These are different namespaces — push fails with 'image not known'.

Root cause of every main branch Build failure since 2026-06-13T03:38 (commit 31b2fae added setup-runner + push-image composite; before that, push-to-registry was used which reads rootless storage directly).

Fix: after exporting to docker-archive for scanning, sudo skopeo copy the archive into root containers-storage so push-image can find it.