### PR TITLE
fix(ci): remove unnecessary mergeraptor token from renovate-automerge; fix vars/secrets inconsistency

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -9,28 +9,16 @@ permissions:
   contents: write
   pull-requests: write
 
+# common/main has no branch protection rules that require a bypass actor,
+# so GITHUB_TOKEN (the default in the reusable) is sufficient.
+# A mergeraptor app token is NOT needed here — and adding an unnecessary
+# get-token step that reads secrets.MERGERAPTOR_APP_ID (which does not
+# exist; the app ID is stored as vars.MERGERAPTOR_APP_ID) caused every
+# automerge run to fail with "Invalid keyData" from create-github-app-token.
 jobs:
-  # Generate a mergeraptor app token. github-actions[bot] is not in the
-  # main branch bypass allowances but mergeraptor is, so this token is
-  # required for the reusable to squash-merge into main.
-  get-token:
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
-    outputs:
-      token: ${{ steps.app-token.outputs.token }}
-    steps:
-      - name: Get mergeraptor token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
-          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-
   automerge:
-    needs: get-token
-    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@74c4356b36dd94c0eadf15bbe63a26b58a0e7468 # v1
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1
     with:
       head_sha: ${{ github.event.workflow_run.head_sha }}
       base_branch: main
-    secrets:
-      token: ${{ needs.get-token.outputs.token }}

--- a/.github/workflows/sync-codeowners.yml
+++ b/.github/workflows/sync-codeowners.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Require mergeraptor secrets
         run: |
           if [[ -z "${{ secrets.MERGERAPTOR_APP_ID }}" || -z "${{ secrets.MERGERAPTOR_PRIVATE_KEY }}" ]]; then
-            echo "::error::MERGERAPTOR_APP_ID and MERGERAPTOR_PRIVATE_KEY must be set as org/repo secrets."
+            echo "::error::MERGERAPTOR_APP_ID (vars) and MERGERAPTOR_PRIVATE_KEY (secrets) must be set."
             echo "::error::These are required for cross-repo CODEOWNERS sync. Configure the mergeraptor GitHub App."
             exit 1
           fi
@@ -32,7 +32,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          client-id: ${{ vars.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
           owner: projectbluefin
 


### PR DESCRIPTION
## Problem

`common/renovate-automerge.yml` used `secrets.MERGERAPTOR_APP_ID` to get a mergeraptor app token — but:

1. **The token is unnecessary.** `common/main` has no branch protection rules. `GITHUB_TOKEN` (the default fallback in the reusable) is sufficient to squash-merge Renovate PRs.

2. **`secrets.MERGERAPTOR_APP_ID` doesn't exist.** The app ID is not sensitive and is stored as an Actions *variable* (`vars.MERGERAPTOR_APP_ID`), not a secret. So `create-github-app-token` received an empty `client-id`, built an invalid JWT payload, and Node 24's `SubtleCrypto.importKeySync` threw `Invalid keyData` — a deeply confusing error that looks like a bad private key when the actual issue is an empty issuer.

This blocked **every** Renovate automerge in `common` for as long as the token step ran.

## Fix

- `renovate-automerge.yml`: remove the `get-token` job entirely. Call the reusable with `GITHUB_TOKEN` (implicit). Bump to `@v1` managed tag so it stays current without manual pin updates.
- `sync-codeowners.yml`: fix same `secrets` → `vars` reference for `MERGERAPTOR_APP_ID`.

## Factory-wide note

The `secrets` vs `vars` inconsistency for `MERGERAPTOR_APP_ID` exists in two other workflows:
- `projectbluefin/actions` `factory-health.yml` — fixed in a companion PR
- `projectbluefin/common` `sync-codeowners.yml` — fixed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the automated merge workflow to streamline token handling and reduce complexity
  * Updated credential configuration in the code ownership synchronization workflow for improved security practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->