### PR TITLE
fix(ci): make downstream dispatch non-blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,7 @@ jobs:
 
       - name: Generate GitHub App token for downstream dispatch
         id: app-token
+        continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
@@ -202,6 +203,7 @@ jobs:
           repositories: bluefin,bluefin-lts,dakota
 
       - name: Notify downstream repos of common image update
+        if: steps.app-token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
MERGERAPTOR_PRIVATE_KEY fails rsaImportKey — the secret needs admin rotation (same Invalid keyData error in both v1/v3 of create-github-app-token, and sync-labels.yml has been failing since June 5 for the same reason).

Build, push, sign, and SBOM all now work. Only the downstream dispatch token fails.

Use continue-on-error on the token step and gate the notify step on success. Downstream repos will miss the auto-trigger until the secret is rotated, but the build goes green.

Note for admin: MERGERAPTOR_PRIVATE_KEY needs to be regenerated at https://github.com/organizations/projectbluefin/settings/apps/mergeraptor and re-added as an org secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Improved build workflow resilience by implementing better error handling to ensure downstream repository notifications remain stable even when intermediary workflow steps encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->