### PR TITLE
fix: set summer wallpaper default and run on first login

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -5,8 +5,8 @@ favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop
 enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'custom-command-list@storageb.github.com', 'dash-to-dock@micxgx.gmail.com', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io']
 
 [org.gnome.desktop.background]
-picture-uri='file:///usr/share/backgrounds/bluefin/12-bluefin.xml'
-picture-uri-dark='file:///usr/share/backgrounds/bluefin/12-bluefin.xml'
+picture-uri='file:///usr/share/backgrounds/bluefin/06-bluefin.xml'
+picture-uri-dark='file:///usr/share/backgrounds/bluefin/06-bluefin.xml'
 picture-options='zoom'
 primary-color='000000'
 secondary-color='FFFFFF'

--- a/system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh
+++ b/system_files/bluefin/usr/share/ublue-os/user-setup.hooks.d/20-dynamic-wallpaper.sh
@@ -8,3 +8,6 @@ version-script dynamic-wallpaper user 1 || exit 0
 
 echo "Enabling dynamic wallpaper timer"
 systemctl --user enable --now bluefin-dynamic-wallpaper.timer
+
+echo "Setting initial dynamic wallpaper"
+/usr/libexec/bluefin-dynamic-wallpaper || true


### PR DESCRIPTION
The gschema override was hardcoded to `12-bluefin.xml` (December) from when wallpapers were first added in December 2025. This caused all new ISO installs to show the winter wallpaper regardless of season.

## Changes

1. **Update gschema default** to `06-bluefin.xml` for the current summer season (`zz0-bluefin-modifications.gschema.override`)
2. **Run dynamic wallpaper immediately** in the user-setup hook so the correct season is applied on first login, not after the 1-minute timer delay (`20-dynamic-wallpaper.sh`)

## Why both?

The gschema fix covers the state before first login (GDM, initial GNOME session). The hook fix covers the edge case where a user installs in June but the timer hasn't fired yet — the wallpaper now updates immediately on first login rather than showing whatever month the gschema hardcoded.

Note: The gschema will need to be updated each season going forward, or better yet replaced with a dynamic default that reads the current month. That's a follow-up; this is the minimum fix for the current summer season.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the default desktop background image configuration to ensure proper and consistent rendering in both light and dark display modes.

* **New Features**
  * Dynamic wallpaper functionality now automatically initializes when your user session starts, providing an improved and consistent visual experience from your first login onwards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->