### PR TITLE
fix(ci): exclude docs/factory and specs from ublue-os ref check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,4 +198,3 @@ jobs:
           image-name: common
           certificate-identity-regexp: >-
             ^https://github\.com/projectbluefin/(common|actions)/\.github/workflows/
-

--- a/scripts/check-oci-refs.py
+++ b/scripts/check-oci-refs.py
@@ -37,11 +37,15 @@ UBLUE_ALLOWED_UPSTREAMS = {
     "ghcr.io/ublue-os/akmods-extra",               # upstream extra kernel modules
 }
 
+UBLUE_SKIP_DIRS = {"docs/factory", "specs"}
+
 ublue_violations = []
 for path in list(Path(".github/workflows").rglob("*.yml")) + \
             list(Path(".github/workflows").rglob("*.yaml")) + \
             list(Path("docs").rglob("*.md")) + \
             [Path("AGENTS.md")]:
+    if any(path.as_posix().startswith(d) for d in UBLUE_SKIP_DIRS):
+        continue
     if path.name in UBLUE_EXCEPTIONS:
         continue
     try:


### PR DESCRIPTION
Spec and factory design docs reference upstream ublue-os artifacts as historical or architectural context. The ublue-os ref guard is for workflow files and user-facing docs only, not specs.