### PR TITLE
feat(oem): add WirePlumber hardware profiles for Framework Desktop AMD Ryzen AI Max 300

### DIFF
--- a/docs/skills/oem-hardware-hooks.md
+++ b/docs/skills/oem-hardware-hooks.md
@@ -156,7 +156,12 @@ and active — a plain `u` means stock, a vendor logo means the OEM stack is run
 3. Add the vendor logo SVG to:
    `system_files/shared/usr/share/icons/hicolor/scalable/actions/<name>-symbolic.svg`
 
-That's it. No new hook file, no version bump to existing hooks.
+4. If the OEM also needs user-session config files (for example a WirePlumber
+   snippet), place them in the same `oem/<Vendor>/` directory and have
+   `20-oem-brew.sh` install them into the user's home directory.
+
+No new hook file is needed. Bump the hook version only when existing machines
+must re-run the hook to pick up a new payload.
 
 ### OEM directories
 
@@ -167,14 +172,17 @@ That's it. No new hook file, no version bump to existing hooks.
 
 ### Version stamp
 
-The stamp slug is `oem-<Vendor> user 1`. This is intentionally separate from
+The stamp slug is `oem-<Vendor> user 2`. This is intentionally separate from
 the old `asus user 1` stamp — existing ASUS machines that already ran the old
 `11-asus.sh` will pick up the new generic hook and get the logo set on next login.
 The brew installs are idempotent (already-installed casks are skipped by brew).
 
 **WirePlumber rules for Framework Desktop (AMD Ryzen AI Max 300):**
-`system_files/shared/usr/share/wireplumber/wireplumber.conf.d/51-framework-desktop.conf`
-— raises HDMI output priority to 1100, internal mic priority to 2100.
+ship the snippet as OEM data in
+`system_files/shared/usr/share/ublue-os/oem/Framework/51-framework-desktop.conf`
+and let `20-oem-brew.sh` install it to
+`~/.config/wireplumber/wireplumber.conf.d/51-framework-desktop.conf`
+on Framework Desktop machines only (`product_name == "Framework Desktop"`).
 
 ---
 
@@ -208,13 +216,22 @@ Bazzite swaps wireplumber from their own COPR (`ublue-os/bazzite`) and enables
 `wireplumber-sysconf.service` in deck builds to process those directories. Stock
 WirePlumber 0.5.x (what bluefin ships) has no `hardware-profiles/` loader.
 
-**For common:** place ALSA node rules directly in:
-```
-system_files/shared/usr/share/wireplumber/wireplumber.conf.d/<name>.conf
+**For common:** do not drop OEM-specific WirePlumber snippets into
+`system_files/shared/usr/share/wireplumber/wireplumber.conf.d/` — that ships
+globally to every machine. If the rule only applies to one OEM family, store it in
+that vendor's `oem/<Vendor>/` directory and have the OEM user hook copy it into the
+user's WirePlumber fragment directory:
+
+```bash
+install -d "${HOME}/.config/wireplumber/wireplumber.conf.d"
+install -m 0644 "${OEM_DIR}/${VENDOR}/51-framework-desktop.conf" \
+  "${HOME}/.config/wireplumber/wireplumber.conf.d/51-framework-desktop.conf"
 ```
 
-The `node.name` match (PCI address or pattern) already scopes the rule to the target
-hardware — no hardware-profiles directory structure needed:
+WirePlumber's documented user fragment path is
+`~/.config/wireplumber/wireplumber.conf.d/`. The `node.name` match (PCI address or
+pattern) still scopes the rule to the target hardware — no hardware-profiles
+directory structure needed:
 
 ```conf
 monitor.alsa.rules = [
@@ -231,6 +248,23 @@ monitor.alsa.rules = [
 ```
 
 Use `~` prefix for regex matching to avoid PCI minor-revision fragility.
+
+If you add a new OEM payload to an existing versioned setup hook and want current
+users to receive it, bump that hook's `version-script` version. Otherwise existing
+machines skip the new logic forever because the old stamp already exists.
+
+If an OEM payload only applies to one model within a vendor family, gate the copy
+on DMI `product_name` as well as vendor. `Framework` alone is too broad — it would
+also match Framework laptops.
+
+If the OEM payload is a user-level config file that should survive failed setup
+retries, run its copy step **after** the versioned work block and make it
+idempotent (`install -d` + `install`). That way existing stamped systems still get
+the file and repeated logins safely refresh it.
+
+## Sources
+
+- WirePlumber config fragments and user override path: Context7 `/websites/pipewire_pages_freedesktop_wireplumber`
 
 ---
 

--- a/system_files/shared/usr/share/ublue-os/oem/Framework/51-framework-desktop.conf
+++ b/system_files/shared/usr/share/ublue-os/oem/Framework/51-framework-desktop.conf
@@ -1,0 +1,35 @@
+# Framework Desktop (AMD Ryzen AI Max 300): prefer HDMI output and
+# raise the onboard analog mic above WirePlumber's default priority.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_output.pci-0000_c3_00.1.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        node.description = "HDMI Audio"
+        priority.driver = 1100
+        priority.session = 1100
+        api.alsa.period-size = 256
+        api.alsa.headroom = 1024
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+  {
+    matches = [
+      {
+        node.name = "~alsa_input.pci-0000_c3_00.6.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.driver = 2100
+        priority.session = 2100
+      }
+    }
+  }
+]

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-oem-brew.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-oem-brew.sh
@@ -11,6 +11,7 @@ OEM_DIR="/usr/share/ublue-os/oem"
 # Add a case arm + oem/<Name>/ directory to support a new OEM.
 CHASSIS_VENDOR=$(cat /sys/devices/virtual/dmi/id/chassis_vendor 2>/dev/null || true)
 SYS_VENDOR=$(cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null || true)
+PRODUCT_NAME=$(cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null || true)
 
 case "${CHASSIS_VENDOR}:${SYS_VENDOR}" in
     Framework:*)        VENDOR="Framework" ;;
@@ -27,19 +28,26 @@ if [[ ! -x "${BREW_BIN}" ]]; then
     exit 0
 fi
 
-version-script "oem-${VENDOR}" user 1 || exit 0
-
 set -xeuo pipefail
 eval "$("${BREW_BIN}" shellenv)"
 
-brew bundle --file="${OEM_DIR}/${VENDOR}/packages.Brewfile"
+if version-script "oem-${VENDOR}" user 2; then
+    brew bundle --file="${OEM_DIR}/${VENDOR}/packages.Brewfile"
 
-if [[ "${VENDOR}" == "ASUS" ]]; then
-    systemctl --user daemon-reload
-    systemctl --user enable --now asusd-user.service || true
+    if [[ "${VENDOR}" == "ASUS" ]]; then
+        systemctl --user daemon-reload
+        systemctl --user enable --now asusd-user.service || true
+    fi
+
+    if [[ -f "${OEM_DIR}/${VENDOR}/logo" ]]; then
+        dconf write /org/gnome/shell/extensions/custom-command-list/menuicon-setting \
+            "'$(cat "${OEM_DIR}/${VENDOR}/logo")'"
+    fi
 fi
 
-if [[ -f "${OEM_DIR}/${VENDOR}/logo" ]]; then
-    dconf write /org/gnome/shell/extensions/custom-command-list/menuicon-setting \
-        "'$(cat "${OEM_DIR}/${VENDOR}/logo")'"
+if [[ "${VENDOR}" == "Framework" && "${PRODUCT_NAME}" == "Framework Desktop" ]] && \
+    [[ -f "${OEM_DIR}/${VENDOR}/51-framework-desktop.conf" ]]; then
+    install -d "${HOME}/.config/wireplumber/wireplumber.conf.d"
+    install -m 0644 "${OEM_DIR}/${VENDOR}/51-framework-desktop.conf" \
+        "${HOME}/.config/wireplumber/wireplumber.conf.d/51-framework-desktop.conf"
 fi


### PR DESCRIPTION
## Summary
- move the Framework Desktop WirePlumber override into `system_files/shared/usr/share/ublue-os/oem/Framework/51-framework-desktop.conf`
- install the override only on Framework systems via `20-oem-brew.sh` into `~/.config/wireplumber/wireplumber.conf.d/51-framework-desktop.conf`
- bump the OEM hook version so existing Framework users pick up the new config on the next login
- update `docs/skills/oem-hardware-hooks.md` with the OEM-specific WirePlumber pattern

## Testing
- just check
- pre-commit run --all-files

Closes #671