### PR TITLE
fix(ci): dispatch common-updated to dakota after manifest publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,3 +198,49 @@ jobs:
           image-name: common
           certificate-identity-regexp: >-
             ^https://github\.com/projectbluefin/(common|actions)/\.github/workflows/
+
+  notify-downstream:
+    name: Notify downstream (dakota, bluefin, bluefin-lts)
+    needs: [manifest]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions: {}
+    steps:
+      - name: Get mergeraptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          owner: projectbluefin
+          repositories: |
+            dakota
+            bluefin
+            bluefin-lts
+
+      - name: Dispatch common-updated to dakota
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/projectbluefin/dakota/dispatches \
+            -X POST \
+            -f event_type=common-updated \
+            -f 'client_payload={"sha":"${{ github.sha }}"}'
+
+      - name: Dispatch common-updated to bluefin
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/projectbluefin/bluefin/dispatches \
+            -X POST \
+            -f event_type=common-updated \
+            -f 'client_payload={"sha":"${{ github.sha }}"}'
+
+      - name: Dispatch common-updated to bluefin-lts
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/projectbluefin/bluefin-lts/dispatches \
+            -X POST \
+            -f event_type=common-updated \
+            -f 'client_payload={"sha":"${{ github.sha }}"}'


### PR DESCRIPTION
## What

Adds a `notify-downstream` job to `build.yml` that fires a `repository_dispatch` event (`common-updated`) to `projectbluefin/dakota` after the multi-arch manifest is signed and published.

## Why

dakota's `track-bst-sources.yml` currently polls for common updates on a daily cron (06:00 UTC). This companion PR activates the event-driven path in [dakota#942](https://github.com/projectbluefin/dakota/pull/942) so `bluefin/common.bst` is updated immediately after common publishes — matching the Renovate cadence used by bluefin and bluefin-lts.

## How

- New `notify-downstream` job, `needs: [manifest]`, skipped on PRs
- Mergeraptor app token scoped to `projectbluefin/dakota` for cross-repo write
- Dispatches `event_type: common-updated` with the triggering SHA as client payload
- Daily cron in dakota remains as fallback if this dispatch ever misses

## Companion PR

projectbluefin/dakota#942 — must land together (either order is fine; cron bridges any gap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build workflow now automatically notifies downstream projects when updates are completed, improving deployment coordination across related repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->