### PR TITLE
fix(motd): prevent double-execution and missing env.sh errors

### DIFF
--- a/system_files/shared/etc/profile.d/ublue-motd.sh
+++ b/system_files/shared/etc/profile.d/ublue-motd.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-[ ! -e "$HOME"/.config/no-show-user-motd ] && ublue-motd
+[ ! -e "$HOME"/.config/no-show-user-motd ] && [ "${UBLUE_MOTD_SHOWN:-0}" != "1" ] && { export UBLUE_MOTD_SHOWN=1; ublue-motd; }

--- a/system_files/shared/usr/bin/ublue-motd
+++ b/system_files/shared/usr/bin/ublue-motd
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 
 MOTD_TEMPLATE_FILE="${MOTD_TEMPLATE_FILE:-/usr/share/ublue-os/motd/template.md}"
-. "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
+if [ -f "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}" ]; then
+  # shellcheck source=/dev/null
+  . "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
+fi
 
 if command -v tput >/dev/null 2>&1 && [ -t 1 ]; then
   cols=$(tput cols 2>/dev/null)

--- a/system_files/shared/usr/share/fish/vendor_conf.d/fish_greeting.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/fish_greeting.fish
@@ -1,5 +1,8 @@
 function fish_greeting
     if test ! -e $HOME/.config/no-show-user-motd
-        ublue-motd
+        if test -z "$UBLUE_MOTD_SHOWN" -or "$UBLUE_MOTD_SHOWN" != "1"
+            set -gx UBLUE_MOTD_SHOWN 1
+            ublue-motd
+        end
     end
 end


### PR DESCRIPTION
This PR fixes two bugs in the MOTD scripts:

1. **Double Execution**: Added double-execution guard checking `UBLUE_MOTD_SHOWN` to `profile.d/ublue-motd.sh` and `fish_greeting.fish` so the motd is not run multiple times on each shell startup (especially relevant for environments where `/etc/bashrc` sources `/etc/profile.d/*.sh` repeatedly).
2. **Missing `env.sh` Errors**: Prevented a fatal error by adding a check to ensure `/usr/share/ublue-os/motd/env.sh` exists before trying to source it in `ublue-motd`.

Fixes an issue observed in downstream images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The message-of-the-day now appears only once per session, reducing repeated prompts in new shells.

* **Bug Fixes**
  * Improved handling when optional greeting configuration is missing, preventing startup errors.
  * Added support for a user disable file so the message can be turned off more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->