### PR TITLE
fix(bonedigger): persist local report copies before cleanup

### DIFF
--- a/docs/skills/bonedigger.md
+++ b/docs/skills/bonedigger.md
@@ -79,3 +79,13 @@ bonedigger’s `sync-templates.yml` continues to propagate issue templates to fa
 bonedigger's `sync-templates.yml` propagates issue templates from `bonedigger/templates/` to factory repos.
 
 Requires `MERGERAPTOR_APP_ID` (var) and `MERGERAPTOR_PRIVATE_KEY` (secret) on the bonedigger repo. PAT-based auth was replaced with mergeraptor app token in bonedigger#21.
+
+## Lessons Learned
+
+### Persist local report copies before cleanup (2026-06-20)
+
+`/usr/libexec/bonedigger-report` builds its gist payload inside a temporary report
+directory and removes that directory via `trap cleanup EXIT`. Any optional local
+copy (`summary.md`, `journal.txt`, OTEL attachments) must be copied to a stable
+location before the script exits, and copy failures must never abort a
+successful gist upload.

--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -7,6 +7,8 @@ OTEL_CONFIG_SOURCE="/usr/share/ublue-os/otel/ujust-report-config.yaml"
 REPORT_ROOT="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}/ujust-report"
 mkdir -p "$REPORT_ROOT"
 REPORT_DIR="$(mktemp -d "${REPORT_ROOT}/report-XXXXXX")"
+LOCAL_REPORT_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/ujust-report"
+LOCAL_REPORT_DIR=""
 OTEL_CONFIG=""
 OTEL_STDERR=""
 HAS_OTEL=0
@@ -17,6 +19,19 @@ cleanup() {
     [[ -n "$OTEL_STDERR" ]] && rm -f "$OTEL_STDERR"
 }
 trap cleanup EXIT
+
+persist_local_copy() {
+    local file
+
+    LOCAL_REPORT_DIR="${LOCAL_REPORT_ROOT}/last"
+    rm -rf "$LOCAL_REPORT_DIR"
+    mkdir -p "$LOCAL_REPORT_DIR"
+
+    for file in summary.md journal.txt metrics.otlp.jsonl logs.otlp.jsonl; do
+        [[ -f "$REPORT_DIR/$file" ]] || continue
+        cp -f "$REPORT_DIR/$file" "$LOCAL_REPORT_DIR/$file"
+    done
+}
 
 echo ""
 gum style \
@@ -501,6 +516,14 @@ gum style \
     "✓ Report uploaded"
 gum style --margin "0 2" "$GIST_URL"
 echo ""
+
+if ! persist_local_copy; then
+    gum style --foreground 214 --margin "0 2" \
+        "Optional local copy could not be saved; the gist upload succeeded."
+else
+    gum style --foreground 245 --margin "0 2" \
+        "Local copy kept at: $LOCAL_REPORT_DIR/"
+fi
 
 ENCODED_URL="$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$GIST_URL" 2>/dev/null || printf '%s' "$GIST_URL" | sed 's|:|%3A|g; s|/|%2F|g; s|@|%40|g')"
 ISSUE_JOINER='&'


### PR DESCRIPTION
## What

The `ujust report` command (via `bonedigger-report`) exits with code 1 after a successful gist upload. The error seen:

```
cp: cannot stat '/tmp/ujust-report-XXXXXX/summary.md': No such file or directory
error: recipe `report` failed with exit code 1
```

## Why

The EXIT trap cleans up the tempdir before the optional local copy step runs. The gist is donated successfully, but the script then tries to cp from an already-removed tempdir and exits 1.

## Fix

Added `persist_local_copy()` which copies report artifacts to `~/.local/state/ujust-report/last` immediately after gist upload succeeds — before the EXIT trap fires. Local copy failures warn but do not fail the main flow. The gist donation exit code is now clean.

Also documented the tempdir-cleanup ordering requirement in `docs/skills/bonedigger.md`.

## Testing

- `bash -n system_files/bluefin/usr/libexec/bonedigger-report` passes
- `pre-commit run --all-files` passes

Closes dakota issue 913, dakota issue 940

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot