### PR TITLE
ci: bump testsuite pin to 8d9ca0b (fix common E2E failures)

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@7647c97faf25f8450c68637623df3ca9960c1915 # main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@8d9ca0b35a25a9c2072067fcdc145268f7e08be5 # main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Picks up testsuite PR 464 which fixed two failing common E2E scenarios:

- fzf test was missing `@requires_brew` tag
- custom-command-list test used `gsettings get` which was clobbered by the CI local.d dconf override; now uses `get_default_value()` to read the schema default directly

The post-merge e2e.yml on main has been failing since these tests were added. This SHA bump makes it green.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot