### PR TITLE
fix(ci): mark notify-downstream continue-on-error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          client-id: ${{ vars.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
 
       - name: Dispatch common-updated to dakota

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,11 +212,6 @@ jobs:
         with:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
-          owner: projectbluefin
-          repositories: |
-            dakota
-            bluefin
-            bluefin-lts
 
       - name: Dispatch common-updated to dakota
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,7 @@ jobs:
     name: Notify downstream (dakota, bluefin, bluefin-lts)
     needs: [manifest]
     if: github.event_name != 'pull_request'
+    continue-on-error: true
     runs-on: ubuntu-24.04
     permissions: {}
     steps:


### PR DESCRIPTION
Dispatch job needs `vars.MERGERAPTOR_APP_ID` + `secrets.MERGERAPTOR_PRIVATE_KEY` not yet accessible in `common`. Builds failing on this job since org-level vars/secrets aren't scoped to this repo.

Dispatch is best-effort — downstream `:testing` builds fall back to Renovate digest automerge. Mark job `continue-on-error: true` so build stays green until org admin fixes secret access.

*Assisted-by: Claude Sonnet 4.5 via pi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for improved error handling and token management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->