### PR TITLE
fix(ci): use workflow_dispatch for bluefin/bluefin-lts common tracking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,17 +233,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/projectbluefin/bluefin/dispatches \
+          gh api repos/projectbluefin/bluefin/actions/workflows/track-common.yml/dispatches \
             -X POST \
-            -f event_type=common-updated \
-            -f 'client_payload={"sha":"${{ github.sha }}"}'
+            -F ref=testing
 
       - name: Dispatch common-updated to bluefin-lts
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/projectbluefin/bluefin-lts/dispatches \
+          gh api repos/projectbluefin/bluefin-lts/actions/workflows/track-common.yml/dispatches \
             -X POST \
-            -f event_type=common-updated \
-            -f 'client_payload={"sha":"${{ github.sha }}"}'
+            -F ref=testing


### PR DESCRIPTION
## Bug

`repository_dispatch` always fires on the repository's **default branch** (`main`). `track-common.yml` lives on the `testing` branch in both bluefin and bluefin-lts — so the dispatch was silently dropped.

## Fix

Switch the bluefin and bluefin-lts dispatch calls from `repository_dispatch` to `workflow_dispatch` via:
```
gh api repos/projectbluefin/bluefin/actions/workflows/track-common.yml/dispatches -X POST -F ref=testing
```
This triggers `track-common.yml` on the `testing` branch directly, where the file actually lives.

Dakota is unaffected (`track-bst-sources.yml` is on `main`).