### PR TITLE
ci: exempt internal projectbluefin/ refs from floating-tag hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
       - id: no-floating-action-tags
         name: Block floating GitHub Action tags (@main, @v*)
         language: pygrep
-        entry: 'uses:.*@(main|master|latest|v[0-9])'
+        entry: 'uses:(?!.*projectbluefin/).*@(main|master|latest|v[0-9])'
         types: [yaml]
         files: '\.github/workflows/'


### PR DESCRIPTION
## What does this change?

Updates the `no-floating-action-tags` pre-commit hook to use a negative lookahead that skips `projectbluefin/` refs.

## Why?

The hook's regex was too broad — it also matched internal workflow refs like:
- `lifecycle-caller.yml`: `uses: projectbluefin/actions/.github/workflows/lifecycle.yml@main`
- `renovate-automerge.yml`: `uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1`

Those refs are **intentionally floating**. SHA-pinning internal org refs causes a factory cascade: every commit to `projectbluefin/actions` requires manual SHA bumps in all consumers (common, bluefin, bluefin-lts, dakota). PR #712 deliberately switched to `@main` for this exact reason.

This was breaking `validate` CI on **all Renovate PRs** (#711, #713, #714) and also on #715.

## Change

```diff
- entry: 'uses:.*@(main|master|latest|v[0-9])'
+ entry: 'uses:(?!.*projectbluefin/).*@(main|master|latest|v[0-9])'
```

External actions (docker/login-action, actions/checkout, etc.) still require SHA pins and will fail CI if floating. Internal `projectbluefin/` refs are exempt.