### PR TITLE
feat(bazaar): add Collabora + Spelling Bee + Whisp, refresh curation

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -181,20 +181,20 @@ rows:
           banner-text-valign: start
           banner-height: 400
           appids:
-            - net.codelogistics.letters
-            - re.sonny.Eloquent
-            - page.codeberg.libre_menu_editor.LibreMenuEditor
-            - app.fotema.Fotema
             - be.alexandervanhee.gradia
             - app.drey.Damask
+            - io.github.sitraorg.sitra
+            - io.speedofsound.SpeedOfSound
+            - app.fotema.Fotema
+            - org.gnome.gitlab.YaLTeR.VideoTrimmer
+            - io.github.tanaybhomia.Whisp
+            - re.sonny.Eloquent
+            - de.schmidhuberj.DieBahn
+            - org.gnome.gitlab.cheywood.Pulp
             - io.github.pleromix.IceBox
             - com.github.ADBeveridge.Raider
-            - org.gnome.gitlab.YaLTeR.VideoTrimmer
-            - org.gnome.gitlab.cheywood.Buffer
             - io.github.kelvinnovais.Kasasa
-            - de.schmidhuberj.DieBahn
-            - com.github.maoschanz.drawing
-            - io.github.sitraorg.sitra
+            - net.codelogistics.letters
 
   - sections:
       - expand-horizontally: true
@@ -295,21 +295,22 @@ rows:
           banner-text-valign: end
           banner-height: 400
           appids:
-            - com.slack.Slack
-            - md.obsidian.Obsidian
-            - io.gitlab.theevilskeleton.Upscaler
-            - io.github.alainm23.planify
-            - org.blender.Blender
+            - com.collaboraoffice.Office
             - org.onlyoffice.desktopeditors
             - org.libreoffice.LibreOffice
-            - org.gimp.GIMP
-            - org.kde.krita
-            - org.inkscape.Inkscape
+            - com.slack.Slack
+            - org.gnome.Fractal
+            - org.blender.Blender
             - io.github.nokse22.Exhibit
-            - com.logseq.Logseq
+            - org.gimp.GIMP
+            - org.inkscape.Inkscape
+            - org.kde.krita
+            - io.gitlab.theevilskeleton.Upscaler
             - org.audacityteam.Audacity
             - org.ardour.Ardour
-            - org.gnome.Fractal
+            - io.github.alainm23.planify
+            - md.obsidian.Obsidian
+            - com.logseq.Logseq
 
   - sections:
       - expand-horizontally: true
@@ -385,7 +386,6 @@ rows:
             - io.github.nozwock.Packet
             - org.gnome.gitlab.somas.Apostrophe
             - org.cockpit_project.CockpitClient
-            - org.gnome.gitlab.cheywood.Pulp
             - io.github.vikdevelop.SaveDesktop
             - org.gnome.World.PikaBackup
             - org.fedoraproject.MediaWriter
@@ -485,6 +485,7 @@ rows:
             - org.turbowarp.TurboWarp
             - as.may.moat
             - app.drey.MultiplicationPuzzle
+            - io.github.josephmawa.SpellingBee
 
   - sections:
       - expand-horizontally: true
@@ -516,4 +517,3 @@ rows:
             - io.github.qwersyk.Newelle
             - ai.jan.Jan
             - ink.whis.Whis
-            - io.speedofsound.SpeedOfSound


### PR DESCRIPTION
## What does this change?

- Refresh item placements for Bluefin Recommends and Office & Productivity sections
- Promote Speed of Sound and Pulp to Bluefin Recommends section
- Add Whisp to Bluefin Recommends section
- Add Collabora Office to Office & Productivity section
- Add Spelling Bee to Sustainability & Education section
- Remove Main Menu and Buffer from Bluefin Recommends section

## Checklist

- [ ] `just check` passes
- [ ] `pre-commit run --all-files` passes
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `chore:`, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed curated app recommendations across multiple Bluefin categories, including "Bluefin Recommends," "Office & Productivity," "Utilities," "Sustainability & Education," and "AI and Machine Learning" with updated selections and reordered lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->