### PR TITLE
feat(uupd): smart AC-aware update scheduling

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/uupd-on-ac.service
+++ b/system_files/shared/usr/lib/systemd/system/uupd-on-ac.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Trigger system updates on AC power connect
+After=network-online.target
+Wants=network-online.target
+ConditionACPower=true
+
+[Service]
+Type=oneshot
+# Wait for network to settle after AC connect before triggering updates
+ExecStartPre=/bin/sleep 60
+ExecStart=/usr/bin/systemctl start uupd.service

--- a/system_files/shared/usr/lib/systemd/system/uupd-on-ac.service
+++ b/system_files/shared/usr/lib/systemd/system/uupd-on-ac.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 ConditionACPower=true
 StartLimitBurst=1
-StartLimitIntervalSec=3600
+StartLimitIntervalSec=21600
 
 [Service]
 Type=oneshot

--- a/system_files/shared/usr/lib/systemd/system/uupd-on-ac.service
+++ b/system_files/shared/usr/lib/systemd/system/uupd-on-ac.service
@@ -3,6 +3,8 @@ Description=Trigger system updates on AC power connect
 After=network-online.target
 Wants=network-online.target
 ConditionACPower=true
+StartLimitBurst=1
+StartLimitIntervalSec=3600
 
 [Service]
 Type=oneshot

--- a/system_files/shared/usr/lib/systemd/system/uupd.service.d/10-bluefin.conf
+++ b/system_files/shared/usr/lib/systemd/system/uupd.service.d/10-bluefin.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionACPower=true

--- a/system_files/shared/usr/lib/systemd/system/uupd.timer
+++ b/system_files/shared/usr/lib/systemd/system/uupd.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Auto Update Timer For Universal Blue
+Wants=network-online.target
+
+[Timer]
+OnCalendar=*-*-* 00,06,12,18:00:00
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target

--- a/system_files/shared/usr/lib/udev/rules.d/99-uupd-on-ac.rules
+++ b/system_files/shared/usr/lib/udev/rules.d/99-uupd-on-ac.rules
@@ -1,0 +1,4 @@
+# Trigger system updates when AC power is connected.
+# ACTION=="change" avoids firing on boot device enumeration.
+# ATTR{type}=="Mains" matches all AC adapters regardless of kernel name.
+ACTION=="change", SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="1", RUN+="/usr/bin/systemctl start --no-block uupd-on-ac.service"


### PR DESCRIPTION
## What

Gate all uupd runs on AC power, update every 6 hours, and trigger immediately when a laptop is plugged in.

## Why

Updates were running on battery, draining charge unexpectedly. The existing uupd battery check (20% threshold) is too permissive — a bootc image pull at 50% battery on an untethered laptop is bad UX. macOS and Windows both defer updates entirely to AC.

The 6h timer alone is not enough for laptops that are on battery during all scheduled windows. The AC-connect trigger closes that gap.

## Changes

- uupd.timer: runs at 00:00, 06:00, 12:00, 18:00 with Persistent=true (sleeping machines catch up on next wake while on AC)
- uupd.service.d/10-bluefin.conf: ConditionACPower=true — hard gate, no updates on battery
- uupd-on-ac.service: oneshot triggered by udev, waits 60s for network to settle, then starts uupd.service
- udev/rules.d/99-uupd-on-ac.rules: fires uupd-on-ac.service on ACTION==change for Mains power supply coming online

## Behavior matrix

| Scenario | Result |
|---|---|
| Desktop (always AC) | Updates every 6h |
| Laptop on AC at timer fire | Updates every 6h |
| Laptop on battery at timer fire | Skips cleanly, no drain |
| Laptop just plugged in | Updates after 60s network settle |
| Machine wakes from sleep on AC | Persistent=true catches up |
| Metered WiFi | Blocked by existing uupd hw-check |
| Power-saver mode | Blocked by existing uupd hw-check |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic update scheduling with a new timer that runs several times a day and persists across reboots.
  * Updates can now start automatically when AC power is connected, after a short delay and once networking is ready.

* **Bug Fixes**
  * Restricted update activity to AC power to help avoid running during battery use.
  * Added rate limiting to prevent repeated rapid starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->