### PR TITLE
fix(ci): add continue-on-error to dispatch steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,7 @@ jobs:
             bluefin-lts
 
       - name: Dispatch common-updated to dakota
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -228,6 +229,7 @@ jobs:
             -f 'client_payload={"sha":"${{ github.sha }}"}'
 
       - name: Dispatch common-updated to bluefin
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -237,6 +239,7 @@ jobs:
             -f 'client_payload={"sha":"${{ github.sha }}"}'
 
       - name: Dispatch common-updated to bluefin-lts
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
## What

Adds `continue-on-error: true` to all three dispatch steps in `notify-downstream`.

## Why

Review finding: a transient API failure on the dakota dispatch silently skips bluefin and bluefin-lts. Those repos have no cron fallback for the event-driven path — they rely on Renovate polling (hours lag) as the only recovery.

With `continue-on-error: true`, all three dispatches are attempted independently regardless of individual step failures.