### PR TITLE
docs(factory): align bluefin-lts to completed testing-first migration

### DIFF
--- a/.gemini/style-guide.md
+++ b/.gemini/style-guide.md
@@ -238,7 +238,8 @@ AI-assisted commits must include attribution:
 ```
 feat(just): add new system management recipe
 
-Assisted-by: Claude 3.5 Sonnet via GitHub Copilot
+Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 ```
 
 ## Comments and Documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ common ────────────────────────�
 (shared OCI layer)               │         sign-and-publish
                                  ▼         scan-image (planned)
 bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
-bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
+bluefin-lts (PRs→testing; testing→main; main→:stable) ←── images ──→ testsuite (e2e gate)
 dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
                                  │
                                  ▼

--- a/docs/factory/agentic-model.md
+++ b/docs/factory/agentic-model.md
@@ -50,7 +50,7 @@ Do not report the factory as broken because a promotion PR is open and waiting. 
 |---|---|---|
 | `common` | `main` | No testing branch — direct to main |
 | `bluefin` | `testing` | Never `main` |
-| `bluefin-lts` | `main` | `main→lts` is the promotion path; migration to `testing` model in progress (issue bluefin-lts/issues/346) |
+| `bluefin-lts` | `testing` | Testing-first model (same as bluefin and dakota). PRs target `testing`; promote-testing-to-main.yml promotes on Tuesday 04:00 UTC; execute-release.yml copies :testing→:stable. lts branch archived. |
 | `dakota` | `testing` | Never `main` — testing-first model, same as bluefin (PR 1004) |
 | `knuckle` | `main` | Installer — no testing branch |
 | `bootc-installer` | `dev` | Active work branch; `prod` triggers Flatpak release CI — never target `prod` directly |


### PR DESCRIPTION
## Summary\n- update the factory branch-target table to show bluefin-lts as testing-first\n- update the common repo map diagram to show the bluefin-lts testing -> main -> stable flow\n- refresh the Gemini style guide AI attribution example to Claude Sonnet 4.6 and include the Copilot co-author trailer\n\n## Context\nThis aligns common documentation with the completed bluefin-lts testing-first migration and closes the stale guidance left after projectbluefin/bluefin-lts#346.