### PR TITLE
fix(ujust): fix changelogs recipe on Dakota

### DIFF
--- a/docs/skills/image-registry.md
+++ b/docs/skills/image-registry.md
@@ -81,6 +81,18 @@ IMAGE_REGISTRY="ghcr.io/${IMAGE_VENDOR}"
 
 `image-vendor` is set at build time via `00-image-info.sh`. The helper reads it dynamically — do not hardcode the registry path.
 
+## Release-notes repo mapping
+
+Runtime tools that need GitHub releases must derive the source repo from the
+current image name/ref, not from the tag alone.
+
+- `dakota` and `dakota-nvidia` → `projectbluefin/dakota`
+- `bluefin-lts*` variants → `projectbluefin/bluefin-lts`
+- `bluefin*` variants → `projectbluefin/bluefin`
+
+Why this matters: tags like `testing` and `stable` are shared across repos, so
+`image-tag` alone cannot tell Dakota apart from Bluefin.
+
 ## Build-time ublue-os source (wallpapers only)
 
 The Containerfile pulls wallpaper artwork from `ghcr.io/ublue-os/bluefin-wallpapers-gnome` as a **build-time COPY source**. This is a read-only upstream artwork dependency and does not violate the ublue-os prohibition. The production image tree and all runtime registries are fully under `ghcr.io/projectbluefin/`. See [`containerfile.md`](containerfile.md) for details.

--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -3,31 +3,59 @@
 # Show the changelog
 changelogs:
     #!/usr/bin/bash
-    if command -v bctl &>/dev/null; then
-        exec bctl changelogs
+    set -euo pipefail
+
+    # bluefinctl currently maps changelogs by tag alone, which sends Dakota
+    # users to Bluefin release notes. Keep ujust variant-aware here until the
+    # CLI implementation derives the repo from image-info too.
+    if [[ -r /usr/share/ublue-os/changelog.md ]]; then
+        exec glow -p /usr/share/ublue-os/changelog.md
     fi
 
-    # Get Image Tag
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
     TAG="$(jq -r '.["image-tag"]' < "${IMAGE_INFO_FILE}")"
+    IMAGE_REF="$(jq -r '.["image-ref"] // empty' < "${IMAGE_INFO_FILE}")"
+    IMAGE_NAME="$(jq -r '.["image-name"] // empty' < "${IMAGE_INFO_FILE}")"
+    IMAGE_SOURCE="${IMAGE_REF:-${IMAGE_NAME}}"
+    IMAGE_PATH="$(sed -E 's|^.*://||; s|^[a-z-]+:||; s|:.+$||' <<< "${IMAGE_SOURCE}")"
+    IMAGE_BASENAME="${IMAGE_PATH##*/}"
 
-    # Select the correct upstream repo based on image stream
-    if [[ "$TAG" =~ ^lts ]]; then
-        REPO="projectbluefin/bluefin-lts"
-    else
-        REPO="projectbluefin/bluefin"
-    fi
+    case "${IMAGE_BASENAME}" in
+        dakota|dakota-*)
+            REPO="projectbluefin/dakota"
+            ;;
+        bluefin-lts|bluefin-lts-*)
+            REPO="projectbluefin/bluefin-lts"
+            ;;
+        *)
+            REPO="projectbluefin/bluefin"
+            ;;
+    esac
 
-    # If stable, gts, or lts, fetch from GitHub Releases
+    fetch_release_body() {
+        local endpoint="$1"
+        curl -fsLS "https://api.github.com/repos/${REPO}/releases/${endpoint}" \
+            | jq -r '.body // empty'
+    }
+
+    CONTENT=""
     if [[ "$TAG" =~ gts$|stable$|^lts ]]; then
         DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
-        CONTENT="$(curl -Ls "https://api.github.com/repos/${REPO}/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+        if [[ -n "${DATE:-}" ]]; then
+            CONTENT="$(curl -fsLS "https://api.github.com/repos/${REPO}/releases" \
+                | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body // empty")"
+        fi
     fi
 
-    # Display Content with Glow, otherwise fallback to latest release for this repo
-    if [[ -n "${CONTENT:-}" ]]; then
-        echo "$CONTENT" | glow -p
-    else
-        echo "WARN: Could not find a release specific to your image"
-        curl -Ls "https://api.github.com/repos/${REPO}/releases/latest" | jq -r ".body" | glow -p
+    if [[ -z "${CONTENT:-}" ]]; then
+        echo "No release-specific notes for ${TAG}; showing the latest ${REPO#projectbluefin/} release notes."
+        CONTENT="$(fetch_release_body latest || true)"
     fi
+
+    if [[ -n "${CONTENT:-}" ]]; then
+        echo "${CONTENT}" | glow -p
+        exit 0
+    fi
+
+    echo "WARN: Could not fetch changelog content for ${REPO}."
+    exit 1


### PR DESCRIPTION
Fixes #646

## Summary
- stop routing ujust changelogs through bluefinctl's tag-only repo detection
- derive the release-notes repo from image-info.json so Dakota maps to projectbluefin/dakota
- document the runtime release-notes repo mapping in docs/skills/image-registry.md

## Verification
- just check
- pre-commit run --all-files
- mocked just --justfile system_files/bluefin/usr/share/ublue-os/just/changelog.just changelogs with Dakota and Bluefin LTS image-info fixtures to verify repo selection and fallback behavior
