### PR TITLE
fix(flatpak): refresh appstream on every boot instead of firstboot only

### DIFF
--- a/system_files/shared/usr/lib/systemd/system-preset/02-flatpak-appstream-firstboot.preset
+++ b/system_files/shared/usr/lib/systemd/system-preset/02-flatpak-appstream-firstboot.preset
@@ -1,1 +1,0 @@
-enable flatpak-appstream-firstboot.service

--- a/system_files/shared/usr/lib/systemd/system-preset/02-flatpak-appstream-refresh.preset
+++ b/system_files/shared/usr/lib/systemd/system-preset/02-flatpak-appstream-refresh.preset
@@ -1,0 +1,1 @@
+enable flatpak-appstream-refresh.service

--- a/system_files/shared/usr/lib/systemd/system/flatpak-appstream-refresh.service
+++ b/system_files/shared/usr/lib/systemd/system/flatpak-appstream-refresh.service
@@ -1,21 +1,19 @@
 [Unit]
-Description=Refresh Flatpak remote metadata (first boot)
+Description=Refresh Flatpak remote metadata
 Documentation=https://docs.projectbluefin.io
 After=network-online.target flatpak-system-helper.service
 Wants=network-online.target
 ConditionPathExists=/usr/bin/flatpak
-ConditionPathExists=!/var/lib/flatpak/.appstream-refreshed
+ExecCondition=bash -c 'v=$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered 2>/dev/null | cut -d" " -f2); [ "$v" != "1" ] && [ "$v" != "2" ]'
 StartLimitIntervalSec=600
+StartLimitBurst=3
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/flatpak update --appstream --system --noninteractive
-ExecStartPost=/bin/touch /var/lib/flatpak/.appstream-refreshed
 RemainAfterExit=yes
 Restart=on-failure
 RestartSec=60
 
-StartLimitBurst=3
-
 [Install]
-WantedBy=multi-user.target
+WantedBy=graphical.target


### PR DESCRIPTION
Remove the firstboot-only condition from flatpak-appstream-firstboot.service so appstream metadata is refreshed on every boot after network is up, before the graphical session starts.

Bazaar calls flatpak_installation_update_appstream_full_sync internally, but when running inside the Flatpak sandbox this can fail, leaving stale cached data. Pre-refreshing as root before the user session starts ensures current metadata is always available on launch.

Changes:
- Remove ConditionPathExists=!/var/lib/flatpak/.appstream-refreshed (firstboot restriction)
- Remove ExecStartPost marker file touch
- Change WantedBy from multi-user.target to graphical.target (runs before user session, after network)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified Flatpak appstream metadata refresh behavior to occur more regularly instead of only during initial system boot.
  * Updated service configuration to ensure appstream management runs properly in graphical environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->