### PR TITLE
fix: changelog reads repo from image-info.json and add tests

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -12,7 +12,10 @@ changelogs:
     TAG="$(jq -r '.["image-tag"]' < "${IMAGE_INFO_FILE}")"
 
     # Select the correct upstream repo based on image stream
-    if [[ "$TAG" =~ ^lts ]]; then
+    IMAGE_NAME="$(jq -r '.["image-name"] // empty' < "${IMAGE_INFO_FILE}")"
+    if [[ "$IMAGE_NAME" == "dakota" ]]; then
+        REPO="projectbluefin/dakota"
+    elif [[ "$TAG" =~ ^lts ]]; then
         REPO="projectbluefin/bluefin-lts"
     else
         REPO="projectbluefin/bluefin"

--- a/tests/test_bonedigger_report.bats
+++ b/tests/test_bonedigger_report.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+setup() {
+    export BONEDIGGER_SCRIPT="$BATS_TEST_DIRNAME/../system_files/bluefin/usr/libexec/bonedigger-report"
+
+    TEST_HELPER="$(mktemp)"
+    cat << 'INNER_EOF' > "$TEST_HELPER"
+#!/usr/bin/bash
+# Evaluate the scrub functions from the script
+eval "$(sed -n '/^scrub_kernel_log() {/,/^}/p' "$BONEDIGGER_SCRIPT")"
+eval "$(sed -n '/^scrub_journal_log() {/,/^}/p' "$BONEDIGGER_SCRIPT")"
+
+# Execute requested function
+"$@"
+INNER_EOF
+    chmod +x "$TEST_HELPER"
+}
+
+teardown() {
+    rm -f "$TEST_HELPER"
+}
+
+@test "scrub_kernel_log redacts MAC addresses" {
+    result="$(echo "Device 00:1A:2B:3C:4D:5E connected" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "Device [MAC-REDACTED] connected" ]
+}
+
+@test "scrub_kernel_log redacts IPv4 addresses" {
+    result="$(echo "Connecting to 192.168.1.100 port 80" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "Connecting to [IP-REDACTED] port 80" ]
+}
+
+@test "scrub_kernel_log redacts IPv6 addresses" {
+    result="$(echo "IP: 2001:0db8:85a3:0000:0000:8a2e:0370:7334" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "IP: [IP-REDACTED]" ]
+}
+
+@test "scrub_kernel_log redacts UUIDs" {
+    result="$(echo "Disk 123e4567-e89b-12d3-a456-426614174000 mounted" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "Disk [UUID-REDACTED] mounted" ]
+}
+
+@test "scrub_kernel_log redacts home paths" {
+    result="$(echo "Error opening /var/home/jorge/.config/file" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "Error opening /var/home/[REDACTED]/.config/file" ]
+
+    result="$(echo "Cannot read /home/alice/Documents" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "Cannot read /home/[REDACTED]/Documents" ]
+}
+
+@test "scrub_journal_log redacts USER/LOGNAME variables" {
+    result="$(echo "Started session for USER=jorge" | "$TEST_HELPER" scrub_journal_log)"
+    [ "$result" = "Started session for USER=[REDACTED]" ]
+
+    result="$(echo "LOGNAME=alice is logging in" | "$TEST_HELPER" scrub_journal_log)"
+    [ "$result" = "LOGNAME=[REDACTED] is logging in" ]
+}
+
+@test "scrub_journal_log redacts email addresses" {
+    result="$(echo "Failed to sync jorge@example.com" | "$TEST_HELPER" scrub_journal_log)"
+    [ "$result" = "Failed to sync [REDACTED-email]" ]
+}
+
+@test "issue_url routing works for bluefin" {
+    # Extract the issue URL routing logic into a testable script
+    TEST_URL_ROUTER="$(mktemp)"
+    cat << 'INNER_EOF' > "$TEST_URL_ROUTER"
+#!/usr/bin/bash
+IMAGE_INFO_FILE="/dev/null"
+IMAGE_NAME="$1"
+IMAGE_TAG="$2"
+BONEDIGGER_ISSUE_URL="$3"
+
+eval "$(sed -n '/^# Derive issue URLs/,/^fi/p' "$BONEDIGGER_SCRIPT")"
+
+echo "$ISSUE_URL_BASE"
+INNER_EOF
+    chmod +x "$TEST_URL_ROUTER"
+
+    # Bluefin generic
+    result="$("$TEST_URL_ROUTER" "bluefin" "latest" "")"
+    [ "$result" = "https://github.com/projectbluefin/bluefin/issues/new?template=bug-report.yml" ]
+
+    # Bluefin LTS
+    result="$("$TEST_URL_ROUTER" "bluefin" "lts-39" "")"
+    [ "$result" = "https://github.com/projectbluefin/bluefin-lts/issues/new?template=bug-report.yml" ]
+
+    # Dakota
+    result="$("$TEST_URL_ROUTER" "dakota" "latest" "")"
+    [ "$result" = "https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml" ]
+
+    # Common fallback
+    result="$("$TEST_URL_ROUTER" "something-else" "latest" "")"
+    [ "$result" = "https://github.com/projectbluefin/common/issues/new?template=bug-report.yml" ]
+
+    # Override
+    result="$("$TEST_URL_ROUTER" "bluefin" "latest" "https://example.com/custom")"
+    [ "$result" = "https://example.com/custom" ]
+
+    rm -f "$TEST_URL_ROUTER"
+}
+
+@test "home paths with spaces are redacted" {
+    result="$(echo "Path /var/home/jorge space/file" | "$TEST_HELPER" scrub_kernel_log)"
+    # Note the original regex: s|/(var/)?home/[^/[:space:]]+/|/\1home/[REDACTED]/|g
+    # It stops at space. So /var/home/jorge space/ might not be fully scrubbed if 'jorge space' is the username.
+    # Actually, usernames cannot contain spaces. So stopping at space is correct to prevent matching across words.
+
+    result="$(echo "File saved to /home/jorge/my documents/file.txt" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "File saved to /home/[REDACTED]/my documents/file.txt" ]
+}
+
+@test "scrub_kernel_log handles multiple PII in one line" {
+    result="$(echo "User /home/alice/ connected from 192.168.1.5 (MAC: AA:BB:CC:DD:EE:FF)" | "$TEST_HELPER" scrub_kernel_log)"
+    [ "$result" = "User /home/[REDACTED]/ connected from [IP-REDACTED] (MAC: [MAC-REDACTED])" ]
+}

--- a/tests/test_changelog.bats
+++ b/tests/test_changelog.bats
@@ -38,13 +38,16 @@ setup() {
     export IMAGE_INFO_FILE="${IMAGE_INFO}"
 
     # Mock jq:
-    #   - '.["image-tag"]' query  → returns $MOCK_TAG (ignores stdin — IMAGE_INFO_FILE set above)
-    #   - all other invocations   → echo a mock changelog body
+    #   - '.["image-tag"]' query  → returns $MOCK_TAG
+    #   - '.["image-name"]' query → returns $MOCK_NAME
     cat > "${MOCKDIR}/jq" << 'EOF'
 #!/bin/bash
 for arg in "$@"; do
     if [[ "$arg" == *'image-tag'* ]]; then
         echo "${MOCK_TAG:-latest}"
+        exit 0
+    elif [[ "$arg" == *'image-name'* ]]; then
+        echo "${MOCK_NAME:-bluefin}"
         exit 0
     fi
 done
@@ -181,4 +184,10 @@ teardown() {
 @test "changelog: exits 0 on lts tag" {
     MOCK_TAG="lts-20260601" run bash "${SCRIPT_FILE}"
     [ "${status}" -eq 0 ]
+}
+
+@test "changelog: dakota image name selects projectbluefin/dakota repo" {
+    MOCK_NAME="dakota" MOCK_TAG="latest" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/dakota" "${CURL_CALLS}"
 }


### PR DESCRIPTION
Fixes #784
Fixes #788

- Added tests/test_bonedigger_report.bats to test bonedigger-report PII redaction and issue URL logic.
- Fixed changelog.just to select correct repo using image-info.json for dakota and tests.

Assisted-by: Gemini 3.1 Pro via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>