### PR TITLE
docs(release-promotion): fix e2e gate model — run_e2e is false for bluefin and dakota

### DIFF
--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -157,9 +157,13 @@ The daily heartbeat ensures the promotion PR stays fresh and gate checks are re-
 
 **dakota** differs from bluefin/lts: rather than squashing git commits, `promote-testing-to-main.yml` resolves the current `:testing` OCI digest and writes it to `.github/release-state.yaml` on the promotion branch.
 
-### Dakota E2E
+### E2E gate model — bluefin and dakota
 
-Dakota's promotion gate runs with `run_e2e: true`. If it gets disabled, re-enable by setting `run_e2e: true` in `dakota/.github/workflows/promote-testing-to-main.yml` and verify the dakota build machine is healthy.
+Both bluefin and dakota run with `run_e2e: false` in their `promote-testing-to-main.yml`. The e2e quality gate is enforced separately by `post-testing-e2e.yml` (bluefin) rather than at the PR gate level.
+
+**Why `run_e2e: false`:** The gate queries GitHub's runs API by `head_sha = <testing-branch-SHA>`. Workflows triggered via `workflow_run` are stored in the API under the **default branch (main) SHA**, so the gate never finds a match regardless of whether E2E passed. This is the structural mismatch documented in [e2e-ci.md — Promotion gate never-stall design](e2e-ci.md#promotion-gate--never-stall-design).
+
+**Restoring `run_e2e: true`:** Only after the `post-testing-e2e.yml` `branches: [main, testing]` fix (and the `promote-testing-to-main.yml` `workflow_run` feedback trigger) have reached `main` via a successful promotion. Until then, re-enabling `run_e2e: true` will permanently block the gate. Follow the bootstrap procedure in [e2e-ci.md — Gate bootstrap for bluefin](e2e-ci.md#gate-bootstrap-for-bluefin-circular-dependency).
 
 ### Approval
 


### PR DESCRIPTION
## Problem

`docs/skills/release-promotion.md` contained a stale and incorrect section:

> **Dakota E2E**: Dakota's promotion gate runs with `run_e2e: true`. If it gets disabled, re-enable by setting `run_e2e: true`...

Dakota has intentionally run `run_e2e: false` since the factory migration. An agent following this doc would re-enable `run_e2e: true` and permanently block promotions.

## Root cause (documented)

The gate queries GitHub's runs API by `head_sha = <testing-branch-SHA>`. Workflows triggered via `workflow_run` are stored under the **default branch (main) SHA** — not the triggering branch SHA. These never match, so the gate always reports "No completed post-testing-e2e run found" regardless of whether E2E passed.

This mismatch is already documented in `e2e-ci.md — Promotion gate never-stall design`. This PR makes `release-promotion.md` consistent with that.

## Changes

Replaces "Dakota E2E" with "E2E gate model — bluefin and dakota":
- Correctly states both repos run `run_e2e: false`
- Explains the structural SHA mismatch (why `true` is broken today)
- Documents the safe restore condition: only re-enable `run_e2e: true` after the `branches:[main,testing]` fix and `workflow_run` feedback trigger land on `main` via a successful promotion
- Points to `e2e-ci.md` bootstrap procedure

## Related

- projectbluefin/bluefin#611 — applies the two factory fixes to bluefin

Assisted-by: Claude Sonnet 4.5 via pi