### PR TITLE
chore(brew): remove bbrew, bluefinctl replaces it

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/homebrew/full-desktop.Brewfile
+++ b/system_files/bluefin/usr/share/ublue-os/homebrew/full-desktop.Brewfile
@@ -3,7 +3,7 @@
 #
 # This Brewfile contains a curated list of high-quality flatpak applications
 # that provide a full desktop experience on Bluefin. Install with:
-#   ujust bbrew
+#   bluefinctl
 # and select "full-desktop" from the menu.
 #
 # These applications are all available from Flathub and include GNOME Circle

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -317,7 +317,7 @@ install-system-flatpaks $confirm="1":
 
 # Install default system flatpaks (alias for install-system-flatpaks)
 
-# For additional applications, use: ujust bbrew
+# For additional applications, use: bluefinctl
 [group('System')]
 bluefin-apps:
     echo "Installing default system flatpaks..."

--- a/system_files/shared/usr/share/ublue-os/homebrew/cli.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/cli.Brewfile
@@ -1,8 +1,6 @@
-tap "valkyrie00/bbrew"
 brew "atuin"
 brew "bat"
 brew "bash-preexec"
-brew "valkyrie00/bbrew/bbrew"
 brew "chezmoi"
 brew "direnv"
 brew "dysk"

--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -47,32 +47,11 @@ install-opentabletdriver:
       flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver
     fi
 
-# Install applications from curated Brewfiles (includes full-desktop.Brewfile with GNOME Circle apps)
-bbrew:
-    #!/usr/bin/env bash
-    if ! command -v bbrew &>/dev/null ; then
-        if gum confirm "Bold Brew is not installed, would you like to install it?" ; then
-            set -e
-            brew install Valkyrie00/homebrew-bbrew/bbrew
-            set +e
-        else
-            exit 0
-        fi
-    fi
-    echo "Note: Some of these take a while to load, we'll keep working on it."
-    bbrew -f "/usr/share/ublue-os/homebrew/$(gum choose $(find "/usr/share/ublue-os/homebrew"/*.Brewfile -exec basename '{}' '.Brewfile' ';')).Brewfile"
-    [[ -t 0 ]] && ujust --choose || true
-
+# Install CNCF tools from curated Brewfile | use bluefinctl for a full TUI experience
+[group('Apps')]
 cncf:
     #!/usr/bin/env bash
-    if ! command -v bbrew &>/dev/null ; then
-        if gum confirm "Bold Brew is not installed, would you like to install it?" ; then
-            brew install Valkyrie00/homebrew-bbrew/bbrew
-        else
-            exit 0
-        fi
-    fi
-    bbrew -f "/usr/share/ublue-os/homebrew/cncf.Brewfile"
+    brew bundle --file=/usr/share/ublue-os/homebrew/cncf.Brewfile
     [[ -t 0 ]] && ujust --choose || true
 
 # Install ASUS laptop tools (asusctl daemon + ROG Control Center) | https://gitlab.com/asus-linux/asusctl


### PR DESCRIPTION
## Summary

Removes bbrew (Bold Brew) from the Bluefin brew lifecycle. bluefinctl replaces it as the TUI for browsing and installing from Brewfiles.

## Changes

| File | Change |
|---|---|
| `apps.just` | Remove `bbrew` recipe entirely |
| `apps.just` | Simplify `cncf` recipe: `brew bundle --file=` directly, no bbrew dependency |
| `cli.Brewfile` | Remove `tap "valkyrie00/bbrew"` and `brew "valkyrie00/bbrew/bbrew"` |
| `system.just` | Update comment: `ujust bbrew` → `bluefinctl` |
| `full-desktop.Brewfile` | Update install comment: `ujust bbrew` → `bluefinctl` |

## Notes

- `ujust cncf` still works — it now calls `brew bundle` directly, no 3rd-party tool needed
- `ujust bbrew` will no longer resolve; users running it will get a 'recipe not found' error until bluefinctl is shipped