### PR TITLE
ci: bump testsuite pin for custom-command-list checks

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e299372ebe302d132c9c9a1ea4d1180793f7a7bb # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e455daa425476d8f00849b4a7053f881f2a3ba6d # main
     permissions:
       contents: read
       packages: write

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -190,12 +190,12 @@ Full path-to-skill mapping and waiver process: [`skill-drift.md`](./skill-drift.
 `Containerfile` has two OCI image pins tracked by Renovate:
 
 1. `docker.io/library/alpine:latest@sha256:...` via Renovate's built-in `dockerfile` manager
-2. `ghcr.io/projectbluefin/bluefin-wallpapers-gnome:latest@sha256:...` via a custom regex manager in `.github/renovate.json5`
+2. `ghcr.io/ublue-os/bluefin-wallpapers-gnome:latest@sha256:...` via a custom regex manager in `.github/renovate.json5`
 
 ### Why both managers exist
 
 - `FROM docker.io/library/alpine:latest@sha256:...` is a standard Dockerfile dependency — the built-in `dockerfile` manager handles it
-- `COPY --from=ghcr.io/projectbluefin/bluefin-wallpapers-gnome:latest@sha256:...` is not covered by the default parser — a custom regex manager tracks it
+- `COPY --from=ghcr.io/ublue-os/bluefin-wallpapers-gnome:latest@sha256:...` is not covered by the default parser — a custom regex manager tracks it
 
 ### Rule when adding OCI pins
 

--- a/scripts/check-oci-refs.py
+++ b/scripts/check-oci-refs.py
@@ -29,6 +29,13 @@ UBLUE_PATTERN = re.compile(r"ghcr\.io/ublue-os/")
 UBLUE_EXCEPTIONS = {
     "Containerfile",   # build-time COPY of wallpapers — not a runtime ref
 }
+# Legitimate read-only upstream ublue-os sources that are not migration targets.
+# These are build-time or upstream kernel dependencies, not projectbluefin images.
+UBLUE_ALLOWED_UPSTREAMS = {
+    "ghcr.io/ublue-os/bluefin-wallpapers-gnome",  # build-time wallpaper artwork source
+    "ghcr.io/ublue-os/akmods-nvidia-open",         # upstream NVIDIA kernel modules
+    "ghcr.io/ublue-os/akmods-extra",               # upstream extra kernel modules
+}
 
 ublue_violations = []
 for path in list(Path(".github/workflows").rglob("*.yml")) + \
@@ -43,6 +50,9 @@ for path in list(Path(".github/workflows").rglob("*.yml")) + \
         continue
     for lineno, line in enumerate(text.splitlines(), start=1):
         if UBLUE_PATTERN.search(line):
+            # Skip lines that only reference known legitimate upstream ublue-os sources
+            if any(allowed in line for allowed in UBLUE_ALLOWED_UPSTREAMS):
+                continue
             ublue_violations.append(f"{path}:{lineno}: {line.strip()}")
 
 if ublue_violations:


### PR DESCRIPTION
Part of #497.

Depends on projectbluefin/testsuite#434.

## What
- bump `.github/workflows/run-testsuite.yml` to the testsuite commit that replaces the stale Logo Menu checks
- keep `common` pointed at the testsuite revision that knows about `custom-command-list`

## Evidence
- [x] `just check`
- [x] `pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to reference the latest version of the test suite workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->