### PR TITLE
fix(ci): remove owner+repositories from create-github-app-token in notify-downstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,11 +212,6 @@ jobs:
         with:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-          owner: projectbluefin
-          repositories: |
-            dakota
-            bluefin
-            bluefin-lts
 
       - name: Dispatch common-updated to dakota
         continue-on-error: true


### PR DESCRIPTION
## Problem

Every merge to `common/main` fails on the `Notify downstream` job:

```
DOMException [DataError]: Invalid keyData
Failed to read private key
```

This blocks the entire downstream dispatch chain — `track-common.yml` in bluefin and bluefin-lts never fires, so common updates don't trigger `:testing` builds on the image repos.

## Root cause

`create-github-app-token` with `owner: projectbluefin` + `repositories: ...` triggers cross-installation token creation which fails with `Invalid keyData` for this key format. Already documented in `docs/skills/ci-tooling.md`:

> `create-github-app-token@v3` fails with `Invalid keyData` when `owner: <org>` + `repositories: <other-repos>` are specified.

See failing runs: https://github.com/projectbluefin/common/actions/runs/27855356506

## Fix

Remove `owner` and `repositories` from the token step. The mergeraptor app is installed org-wide — the default token already has write access to dispatch to all three repos.

## Effect

Restores the full chain:
```
common merge → build.yml publishes common:latest
  → notify-downstream fires track-common.yml@testing in bluefin + bluefin-lts
    → opens auto/track-common PR bumping common digest
      → PR merges to testing → build-image-testing.yml fires → :testing published
```

## Verification

Merge and watch the next `Notify downstream` job — it should succeed and trigger `track-common.yml` runs in bluefin and bluefin-lts.

---

*Assisted-by: Claude Sonnet 4.5 via pi*