### PR TITLE
ci(renovate): use --auto merge for merge queue on main

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -9,16 +9,48 @@ permissions:
   contents: write
   pull-requests: write
 
-# common/main has no branch protection rules that require a bypass actor,
-# so GITHUB_TOKEN (the default in the reusable) is sufficient.
-# A mergeraptor app token is NOT needed here — and adding an unnecessary
-# get-token step that reads secrets.MERGERAPTOR_APP_ID (which does not
-# exist; the app ID is stored as vars.MERGERAPTOR_APP_ID) caused every
-# automerge run to fail with "Invalid keyData" from create-github-app-token.
+# common/main has a merge queue ruleset. github-actions[bot] is not a bypass
+# actor, so direct --squash merge is rejected with "merge strategy is set by
+# the merge queue". We inline the logic here and use --auto instead, which
+# enqueues the PR. Checks have already passed (workflow_run fires on success),
+# so the queue processes immediately.
+# The reusable-renovate-automerge.yml is intentionally NOT used here because
+# it targets testing branches (no merge queue) and uses direct --squash merge.
 jobs:
   automerge:
     if: github.event.workflow_run.conclusion == 'success'
-    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@v1
-    with:
-      head_sha: ${{ github.event.workflow_run.head_sha }}
-      base_branch: main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Renovate PR for this commit
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --state open \
+            --json number,headRefOid,author \
+            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\" or .author.login == \"app/mergeraptor\") | .number" \
+            | head -1)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open Renovate/Mergeraptor PR found for SHA $HEAD_SHA on base main — skipping"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found Renovate/Mergeraptor PR #$PR_NUMBER"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enqueue PR via auto-merge
+        if: steps.find-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr merge "${{ steps.find-pr.outputs.pr_number }}" \
+            --auto \
+            --squash \
+            --repo "${{ github.repository }}" \
+            && echo "✅ Enqueued PR #${{ steps.find-pr.outputs.pr_number }} for merge" \
+            || echo "::warning::PR #${{ steps.find-pr.outputs.pr_number }} merge skipped (already merged or conflicting)"


### PR DESCRIPTION
## Problem

Renovate PRs targeting `main` have not been auto-merging despite passing all CI checks. The automerge workflow logs falsely show `✅ Merged` but the PRs remain open.

Root cause: `main` has a merge queue ruleset. `github-actions[bot]` is not a bypass actor, so `gh pr merge --squash` is rejected with "The merge strategy for main is set by the merge queue". The `||` catch in the reusable suppresses the error and the unconditional success echo runs regardless.

Confirmed stuck: PRs #763 and #764 both had successful builds and automerge runs at 04:42, but are still open now.

## Fix

Stop delegating to the reusable (designed for `testing` branches with no merge queue) and inline the logic using `--auto --squash` instead. This enqueues the PR via the merge queue. Since the workflow fires after a successful build, checks have already passed and the queue processes immediately.

Also fixes the false-success logging: success echo is now in the `&&` branch only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request merge workflow to use inline logic instead of external dependencies, maintaining the same auto-merge behavior for dependency updates after successful builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->