### PR TITLE
chore: ponytail shrink — dedup Justfile loops, extract OCI ref check, combine test deps install

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,12 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install bats-core
+      - name: Install test deps
         run: |
           sudo apt-get install -y bats
-
-      - name: Install pytest and pytest-cov
-        run: pip install pytest pytest-cov
+          pip install pytest pytest-cov
 
       - name: Run shellcheck — extensionless scripts
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,58 +69,7 @@ jobs:
 
       - name: Guard against ublue-os→projectbluefin image ref regressions
         shell: bash
-        run: |
-          echo "Checking for disallowed ublue-os→projectbluefin OCI image ref changes..."
-          python - <<'PY'
-          from pathlib import Path
-          import re
-          import sys
-
-          allowed_refs = {
-              Path(".github/workflows/promotion-candidate-e2e.yml"): {
-                  "ghcr.io/projectbluefin/bluefin:testing",
-                  "ghcr.io/projectbluefin/bluefin:lts-testing",
-              },
-              Path(".github/workflows/e2e.yml"): {
-                  "ghcr.io/projectbluefin/bluefin:testing",
-                  "ghcr.io/projectbluefin/bluefin:lts-testing",
-              },
-              Path(".github/workflows/pr-e2e.yml"): {
-                  "ghcr.io/projectbluefin/bluefin:testing",
-              },
-          }
-          pattern = re.compile(r"ghcr\.io/projectbluefin/(bluefin|aurora|bazzite)(?::[A-Za-z0-9._-]+)?")
-          candidates = [
-              path
-              for path in Path(".github/workflows").rglob("*.yml")
-              if path.name != "validate.yml"
-          ]
-          candidates += list(Path(".github/workflows").rglob("*.yaml"))
-
-          violations = []
-          for path in candidates:
-              for lineno, line in enumerate(path.read_text().splitlines(), start=1):
-                  for match in pattern.finditer(line):
-                      ref = match.group(0)
-                      if ref in allowed_refs.get(path, set()):
-                          continue
-                      violations.append(f"{path}:{lineno}:{ref}")
-
-          if violations:
-              print("")
-              print("ERROR: Found disallowed projectbluefin OCI image refs:")
-              for violation in violations:
-                  print(f"  - {violation}")
-              print("")
-              print("Production images are still published at ghcr.io/ublue-os/.")
-              print("Only testing-stream tags are allowed under ghcr.io/projectbluefin/bluefin,")
-              print("and only in the explicitly whitelisted workflow files:")
-              for allowed_path, allowed in allowed_refs.items():
-                  print(f"  {allowed_path}: {sorted(allowed)}")
-              print("See docs/skills/image-registry.md for details.")
-              sys.exit(1)
-          PY
-          echo "No disallowed image ref changes found."
+        run: python scripts/check-oci-refs.py
 
       - name: Validate dconf lock/override parity
         shell: bash

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 just := just_executable()
 
 # Run unit tests (pytest for hooks.py, bats for shell scripts)
+# test_libvirt_helper.bats is excluded — requires a running libvirtd session
 test:
     python3 -m pytest tests/test_hooks.py -v --cov=tests --cov-report=term-missing
     bats tests/test_libsetup.bats
@@ -26,37 +27,33 @@ build:
     git submodule update --init bluefin-branding
     podman build -t localhost/bluefin-common:latest -f ./Containerfile .
 
-check:
+_fmt mode verb:
     #!/usr/bin/bash
     failed=0
     while read -r file; do
-      echo "Checking syntax: $file"
-      {{ just }} --unstable --fmt --check -f "$file" || failed=1
+      echo "{{ verb }} syntax: $file"
+      {{ just }} --unstable --fmt {{ mode }} -f "$file" || failed=1
     done < <(find . -type f -name "*.just")
-    echo "Checking syntax: Justfile"
-    {{ just }} --unstable --fmt --check -f Justfile || failed=1
+    echo "{{ verb }} syntax: Justfile"
+    {{ just }} --unstable --fmt {{ mode }} -f Justfile || failed=1
     exit "$failed"
 
-fix:
-    #!/usr/bin/bash
-    failed=0
-    while read -r file; do
-      echo "Fixing syntax: $file"
-      {{ just }} --unstable --fmt -f "$file" || failed=1
-    done < <(find . -type f -name "*.just")
-    echo "Fixing syntax: Justfile"
-    {{ just }} --unstable --fmt -f Justfile || failed=1
-    exit "$failed"
+check: (_fmt "--check" "Checking")
+
+fix: (_fmt "" "Fixing")
 
 # Inspect the directory structure of an OCI image
 tree IMAGE="localhost/bluefin-common:latest":
-    echo "FROM alpine:latest" > TreeContainerfile
-    echo "RUN apk add --no-cache tree" >> TreeContainerfile
-    echo "COPY --from={{ IMAGE }} / /mnt/root" >> TreeContainerfile
-    echo "CMD tree /mnt/root" >> TreeContainerfile
+    #!/usr/bin/env bash
+    cat > TreeContainerfile <<'EOF'
+    FROM alpine:latest
+    RUN apk add --no-cache tree
+    COPY --from={{ IMAGE }} / /mnt/root
+    CMD tree /mnt/root
+    EOF
     podman build -t tree-temp -f TreeContainerfile .
     podman run --rm tree-temp
-    rm TreeContainerfile
+    rm -f TreeContainerfile
     podman rmi tree-temp
 
 overlay $BLUEFIN_MERGE="1" $SOURCE="dir":

--- a/scripts/check-oci-refs.py
+++ b/scripts/check-oci-refs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Guard against ublue-os→projectbluefin OCI image ref regressions.
+
+Only testing-stream tags are allowed under ghcr.io/projectbluefin/bluefin,
+and only in the explicitly whitelisted workflow files.
+See docs/skills/image-registry.md for details.
+"""
+from pathlib import Path
+import re
+import sys
+
+allowed_refs = {
+    Path(".github/workflows/promotion-candidate-e2e.yml"): {
+        "ghcr.io/projectbluefin/bluefin:testing",
+        "ghcr.io/projectbluefin/bluefin:lts-testing",
+    },
+    Path(".github/workflows/e2e.yml"): {
+        "ghcr.io/projectbluefin/bluefin:testing",
+        "ghcr.io/projectbluefin/bluefin:lts-testing",
+    },
+    Path(".github/workflows/pr-e2e.yml"): {
+        "ghcr.io/projectbluefin/bluefin:testing",
+    },
+}
+pattern = re.compile(r"ghcr\.io/projectbluefin/(bluefin|aurora|bazzite)(?::[A-Za-z0-9._-]+)?")
+candidates = [
+    path
+    for path in Path(".github/workflows").rglob("*.yml")
+    if path.name != "validate.yml"
+]
+candidates += list(Path(".github/workflows").rglob("*.yaml"))
+
+violations = []
+for path in candidates:
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        for match in pattern.finditer(line):
+            ref = match.group(0)
+            if ref in allowed_refs.get(path, set()):
+                continue
+            violations.append(f"{path}:{lineno}:{ref}")
+
+if violations:
+    print("")
+    print("ERROR: Found disallowed projectbluefin OCI image refs:")
+    for violation in violations:
+        print(f"  - {violation}")
+    print("")
+    print("Production images are still published at ghcr.io/ublue-os/.")
+    print("Only testing-stream tags are allowed under ghcr.io/projectbluefin/bluefin,")
+    print("and only in the explicitly whitelisted workflow files:")
+    for allowed_path, allowed in allowed_refs.items():
+        print(f"  {allowed_path}: {sorted(allowed)}")
+    print("See docs/skills/image-registry.md for details.")
+    sys.exit(1)


### PR DESCRIPTION
## What

Implements the four findings from a ponytail-audit of this repo. No behaviour change.

### Changes

| File | Change |
|---|---|
| `Justfile` | Extract `_fmt mode verb` private recipe; `check`/`fix` become one-liner callers. **-10 lines** |
| `Justfile` | Add comment explaining `test_libvirt_helper.bats` exclusion from `just test` (requires running libvirtd) |
| `Justfile` | `tree` recipe: 4 `echo` lines → heredoc |
| `.github/workflows/unit-tests.yml` | Merge `Install bats-core` + `Install pytest and pytest-cov` into one step. **-5 lines** |
| `.github/workflows/validate.yml` | Replace 50-line inline Python heredoc with `python scripts/check-oci-refs.py` |
| `scripts/check-oci-refs.py` | Extracted script — independently runnable and unit-testable |

### Verified

- `just check` passes ✓
- `python scripts/check-oci-refs.py` exits 0 against current workflows ✓
- `pre-commit run --all-files` passes ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Consolidated test dependency installation in CI/CD workflows for improved efficiency
  * Refactored image reference validation to use a dedicated script
  * Enhanced build system targets with improved formatting workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->