### PR TITLE
fix(ci): remove continue-on-error incompatible with uses: in e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,9 +40,6 @@ jobs:
           - name: Dakota
             image: ghcr.io/projectbluefin/dakota:testing
             suites: common
-            allow_failure: true # Non-blocking: flip to false when infra is confirmed stable (see issue #497)
-    # Non-blocking: flip to false when infra is confirmed stable (see issue #497)
-    continue-on-error: ${{ matrix.allow_failure == true }}
     name: "E2E — ${{ matrix.name }}"
     permissions:
       contents: read


### PR DESCRIPTION
The post-merge E2E workflow has been failing with 'workflow file issue' on every main push for days. No jobs ever start.

Root cause: `continue-on-error` is forbidden when a job uses `uses:` to call a reusable workflow. GitHub rejects it at parse time.

Fix: remove `continue-on-error` and the `allow_failure` matrix property. Dakota E2E becomes blocking, consistent with Bluefin. If a non-blocking gate is needed, track in issue #497.

Verified with actionlint before pushing.