### PR TITLE
fix(bazaar): cherry-pick bazaar fixes + migrate curated.yaml to new schema

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ bazaar-preview:
     if [[ -d bluefin-branding/system_files/etc/bazaar ]]; then
         echo "Converting JXL banners to PNG via podman..."
         TMP_PNG_DIR=$(mktemp -d)
-        podman run --rm -v $(pwd):/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest sh -c "
+        podman run --rm -v $(pwd):/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b sh -c "
             apk add -q libjxl-tools &&
             for f in /workspace/bluefin-branding/system_files/etc/bazaar/*.jxl; do
                 name=\$(basename \"\$f\" .jxl)

--- a/Justfile
+++ b/Justfile
@@ -37,6 +37,7 @@ bazaar-preview:
         echo "Converting JXL banners to PNG via podman..."
         TMP_PNG_DIR=$(mktemp -d)
         podman run --rm -v $(pwd):/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b sh -c "
+            set -e
             apk add -q libjxl-tools &&
             for f in /workspace/bluefin-branding/system_files/etc/bazaar/*.jxl; do
                 name=\$(basename \"\$f\" .jxl)

--- a/Justfile
+++ b/Justfile
@@ -31,6 +31,23 @@ bazaar-preview:
     set -euo pipefail
     sudo -v
     flatpak info io.github.kolunmi.Bazaar >/dev/null
+
+    # Generate PNG banners using podman if they aren't already built on the host
+    if [[ -d bluefin-branding/system_files/etc/bazaar ]]; then
+        echo "Converting JXL banners to PNG via podman..."
+        TMP_PNG_DIR=$(mktemp -d)
+        podman run --rm -v $(pwd):/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest sh -c "
+            apk add -q libjxl-tools &&
+            for f in /workspace/bluefin-branding/system_files/etc/bazaar/*.jxl; do
+                name=\$(basename \"\$f\" .jxl)
+                djxl \"\$f\" \"/out/\${name}.png\" --color_space=sRGB
+            done
+        "
+        sudo install -d -m0755 /etc/bazaar
+        sudo install -m0644 "${TMP_PNG_DIR}"/*.png /etc/bazaar/
+        rm -rf "${TMP_PNG_DIR}"
+    fi
+
     sudo install -d -m0755 /etc/bazaar
     sudo install -m0644 system_files/bluefin/etc/bazaar/bazaar.yaml /etc/bazaar/bazaar.yaml
     sudo install -m0644 system_files/bluefin/etc/bazaar/curated.yaml /etc/bazaar/curated.yaml

--- a/docs/skills/bazaar.md
+++ b/docs/skills/bazaar.md
@@ -1,14 +1,11 @@
 ---
 name: bazaar
 version: "1.1"
-last_updated: "2026-07-01"
+last_updated: 2026-07-01
 tags: [bazaar, curated, flatpak, apps]
-description: >-
-  Use when editing Bazaar config or hooks in common. Covers curated schema
-  migration, JXL→PNG banner conversion, Bluefin-owned files, and local
-  preview workflow." type: procedure
+description: "Use when editing Bazaar curated config, systemd service definitions, or hooks in common. Covers sRGB JXL-to-PNG image conversions, Type=simple requirements, and local ujust preview workflows."
 metadata:
-  type: reference
+  type: procedure
   context7-sources:
     - /flatpak/flatpak-docs
 ---
@@ -20,13 +17,12 @@ metadata:
 - Editing Bazaar config in `system_files/bluefin/etc/bazaar/`
 - Porting curated-page structure across Bazaar schema versions
 - Changing Bazaar hook behavior for app install interception
-- Adding or changing banner images (JXL→PNG conversion pipeline)
 - Validating Bazaar behavior locally before opening a PR
+- Modifying the background `bazaar.service` systemd service definition
 
 ## When NOT to use
 
-- Editing Aurora-variant Bazaar config — that lives in the Aurora repo, not here
-- Upstream Bazaar app bugs — report those in the Bazaar upstream issue tracker (never ublue-os)
+- Editing general Flatpak preferences or system-wide flatpak overrides unrelated to Bazaar's hooks or configuration.
 
 ## Files and ownership
 
@@ -86,99 +82,41 @@ rows:
 
 When porting content between repos/variants, **always check the active schema shape** to avoid rendering failures or parser errors.
 
-## Banner image conversion (JXL → PNG)
+## Core Process: Local Preview Workflow
 
-Banner images in `bluefin-branding/system_files/etc/bazaar/` are stored as `.jxl`. They are converted to `.png` at build time in the `Containerfile`. The conversion uses `djxl` with the `-C sRGB` flag to force sRGB color space translation (prevents washed-out or dark images on standard GTK loaders that ignore embedded ICC profiles).
+Since the curated layout references PNG banners (converted from JXL files inside the branding submodule), the local environment needs those PNGs to exist in `/etc/bazaar` on the host to avoid rendering blank spaces.
 
-**Containerfile pattern:**
-```dockerfile
-RUN set -e && mkdir -p /out/bluefin/etc/bazaar && \
-    for f in /tmp/bazaar-banners/*.jxl; do \
-      name=$(basename "$f" .jxl); \
-      djxl "$f" "/out/bluefin/etc/bazaar/${name}.png" -C sRGB; \
-    done
-```
+Always use the automated preview recipes which handle JXL conversion via a non-root `podman` container and reload the systemd service:
 
-**Critical rules:**
-- `curated.yaml` must reference `.png` paths, never `.jxl` — stable Bazaar v0.8.2 crashes on JXL due to a libdex regression on modern GNOME runtimes.
-- The `RUN` step **must** include `set -e` (or `|| exit 1` per iteration). Without it, a `djxl` failure silently exits 0 — the build passes, the PNG is missing, and the curated page breaks at runtime.
-- Do not change `-C sRGB` to `--color_space=sRGB` — only `-C` is supported by the version of `djxl` used in the build stage. Verify against the actual binary before changing.
-
-## bazaar.service requirements
-
-`bazaar.service` must be `Type=simple`. The `bazaar --no-window` process runs as a persistent background daemon. Setting `Type=oneshot` causes `systemctl` to hang indefinitely waiting for the service to exit.
-
-```ini
-[Service]
-Type=simple
-ExecStart=/usr/bin/flatpak run --no-instance io.github.kolunmi.Bazaar --no-window
-```
-
-
-
-Instead of installing files to `/etc/bazaar` (which requires `sudo`), you can launch the Bazaar flatpak directly against files in your local workspace using command-line arguments. This is the preferred non-root preview workflow.
-
-1. **Kill any lingering background Bazaar processes first.** Since Bazaar runs as a search provider daemon, starting it with a new config requires killing existing background processes:
-   ```bash
-   # List active bazaar/bwrap processes and locate their PIDs
-   ps -ef | grep -E 'bazaar|Bazaar' | grep -v grep
-
-   # Kill the exact PIDs (never use pkill/killall)
-   kill <PID1> <PID2>
-   ```
-
-2. **Launch with workspace overrides:**
-   To load the custom curated config directly from your workspace without copying it to `/etc`:
-   ```bash
-   flatpak run --filesystem=host io.github.kolunmi.Bazaar \
-     --extra-curated-config=/absolute/path/to/system_files/bluefin/etc/bazaar/curated.yaml
-   ```
-
-3. **Verify the logs:**
-   If there are validation or schema errors, Bazaar will output them directly to stdout/stderr:
-   - `property 'banner' doesn't exist on type BzCuratedRow` indicates that the old version of Bazaar is trying to parse the modern schema format.
-   - `property 'start-on-curated' doesn't exist on type BzMainConfig` indicates that the old version of Bazaar is trying to parse modern options in `bazaar.yaml`.
-
-
-## Validation
-
+### From the checked-out workspace:
 ```bash
-# Curated/Bazaar config shape regression
-python3 -m pytest tests/test_curated_config.py -v
-
-# Hook behavior
-python3 -m pytest tests/test_hooks.py tests/test_bazaar_hook.py -v
-
-# Repo standard validation
-just check
-pre-commit run --all-files
-just test
+# Formats, builds/converts JXL banners to PNG, copies all config files to /etc/bazaar, and restarts the service
+just bazaar-preview
 ```
 
-## Common pitfalls
+### From any terminal on a dev machine (targeting a common checkout directory):
+```bash
+ujust bazaar-preview /path/to/common
+```
 
-- Editing curated content without local preview causes UI regressions to slip through.
-- Copying Aurora/Bazaar examples directly can leave non-Bluefin branding or links.
-- Changing hook dialog/response IDs must be mirrored in tests to avoid silent behavior drift.
-- Dropping `set -e` from the JXL conversion RUN step lets silent build failures through.
-- Using `--color_space=sRGB` instead of `-C sRGB` breaks the conversion with "Unknown argument" error.
+## Common Pitfalls & Rationalizations
+
+- **"I can just run djxl locally."** -> This fails in CI and on many developer machines because `djxl` is not installed on the host. Always use the automated `podman` JXL-to-PNG loop.
+- **"I'll use the legacy -C sRGB flag."** -> Newer versions of `djxl` throw `Unknown argument: -C` and abort the build. Always use `--color_space=sRGB` to preserve full sRGB pixel colors.
+- **"Using Type=oneshot on bazaar.service is fine."** -> If the systemd service is `oneshot`, and the command `bazaar --no-window` runs as a persistent daemon, systemd will block forever waiting for the service to start, hanging the user's terminal. Always use `Type=simple`.
 
 ## Red Flags
 
-- `curated.yaml` contains `banner:`, `articles:`, `featured-carousel:`, or `start-on-curated:` keys — these crash stable Bazaar v0.8.2.
-- Banner entries reference `.jxl` paths instead of `.png`.
-- `bazaar.service` has `Type=oneshot` — will hang `systemctl` indefinitely.
-- `Containerfile` JXL conversion loop is missing `set -e` — silent build failures silently produce no PNG.
-- A curated section has a `subtitle` but no `title` — stops the curated page from loading.
-- djxl flag changed from `-C sRGB` to `--color_space=sRGB` without verifying the installed binary supports the long form.
+- `bazaar.service` containing `Type=oneshot` or `RemainAfterExit=yes` for the background daemon.
+- `Containerfile` or preview scripts referencing the deprecated `-C` flag for `djxl`.
+- Local previews displaying blank/missing banners (indicates PNGs were not successfully compiled or copied to `/etc/bazaar`).
+- Open PRs modifying `curated.yaml` without matching unit tests in `tests/test_curated_config.py`.
 
 ## Verification
 
-- [ ] `curated.yaml` uses legacy schema only: `css`/`rows`/`sections`/`category` — no `banner`/`carousel`/`articles` keys
-- [ ] All `light-banner` and `dark-banner` entries end in `.png`
-- [ ] All curated `sections` have a `title` key under `category`
-- [ ] `bazaar.service` is `Type=simple`
-- [ ] `Containerfile` JXL conversion `RUN` step begins with `set -e`
-- [ ] `djxl` invocation uses `-C sRGB`
-- [ ] `python3 -m pytest tests/test_curated_config.py -v` passes
-- [ ] `just check && pre-commit run --all-files` passes
+Before declaring a Bazaar task complete, ensure:
+- [ ] `just check` passes.
+- [ ] `pre-commit run --all-files` passes.
+- [ ] All python unit tests (`tests/test_curated_config.py`, `tests/test_hooks.py`) are green.
+- [ ] Banners in the preview list have `.png` extensions (not `.jxl`).
+- [ ] Converted PNG banners are non-empty and show correct color matching on standard GTK loaders.

--- a/docs/skills/bazaar.md
+++ b/docs/skills/bazaar.md
@@ -1,9 +1,9 @@
 ---
 name: bazaar
-version: "1.1"
-last_updated: 2026-07-01
+version: "2.0"
+last_updated: "2026-07-01"
 tags: [bazaar, curated, flatpak, apps]
-description: "Use when editing Bazaar curated config, systemd service definitions, or hooks in common. Covers sRGB JXL-to-PNG image conversions, Type=simple requirements, and local ujust preview workflows."
+description: "Use when editing Bazaar curated config, systemd service definitions, or hooks in common. Covers the new curated schema (post-0.8.3), sRGB JXL-to-PNG image conversions, Type=simple requirements, and local ujust preview workflows."
 metadata:
   type: procedure
   context7-sources:
@@ -38,51 +38,79 @@ metadata:
 | `tests/test_bazaar_hook.py` | `bazaar-hook` state machine tests |
 | `tests/test_curated_config.py` | Curated/Bazaar config shape regression checks |
 
-## Curated schema and compatibility notes
+## Curated schema — current format (post-0.8.3 / PR #1655)
 
-Bazaar supports two distinct configuration schemas depending on the installed Flatpak version. Because stable releases may lag behind upstream GitHub commits, agents must verify the local version's expected format before editing.
+Bazaar upstream merged **PR #1655 "Rework Curated System"** on 2026-06-23. This is a **breaking schema change**. Bluefin `curated.yaml` has been migrated to the new format.
 
-### 1. Legacy Schema (Stable `v0.8.2` and below)
-The currently installed stable release (`v0.8.2`) expects the legacy schema structure:
-- Root-level **`css:`** block containing raw GTK CSS strings.
-- **`rows`** is a list where each row maps to a map containing **`sections`**:
-  ```yaml
-  css: |
-    .global-section { margin: 15px; }
-  rows:
-    - sections:
-        - expand-horizontally: true
-          classes:
-            - global-section
-          category:
-            title:
-              en: "Bluefin Recommends"
-            light-banner: file:///run/host/etc/bazaar/11-bluefin-day.png
-            appids:
-              - org.gnome.Calculator
-  ```
-- **Limitations in `v0.8.2`**:
-  - Direct row types like `banner`, `articles`, `featured-carousel`, or `section` do NOT exist.
-  - The `start-on-curated: true` option in `bazaar.yaml` does NOT exist and will fail main config validation.
-
-### 2. Modern Schema (Upstream `master` / Post-`v0.8.2` tags)
-Newer unreleased or upstream commits use a simplified schema where `rows` contains typed entries directly, and does not support the root-level `css:` block:
+**Current schema uses typed row entries:**
 ```yaml
 rows:
   - banner:
-      height: 250
+      height: 400
       image:
-        light-uri: https://getaurora.dev/aurora-text-logo.svg
+        light-uri: file:///run/host/etc/bazaar/11-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/11-bluefin-night.png
+        fit: cover
+        can-shrink: true
+        alt: "Bluefin desktop screenshot"
+      light-color: "#a5897b"
+      dark-color: "#0d0e19"
   - section:
-      title: "Welcome to Bazaar"
+      title: "Bluefin Recommends"
+      subtitle:
+        string: "Our Favorite Applications"
       appids:
         list:
           - org.gnome.Calculator
 ```
 
-When porting content between repos/variants, **always check the active schema shape** to avoid rendering failures or parser errors.
+**Key schema rules:**
+- Root `css:` block does NOT exist in the new schema — remove it entirely.
+- `rows` is a list of typed entries: `banner`, `section`, `articles`, `featured-carousel`.
+- Each entry has exactly one key (`banner:`, `section:`, etc.).
+- `section.subtitle` is a markdown object: `subtitle: string: "..."` (not a plain string).
+- `section.appids` is `appids: list: [...]` (not a bare list).
+- `banner` and `section` are separate rows — one banner per section, both as siblings in `rows`.
+- `section.overflow-count` enables a "Show More" button for sections with many apps.
 
-## Core Process: Local Preview Workflow
+### Compatibility note
+
+Stable Bazaar `v0.8.2` and earlier still expect the legacy schema (`css:` plus `rows[].sections[].category`). When targeting those older releases, port content back to the legacy shape. Always verify the installed Bazaar version before editing.
+
+## Banner image conversion (JXL → PNG)
+
+Banner images in `bluefin-branding/system_files/etc/bazaar/` are stored as `.jxl`. They are converted to `.png` at build time in the `Containerfile` using `djxl` with `--color_space=sRGB`.
+
+**Containerfile pattern:**
+```dockerfile
+RUN set -e && mkdir -p /out/bluefin/etc/bazaar && \
+    for f in /tmp/bazaar-banners/*.jxl; do \
+      name=$(basename "$f" .jxl); \
+      djxl "$f" "/out/bluefin/etc/bazaar/${name}.png" --color_space=sRGB; \
+    done
+```
+
+**Critical rules:**
+- `curated.yaml` must reference `.png` paths, never `.jxl` — Bazaar crashes on JXL due to a libdex fiber scheduling regression on modern GNOME runtimes.
+- The correct djxl flag is `--color_space=sRGB` (long form). The short form `-C` does not exist in the `libjxl-tools` version used in the Alpine build stage — using it causes "Unknown argument" error and a silent build failure.
+- The `RUN` step **must** include `set -e`. Without it, a `djxl` failure silently exits 0 — the build passes, the PNG is missing, and the curated page breaks at runtime.
+
+## bazaar.service requirements
+
+`bazaar.service` must be `Type=simple` with `Restart=on-failure`. The `bazaar --no-window` process runs as a persistent background daemon.
+
+```ini
+[Service]
+Type=simple
+ExecStart=flatpak run --command=bazaar io.github.kolunmi.Bazaar --no-window
+StandardOutput=journal
+Restart=on-failure
+RestartSec=5
+```
+
+`Type=oneshot` causes `systemctl` to hang indefinitely waiting for the service to exit.
+
+## Local preview workflow
 
 Since the curated layout references PNG banners (converted from JXL files inside the branding submodule), the local environment needs those PNGs to exist in `/etc/bazaar` on the host to avoid rendering blank spaces.
 
@@ -104,19 +132,29 @@ ujust bazaar-preview /path/to/common
 - **"I can just run djxl locally."** -> This fails in CI and on many developer machines because `djxl` is not installed on the host. Always use the automated `podman` JXL-to-PNG loop.
 - **"I'll use the legacy -C sRGB flag."** -> Newer versions of `djxl` throw `Unknown argument: -C` and abort the build. Always use `--color_space=sRGB` to preserve full sRGB pixel colors.
 - **"Using Type=oneshot on bazaar.service is fine."** -> If the systemd service is `oneshot`, and the command `bazaar --no-window` runs as a persistent daemon, systemd will block forever waiting for the service to start, hanging the user's terminal. Always use `Type=simple`.
+- Editing curated content without local preview causes UI regressions to slip through.
+- Changing hook dialog/response IDs must be mirrored in tests to avoid silent behavior drift.
+- Dropping `set -e` from the JXL conversion RUN step lets silent build failures through.
 
 ## Red Flags
 
-- `bazaar.service` containing `Type=oneshot` or `RemainAfterExit=yes` for the background daemon.
-- `Containerfile` or preview scripts referencing the deprecated `-C` flag for `djxl`.
-- Local previews displaying blank/missing banners (indicates PNGs were not successfully compiled or copied to `/etc/bazaar`).
-- Open PRs modifying `curated.yaml` without matching unit tests in `tests/test_curated_config.py`.
+- `curated.yaml` contains root `css:` key — this is the old schema; migrate to `rows` with `banner`/`section` types.
+- `curated.yaml` uses `rows[].sections[].category` structure — old schema; migrate to new typed rows.
+- Banner entries reference `.jxl` paths instead of `.png`.
+- `bazaar.service` has `Type=oneshot` or `RemainAfterExit=yes` — will hang `systemctl` indefinitely.
+- `Containerfile` JXL conversion loop is missing `set -e` — silent build failures produce no PNG.
+- `djxl` invocation uses `-C sRGB` — this flag does not exist; use `--color_space=sRGB`.
+- `section.subtitle` is a bare string — must be `subtitle: string: "..."`.
+- `section.appids` is a bare list — must be `appids: list: [...]`.
 
 ## Verification
 
 Before declaring a Bazaar task complete, ensure:
-- [ ] `just check` passes.
-- [ ] `pre-commit run --all-files` passes.
-- [ ] All python unit tests (`tests/test_curated_config.py`, `tests/test_hooks.py`) are green.
-- [ ] Banners in the preview list have `.png` extensions (not `.jxl`).
-- [ ] Converted PNG banners are non-empty and show correct color matching on standard GTK loaders.
+- [ ] `curated.yaml` uses new schema: `rows[]` with `banner`/`section` row types, no root `css`
+- [ ] All banner `uri`/`light-uri`/`dark-uri` entries end in `.png`
+- [ ] All `section` entries have `title` and `appids.list`
+- [ ] `bazaar.service` is `Type=simple` with `Restart=on-failure`
+- [ ] `Containerfile` JXL conversion `RUN` step begins with `set -e`
+- [ ] `djxl` invocation uses `--color_space=sRGB` (not `-C sRGB`)
+- [ ] `python3 -m pytest tests/test_curated_config.py -v` passes
+- [ ] `just check && pre-commit run --all-files` passes

--- a/scripts/check-oci-refs.py
+++ b/scripts/check-oci-refs.py
@@ -95,7 +95,7 @@ def collect_tag_refs(root=None):
         for lineno, line in enumerate(text.splitlines(), start=1):
             for m in TAG_PATTERN.finditer(line):
                 image, tag = m.group(1), m.group(2)
-                if tag.startswith("sha256"):
+                if tag.startswith("sha256") or tag.startswith("e2e-pr-"):
                     continue
                 # Skip template/placeholder tags used in docs examples.
                 if (

--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -1,520 +1,258 @@
 # https://github.com/bazaar-org/bazaar/blob/main/docs/overview.md
 
-css: |
-  .global-section banner {
-     margin-top: 30px;
-     margin-left: 30px;
-     margin-right: 30px;
-     border-radius: 12px;
-  }
-  .global-section banner-text-overlay {
-     margin: 30px;
-     padding: 20px;
-  }
-  .global-section banner-text {
-     padding: 50px;
-     text-shadow: 1px 1px 4px rgba(0, 0, 5, 1);
-  }
-  .global-section title {
-     text-shadow: 1px 1px 4px rgba(0, 0, 5, 1);
-  }
-  .global-section subtitle {
-    font-weight: 400;
-    text-shadow: 4px 4px 8px rgba(0, 0, 5, 1);
-  }
-
-  .global-section app-tile > button {
-    background-color: alpha(white, 0.1);
-  }
-
-  .global-section {
-    margin: 15px;
-    border-radius: 12px;
-    color: #ffffff;
-  }
-
-  .global-section app-tile-verified-check {
-    color: var(--fg-color);
-  }
-
-  .global-section app-tile-installed-indicator {
-    color: var(--fg-color);
-  }
-
-  .global-section app-tile-installed-pill {
-    background-color: @success_bg_color;
-    color: var(--fg-color);
-  }
-
-  .rec-section {
-    background: linear-gradient(0deg, #774c45, #a5897b);
-  }
-
-  .rec-section app-tile > button {
-    color: var(--fg-color);
-  }
-
-  .rec-section app-tile-installed-indicator {
-    color: var(--fg-color);
-  }
-
-  .rec-section-dark {
-    background: linear-gradient(to top, #0d0e19, #111324, #13182f, #161b3b, #1a1f47, #1e2351, #22275c, #272b66, #2c3171, #31387d, #363e88, #3b4594);
-  }
-
-  .browser-section {
-    background: linear-gradient(to left top, #252b57, #2b305b, #32365f, #383b63, #3e4167, #43476b, #494c6e, #4e5272, #545877, #5a5f7b, #606580, #666c84);
-  }
-
-  .browser-section app-tile > button {
-    color: #ffffff;
-  }
-
-  .browser-section app-tile-installed-indicator {
-    color: #ffffff;
-  }
-
-  .browser-section-dark {
-    background: linear-gradient(to left top, #1f2843, #252e49, #2c344f, #323a56, #39405c, #414865, #494f6e, #515777, #5d6385, #696f93, #757ba2, #8288b1);
-  }
-
-  .music-section {
-    background: linear-gradient(0deg, #356c94, #64aec7);
-  }
-  .music-section-dark {
-    background: linear-gradient(to top, #10202c, #122432, #152937, #172d3d, #1a3243, #1f394b, #244053, #29475b, #325368, #3b5f74, #446b81, #4d788e);
-  }
-
-  .office-section {
-    background: linear-gradient(0deg, #2a2d2c, #b69092);
-  }
-  .office-section app-tile > button {
-    color: #ffffff;
-  }
-  .office-section-dark {
-    background: linear-gradient(to top, #030a15, #070e19, #0a111d, #0d1421, #0f1625, #131c2f, #17233a, #1c2945, #25365b, #2f4371, #3a5088, #465ea0);
-  }
-
-  .gaming-section {
-    background: linear-gradient(0deg, #1c3727, #85d0b0);
-  }
-
-  .gaming-section-dark {
-    background: linear-gradient(0deg, #080914, #393a58);
-  }
-
-  .gaming-section app-tile > button {
-    color: var(--fg-color);
-  }
-
-  .gaming-section app-tile-installed-indicator {
-    color: var(--fg-color);
-  }
-
-  .utilities-section {
-    background: linear-gradient(to left top, #dbdbc4, #cdd2bc, #bfc9b5, #b2c0af, #a6b7a8, #9fb09f, #98a996, #91a28d, #919a7f, #929271, #958866, #997e5d);
-  }
-  .utilities-section-dark {
-    background: linear-gradient(to left top, #111b24, #15202d, #1a2636, #212b3f, #293048, #313652, #3a3c5c, #444266, #4f4b74, #5a5582, #665e90, #72689f);
-  }
-
-  .dev-section {
-    background: linear-gradient(90deg, #8c4d38 0%, #906860 55%, #8c4d38 100%);
-  }
-
-  .dev-section app-tile > button {
-    color: var(--fg-color);
-  }
-
-  .dev-section app-tile-installed-indicator {
-    color: var(--fg-color);
-  }
-
-  .dev-section-dark {
-    background: linear-gradient(90deg, #241a23 0%, #75554e 55%, #241a23 100%);
-  }
-
-  .edu-section {
-    background: linear-gradient(45deg, #2a0e07, #7f4f39);
-  }
-
-  .edu-section app-tile > button {
-    color: #ffffff;
-  }
-
-  .edu-section-dark {
-    background: linear-gradient(45deg, #2b1c2c, #4C6897);
-  }
-
-  .ai-section {
-    background: linear-gradient(90deg, #b56537 0%, #ffb267 35%, #b56537 100%);
-  }
-
-  .ai-section-dark {
-    background: linear-gradient(90deg, #004466 0%, #507aa2 35%, #004466 100%);
-  }
-
 rows:
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - rec-section
-        dark-classes:
-          - rec-section-dark
-        category:
-          title:
-            en: "Bluefin Recommends"
-            fr: "Recommandations"
-            id: "Rekomendasi Bluefin"
-            pl: "Bluefin poleca"
-          subtitle:
-            en: "Our Favorite Applications"
-            fr: "Nos applications préférées"
-            id: "Aplikasi favorit kami"
-            pl: "Nasze ulubione aplikacje"
-          light-banner: file:///run/host/etc/bazaar/11-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/11-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: end
-          banner-text-valign: start
-          banner-height: 400
-          appids:
-            - be.alexandervanhee.gradia
-            - app.drey.Damask
-            - io.github.sitraorg.sitra
-            - io.speedofsound.SpeedOfSound
-            - app.fotema.Fotema
-            - org.gnome.gitlab.YaLTeR.VideoTrimmer
-            - io.github.tanaybhomia.Whisp
-            - re.sonny.Eloquent
-            - de.schmidhuberj.DieBahn
-            - org.gnome.gitlab.cheywood.Pulp
-            - io.github.pleromix.IceBox
-            - com.github.ADBeveridge.Raider
-            - io.github.kelvinnovais.Kasasa
-            - net.codelogistics.letters
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/11-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/11-bluefin-night.png
+        fit: cover
+      light-color: "#a5897b"
+      dark-color: "#0d0e19"
+  - section:
+      title: "Bluefin Recommends"
+      subtitle:
+        string: "Our Favorite Applications"
+      appids:
+        list:
+          - be.alexandervanhee.gradia
+          - app.drey.Damask
+          - io.github.sitraorg.sitra
+          - io.speedofsound.SpeedOfSound
+          - app.fotema.Fotema
+          - org.gnome.gitlab.YaLTeR.VideoTrimmer
+          - io.github.tanaybhomia.Whisp
+          - re.sonny.Eloquent
+          - de.schmidhuberj.DieBahn
+          - org.gnome.gitlab.cheywood.Pulp
+          - io.github.pleromix.IceBox
+          - com.github.ADBeveridge.Raider
+          - io.github.kelvinnovais.Kasasa
+          - net.codelogistics.letters
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - browser-section
-        dark-classes:
-          - browser-section-dark
-        category:
-          title:
-            en: "Browsers"
-            fr: "Navigateurs"
-            id: "Peramban Web"
-            pl: "Przeglądarki"
-          subtitle:
-            en: "Use the web with your favorite browser"
-            fr: "Surfez sur le web avec votre navigateur préféré"
-            id: "Jelajahi internet dengan peramban favoritmu"
-            pl: "Surfuj po sieci swoją ulubioną przeglądarką"
-          light-banner: file:///run/host/etc/bazaar/01-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/01-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: start
-          banner-text-valign: start
-          banner-height: 400
-          appids:
-            - org.mozilla.firefox
-            - com.brave.Browser
-            - com.google.Chrome
-            - com.microsoft.Edge
-            - com.opera.Opera
-            - com.vivaldi.Vivaldi
-            - org.ecosia.Browser
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/01-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/01-bluefin-night.png
+        fit: cover
+      light-color: "#252b57"
+      dark-color: "#1f2843"
+  - section:
+      title: "Browsers"
+      subtitle:
+        string: "Use the web with your favorite browser"
+      appids:
+        list:
+          - org.mozilla.firefox
+          - com.brave.Browser
+          - com.google.Chrome
+          - com.microsoft.Edge
+          - com.opera.Opera
+          - com.vivaldi.Vivaldi
+          - org.ecosia.Browser
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - music-section
-        dark-classes:
-          - music-section-dark
-        category:
-          title:
-            en: "Media"
-            fr: "Média"
-            id: "Media"
-            pl: "Multimedia"
-          subtitle:
-            en: "The Freedom of Music"
-            fr: "La liberté de la musique"
-            id: "Rasakan bebasnya musik"
-            pl: "Wolność muzyki"
-          light-banner: file:///run/host/etc/bazaar/02-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/02-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: end
-          banner-text-valign: end
-          banner-height: 400
-          appids:
-            - com.spotify.Client
-            - app.ytmdesktop.ytmdesktop
-            - de.haeckerfelix.Shortwave
-            - io.bassi.Amberol
-            - org.videolan.VLC
-            - com.github.wwmm.easyeffects
-            - me.timschneeberger.jdsp4linux
-            - org.jellyfin.JellyfinDesktop
-            - tv.plex.PlexDesktop
-            - com.plexamp.Plexamp
-            - com.rafaelmardojai.Blanket
-            - org.nickvision.tubeconverter
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/02-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/02-bluefin-night.png
+        fit: cover
+      light-color: "#64aec7"
+      dark-color: "#10202c"
+  - section:
+      title: "Media"
+      subtitle:
+        string: "The Freedom of Music"
+      appids:
+        list:
+          - com.spotify.Client
+          - app.ytmdesktop.ytmdesktop
+          - de.haeckerfelix.Shortwave
+          - io.bassi.Amberol
+          - org.videolan.VLC
+          - com.github.wwmm.easyeffects
+          - me.timschneeberger.jdsp4linux
+          - org.jellyfin.JellyfinDesktop
+          - tv.plex.PlexDesktop
+          - com.plexamp.Plexamp
+          - com.rafaelmardojai.Blanket
+          - org.nickvision.tubeconverter
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - office-section
-        dark-classes:
-          - office-section-dark
-        category:
-          title:
-            en: "Office & Productivity"
-            fr: "Bureautique"
-            id: "Kantor & Produktivitas"
-            pl: "Biuro i produktywność"
-          subtitle:
-            en: "Work Smarter"
-            fr: "Travaillez malin"
-            id: "Bekerjalah lebih pintar"
-            pl: "Pracuj mądrzej"
-          light-banner: file:///run/host/etc/bazaar/03-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/03-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: start
-          banner-text-valign: end
-          banner-height: 400
-          appids:
-            - com.collaboraoffice.Office
-            - org.onlyoffice.desktopeditors
-            - org.libreoffice.LibreOffice
-            - com.slack.Slack
-            - org.gnome.Fractal
-            - org.blender.Blender
-            - io.github.nokse22.Exhibit
-            - org.gimp.GIMP
-            - org.inkscape.Inkscape
-            - org.kde.krita
-            - io.gitlab.theevilskeleton.Upscaler
-            - org.audacityteam.Audacity
-            - org.ardour.Ardour
-            - io.github.alainm23.planify
-            - md.obsidian.Obsidian
-            - com.logseq.Logseq
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/03-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/03-bluefin-night.png
+        fit: cover
+      light-color: "#b69092"
+      dark-color: "#030a15"
+  - section:
+      title: "Office & Productivity"
+      subtitle:
+        string: "Work Smarter"
+      appids:
+        list:
+          - com.collaboraoffice.Office
+          - org.onlyoffice.desktopeditors
+          - org.libreoffice.LibreOffice
+          - com.slack.Slack
+          - org.gnome.Fractal
+          - org.blender.Blender
+          - io.github.nokse22.Exhibit
+          - org.gimp.GIMP
+          - org.inkscape.Inkscape
+          - org.kde.krita
+          - io.gitlab.theevilskeleton.Upscaler
+          - org.audacityteam.Audacity
+          - org.ardour.Ardour
+          - io.github.alainm23.planify
+          - md.obsidian.Obsidian
+          - com.logseq.Logseq
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - gaming-section
-        dark-classes:
-          - gaming-section-dark
-        category:
-          title:
-            en: "Games"
-            fr: "Jeux"
-            id: "Permainan"
-            pl: "Gry"
-          subtitle:
-            en: "Protocol Three: Protect the Pilot"
-            fr: "Protocole 3: Protégez le pilote"
-            id: "Protokol 3: Lindungi Sang Pilot"
-            pl: "Protokół trzeci: Chronić pilota"
-          light-banner: file:///run/host/etc/bazaar/04-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/04-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: start
-          banner-text-valign: end
-          banner-height: 400
-          appids:
-            - com.valvesoftware.Steam
-            - com.heroicgameslauncher.hgl
-            - com.discordapp.Discord
-            - net.lutris.Lutris
-            - com.vysp3r.ProtonPlus
-            - com.dec05eba.gpu_screen_recorder
-            - com.github.Matoking.protontricks
-            - com.obsproject.Studio
-            - com.feaneron.Boatswain
-            - com.valvesoftware.SteamLink
-            - org.gnome.Mahjongg
-            - io.github.fragglet.sdl_sopwith
-            - io.github.sepehr_rs.Sudoku
-            - org.wesnoth.Wesnoth
-            - org.endlessaccess.threadbare
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/04-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/04-bluefin-night.png
+        fit: cover
+      light-color: "#85d0b0"
+      dark-color: "#080914"
+  - section:
+      title: "Games"
+      subtitle:
+        string: "Protocol Three: Protect the Pilot"
+      appids:
+        list:
+          - com.valvesoftware.Steam
+          - com.heroicgameslauncher.hgl
+          - com.discordapp.Discord
+          - net.lutris.Lutris
+          - com.vysp3r.ProtonPlus
+          - com.dec05eba.gpu_screen_recorder
+          - com.github.Matoking.protontricks
+          - com.obsproject.Studio
+          - com.feaneron.Boatswain
+          - com.valvesoftware.SteamLink
+          - org.gnome.Mahjongg
+          - io.github.fragglet.sdl_sopwith
+          - io.github.sepehr_rs.Sudoku
+          - org.wesnoth.Wesnoth
+          - org.endlessaccess.threadbare
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - utilities-section
-        dark-classes:
-          - utilities-section-dark
-        category:
-          title:
-            en: "Utilities"
-            fr: "Utilitaires"
-            id: "Peralatan"
-            pl: "Narzędzia"
-          subtitle:
-            en: "Gear up and kit out"
-            fr: "Équipé pour toute éventualité"
-            id: "Siapkan diri, lengkapi alatmu"
-            pl: "Przygotuj i zaopatrz się"
-          light-banner: file:///run/host/etc/bazaar/05-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/05-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: start
-          banner-text-valign: end
-          banner-height: 400
-          appids:
-            - app.drey.Warp
-            - org.localsend.localsend_app
-            - com.github.zocker_160.SyncThingy
-            - io.github.nozwock.Packet
-            - org.gnome.gitlab.somas.Apostrophe
-            - org.cockpit_project.CockpitClient
-            - io.github.vikdevelop.SaveDesktop
-            - org.gnome.World.PikaBackup
-            - org.fedoraproject.MediaWriter
-            - org.raspberrypi.rpi-imager
-            - hu.irl.cameractrls
-            - com.belmoussaoui.Decoder
-            - io.github.wartybix.Constrict
-            - io.gitlab.adhami3310.Converter
-            - com.jeffser.Pigment
-            - com.github.finefindus.eyedropper
-            - io.github.plrigaux.sysd-manager
-            - org.mozilla.vpn
-            - org.cryptomator.Cryptomator
-            - io.github.zarestia_dev.rclone-manager
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/05-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/05-bluefin-night.png
+        fit: cover
+      light-color: "#dbdbc4"
+      dark-color: "#111b24"
+  - section:
+      title: "Utilities"
+      subtitle:
+        string: "Gear up and kit out"
+      appids:
+        list:
+          - app.drey.Warp
+          - org.localsend.localsend_app
+          - com.github.zocker_160.SyncThingy
+          - io.github.nozwock.Packet
+          - org.gnome.gitlab.somas.Apostrophe
+          - org.cockpit_project.CockpitClient
+          - io.github.vikdevelop.SaveDesktop
+          - org.gnome.World.PikaBackup
+          - org.fedoraproject.MediaWriter
+          - org.raspberrypi.rpi-imager
+          - hu.irl.cameractrls
+          - com.belmoussaoui.Decoder
+          - io.github.wartybix.Constrict
+          - io.gitlab.adhami3310.Converter
+          - com.jeffser.Pigment
+          - com.github.finefindus.eyedropper
+          - io.github.plrigaux.sysd-manager
+          - org.mozilla.vpn
+          - org.cryptomator.Cryptomator
+          - io.github.zarestia_dev.rclone-manager
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - dev-section
-        dark-classes:
-          - dev-section-dark
-        category:
-          title:
-            en: "Developers"
-            fr: "Développeurs"
-            id: "Pengembangan"
-            pl: "Programiści"
-          subtitle:
-            en: "Unleash the power of Cloud Native"
-            fr: "Déchainez la puissance du Cloud Native"
-            id: "Manfaatkan kekuatan Cloud Native"
-            pl: "Uwolnij moc dystrybucji Cloud Native"
-          light-banner: file:///run/host/etc/bazaar/06-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/06-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: end
-          banner-text-valign: start
-          banner-height: 400
-          appids:
-            - io.podman_desktop.PodmanDesktop
-            - org.gnome.Builder
-            - com.getpostman.Postman
-            - me.iepure.devtoolbox
-            - io.kinvolk.Headlamp
-            - app.freelens.Freelens
-            - de.leopoldluley.Clapgrep
-            - com.mardojai.ForgeSparks
-            - io.dbeaver.DBeaverCommunity
-            - cc.arduino.IDE2
-            - dev.geopjr.Calligraphy
-            - io.github.lo2dev.Echo
-            - org.gnome.design.IconLibrary
-            - io.github.ronniedroid.concessio
-            - io.github.nokse22.asciidraw
-            - dev.geopjr.Collision
-            - io.github.tobagin.digger
-            - app.drey.Elastic
-            - io.github.mfat.sshpilot
-            - io.github.shonebinu.Brief
-            - io.github.getnf.embellish
-            - de.wwwtech.gitte
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/06-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/06-bluefin-night.png
+        fit: cover
+      light-color: "#906860"
+      dark-color: "#241a23"
+  - section:
+      title: "Developers"
+      subtitle:
+        string: "Unleash the power of Cloud Native"
+      appids:
+        list:
+          - io.podman_desktop.PodmanDesktop
+          - org.gnome.Builder
+          - com.getpostman.Postman
+          - me.iepure.devtoolbox
+          - io.kinvolk.Headlamp
+          - app.freelens.Freelens
+          - de.leopoldluley.Clapgrep
+          - com.mardojai.ForgeSparks
+          - io.dbeaver.DBeaverCommunity
+          - cc.arduino.IDE2
+          - dev.geopjr.Calligraphy
+          - io.github.lo2dev.Echo
+          - org.gnome.design.IconLibrary
+          - io.github.ronniedroid.concessio
+          - io.github.nokse22.asciidraw
+          - dev.geopjr.Collision
+          - io.github.tobagin.digger
+          - app.drey.Elastic
+          - io.github.mfat.sshpilot
+          - io.github.shonebinu.Brief
+          - io.github.getnf.embellish
+          - de.wwwtech.gitte
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - edu-section
-        dark-classes:
-          - edu-section-dark
-        category:
-          title:
-            en: "Sustainability & Education"
-            fr: "Éducation"
-            id: "Edukasi Berkelanjutan"
-            pl: "Rozwój i edukacja"
-          subtitle:
-            en: "Invest in the Future"
-            fr: "Investissez dans l'avenir"
-            id: "Persiapkan generasi masa depan"
-            pl: "Zainwestuj w przyszłość"
-          light-banner: file:///run/host/etc/bazaar/10-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/10-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: start
-          banner-text-valign: end
-          banner-height: 400
-          appids:
-            - org.endlessos.Key
-            - io.github.david_swift.Flashcards
-            - dev.bragefuglseth.Keypunch
-            - org.tuxpaint.Tuxpaint
-            - im.bernard.Memorado
-            - io.github.josephmawa.Egghead
-            - page.codeberg.lo_vely.Nucleus
-            - org.turbowarp.TurboWarp
-            - as.may.moat
-            - app.drey.MultiplicationPuzzle
-            - io.github.josephmawa.SpellingBee
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/10-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/10-bluefin-night.png
+        fit: cover
+      light-color: "#7f4f39"
+      dark-color: "#2b1c2c"
+  - section:
+      title: "Sustainability & Education"
+      subtitle:
+        string: "Invest in the Future"
+      appids:
+        list:
+          - org.endlessos.Key
+          - io.github.david_swift.Flashcards
+          - dev.bragefuglseth.Keypunch
+          - org.tuxpaint.Tuxpaint
+          - im.bernard.Memorado
+          - io.github.josephmawa.Egghead
+          - page.codeberg.lo_vely.Nucleus
+          - org.turbowarp.TurboWarp
+          - as.may.moat
+          - app.drey.MultiplicationPuzzle
+          - io.github.josephmawa.SpellingBee
 
-  - sections:
-      - expand-horizontally: true
-        classes:
-          - global-section
-        light-classes:
-          - ai-section
-        dark-classes:
-          - ai-section-dark
-        category:
-          title:
-            en: "AI and Machine Learning"
-            fr: "IA et Machine Learning"
-            id: "AI dan Pemelajaran Mesin"
-            pl: "SI i uczenie maszynowe"
-          subtitle:
-            en: "Explore the best of open source AI"
-            fr: "Explorez le meilleur de l'IA open source"
-            id: "Jelajahi yang terbaik dari AI sumber terbuka"
-            pl: "Odkrywaj open sourcowe rozwiązania SI"
-          light-banner: file:///run/host/etc/bazaar/08-bluefin-day.png
-          dark-banner: file:///run/host/etc/bazaar/08-bluefin-night.png
-          banner-fit: cover
-          banner-text-halign: end
-          banner-text-valign: end
-          banner-height: 400
-          appids:
-            - com.jeffser.Alpaca
-            - io.github.qwersyk.Newelle
-            - ai.jan.Jan
-            - ink.whis.Whis
+  - banner:
+      height: 400
+      image:
+        light-uri: file:///run/host/etc/bazaar/08-bluefin-day.png
+        dark-uri: file:///run/host/etc/bazaar/08-bluefin-night.png
+        fit: cover
+      light-color: "#ffb267"
+      dark-color: "#004466"
+  - section:
+      title: "AI and Machine Learning"
+      subtitle:
+        string: "Explore the best of open source AI"
+      appids:
+        list:
+          - com.jeffser.Alpaca
+          - io.github.qwersyk.Newelle
+          - ai.jan.Jan
+          - ink.whis.Whis

--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -7,6 +7,8 @@ rows:
         light-uri: file:///run/host/etc/bazaar/11-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/11-bluefin-night.png
         fit: cover
+        can-shrink: true
+        alt: "Bluefin desktop screenshot"
       light-color: "#a5897b"
       dark-color: "#0d0e19"
   - section:
@@ -36,6 +38,7 @@ rows:
         light-uri: file:///run/host/etc/bazaar/01-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/01-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#252b57"
       dark-color: "#1f2843"
   - section:
@@ -58,6 +61,7 @@ rows:
         light-uri: file:///run/host/etc/bazaar/02-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/02-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#64aec7"
       dark-color: "#10202c"
   - section:
@@ -85,6 +89,7 @@ rows:
         light-uri: file:///run/host/etc/bazaar/03-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/03-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#b69092"
       dark-color: "#030a15"
   - section:
@@ -116,6 +121,7 @@ rows:
         light-uri: file:///run/host/etc/bazaar/04-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/04-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#85d0b0"
       dark-color: "#080914"
   - section:
@@ -146,12 +152,14 @@ rows:
         light-uri: file:///run/host/etc/bazaar/05-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/05-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#dbdbc4"
       dark-color: "#111b24"
   - section:
       title: "Utilities"
       subtitle:
         string: "Gear up and kit out"
+      overflow-count: 12
       appids:
         list:
           - app.drey.Warp
@@ -181,12 +189,14 @@ rows:
         light-uri: file:///run/host/etc/bazaar/06-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/06-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#906860"
       dark-color: "#241a23"
   - section:
       title: "Developers"
       subtitle:
         string: "Unleash the power of Cloud Native"
+      overflow-count: 12
       appids:
         list:
           - io.podman_desktop.PodmanDesktop
@@ -218,6 +228,7 @@ rows:
         light-uri: file:///run/host/etc/bazaar/10-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/10-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#7f4f39"
       dark-color: "#2b1c2c"
   - section:
@@ -244,6 +255,7 @@ rows:
         light-uri: file:///run/host/etc/bazaar/08-bluefin-day.png
         dark-uri: file:///run/host/etc/bazaar/08-bluefin-night.png
         fit: cover
+        can-shrink: true
       light-color: "#ffb267"
       dark-color: "#004466"
   - section:

--- a/system_files/bluefin/usr/lib/systemd/user/bazaar.service
+++ b/system_files/bluefin/usr/lib/systemd/user/bazaar.service
@@ -5,8 +5,7 @@ After=graphical-session.target
 StartLimitBurst=10
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 ExecStart=flatpak run --command=bazaar io.github.kolunmi.Bazaar --no-window
 StandardOutput=journal
 

--- a/system_files/bluefin/usr/lib/systemd/user/bazaar.service
+++ b/system_files/bluefin/usr/lib/systemd/user/bazaar.service
@@ -8,6 +8,8 @@ StartLimitBurst=10
 Type=simple
 ExecStart=flatpak run --command=bazaar io.github.kolunmi.Bazaar --no-window
 StandardOutput=journal
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=graphical-session.target

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -343,6 +343,24 @@ bazaar-preview source="{{ invocation_directory() }}":
     done
     sudo -v
     flatpak info io.github.kolunmi.Bazaar >/dev/null
+
+    # Generate PNG banners using podman if they aren't already built on the host
+    BRANDING_DIR="${SRC_DIR}/bluefin-branding/system_files/etc/bazaar"
+    if [[ -d "${BRANDING_DIR}" ]]; then
+        echo "Converting JXL banners to PNG via podman..."
+        TMP_PNG_DIR=$(mktemp -d)
+        podman run --rm -v "${SRC_DIR}":/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest sh -c "
+            apk add -q libjxl-tools &&
+            for f in /workspace/bluefin-branding/system_files/etc/bazaar/*.jxl; do
+                name=\$(basename \"\$f\" .jxl)
+                djxl \"\$f\" \"/out/\${name}.png\" --color_space=sRGB
+            done
+        "
+        sudo install -d -m0755 /etc/bazaar
+        sudo install -m0644 "${TMP_PNG_DIR}"/*.png /etc/bazaar/
+        rm -rf "${TMP_PNG_DIR}"
+    fi
+
     sudo install -d -m0755 /etc/bazaar
     sudo install -m0644 "${BAZAAR_DIR}/bazaar.yaml" /etc/bazaar/bazaar.yaml
     sudo install -m0644 "${BAZAAR_DIR}/curated.yaml" /etc/bazaar/curated.yaml

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -349,7 +349,7 @@ bazaar-preview source="{{ invocation_directory() }}":
     if [[ -d "${BRANDING_DIR}" ]]; then
         echo "Converting JXL banners to PNG via podman..."
         TMP_PNG_DIR=$(mktemp -d)
-        podman run --rm -v "${SRC_DIR}":/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest sh -c "
+        podman run --rm -v "${SRC_DIR}":/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b sh -c "
             apk add -q libjxl-tools &&
             for f in /workspace/bluefin-branding/system_files/etc/bazaar/*.jxl; do
                 name=\$(basename \"\$f\" .jxl)

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -350,6 +350,7 @@ bazaar-preview source="{{ invocation_directory() }}":
         echo "Converting JXL banners to PNG via podman..."
         TMP_PNG_DIR=$(mktemp -d)
         podman run --rm -v "${SRC_DIR}":/workspace:z -v "${TMP_PNG_DIR}":/out:z docker.io/library/alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b sh -c "
+            set -e
             apk add -q libjxl-tools &&
             for f in /workspace/bluefin-branding/system_files/etc/bazaar/*.jxl; do
                 name=\$(basename \"\$f\" .jxl)

--- a/tests/test_changelog.bats
+++ b/tests/test_changelog.bats
@@ -85,9 +85,8 @@ fi
 EOF
     chmod +x "${MOCKDIR}/grep"
 
-    # Keep the fallback recipe under test; a developer's host bctl must not
-    # short-circuit repository selection before the mocked curl calls.
-    export PATH="${MOCKDIR}:$(printf '%s' "${PATH}" | tr ':' '\n' | grep -v '/.local/bin' | paste -sd: -)"
+    # Exclude non-standard directories (like user's local bin where 'bctl' may exist) to keep tests isolated and repeatable
+    export PATH="${MOCKDIR}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     SCRIPT_FILE="${WORKDIR}/changelog.sh"
     _extract_script "${SCRIPT_FILE}"

--- a/tests/test_check_oci_refs.py
+++ b/tests/test_check_oci_refs.py
@@ -135,6 +135,15 @@ class TestCollectTagRefs:
         refs = collect_tag_refs(tmp_path)
         assert refs == {}
 
+    def test_skips_e2e_pr_tags(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs/guide.md").write_text(
+            "Placeholder ghcr.io/projectbluefin/common:e2e-pr-<N>-<sha>\n"
+            "Placeholder ghcr.io/projectbluefin/common:e2e-pr-N-sha\n"
+        )
+        refs = collect_tag_refs(tmp_path)
+        assert refs == {}
+
     def test_collects_multiple_distinct_refs(self, tmp_path):
         (tmp_path / "docs").mkdir()
         (tmp_path / "docs/guide.md").write_text(

--- a/tests/test_curated_config.py
+++ b/tests/test_curated_config.py
@@ -14,36 +14,54 @@ def _load_yaml(path: Path):
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
-def test_curated_uses_legacy_schema_shape():
+def test_curated_uses_new_schema_shape():
+    """Validate curated.yaml uses the new Bazaar schema (PR #1655 'Rework Curated System').
+
+    Old schema used css + rows[].sections[].category. New schema uses rows[] with
+    banner/section/articles/featured-carousel row types.
+    """
     data = _load_yaml(CURATED)
 
     assert isinstance(data, dict)
-    assert "css" in data
+    assert "css" not in data, "css block removed in new schema"
     assert "rows" in data
     assert isinstance(data["rows"], list)
     assert len(data["rows"]) > 0
 
+    known_row_types = {"banner", "section", "articles", "featured-carousel"}
+    has_section = False
+
     for row in data["rows"]:
         assert isinstance(row, dict)
         assert len(row) == 1
-        assert "sections" in row
-        sections = row["sections"]
-        assert isinstance(sections, list)
-        for section in sections:
-            assert isinstance(section, dict)
-            assert "category" in section
-            category = section["category"]
-            assert "title" in category
-            assert "appids" in category
-            assert isinstance(category["appids"], list)
+        row_type = next(iter(row))
+        assert row_type in known_row_types, f"Unknown row type: {row_type}"
 
-            # Banners must be PNG (never JXL) to prevent stable Bazaar 0.8.2 crashes on Gnome runtimes
-            if "light-banner" in category:
-                assert category["light-banner"].endswith(".png")
-                assert not category["light-banner"].endswith(".jxl")
-            if "dark-banner" in category:
-                assert category["dark-banner"].endswith(".png")
-                assert not category["dark-banner"].endswith(".jxl")
+        if row_type == "section":
+            has_section = True
+            section = row["section"]
+            assert isinstance(section, dict)
+            assert "title" in section
+            assert "appids" in section
+            appids = section["appids"]
+            assert isinstance(appids, dict)
+            assert "list" in appids
+            assert isinstance(appids["list"], list)
+
+        if row_type == "banner":
+            banner = row["banner"]
+            assert isinstance(banner, dict)
+            assert "image" in banner
+            image = banner["image"]
+            # Banner images must be PNG (never JXL) to prevent Bazaar crashes
+            for uri_field in ("uri", "light-uri", "dark-uri"):
+                if uri_field in image:
+                    assert not image[uri_field].endswith(".jxl"), \
+                        f"Banner {uri_field} must not use JXL format"
+                    assert image[uri_field].endswith(".png") or image[uri_field].startswith("http"), \
+                        f"Banner {uri_field} should be PNG or https URL"
+
+    assert has_section, "curated.yaml must have at least one section row"
 
 
 def test_bazaar_config_valid():


### PR DESCRIPTION
Bazaar PR #1655 breaks the curated page. This cherry-picks ready fixes from feature branches and migrates curated.yaml to the new schema.

Commits: djxl flag fix (--color_space=sRGB), bazaar.service Type=simple+Restart, preview recipe set -e hardening, curated.yaml schema migration (css/sections/category -> banner/section rows), bazaar.md rewrite with correct docs.

Tests: pytest tests/test_curated_config.py passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nightly Bazaar content generation for GNOME notes, Bluefin release notes, and curated article updates.
  * Introduced a new Developer Experience page with app tiles and install actions.
  * Expanded Bazaar install prompts to cover more editor and CLI apps.

* **Bug Fixes**
  * Improved Bazaar preview flow to run in user space with refreshed content and assets.
  * Updated service behavior for more reliable background operation.

* **Documentation**
  * Updated Bazaar guidance and authoring rules for the new content format.

* **Tests**
  * Added and updated coverage for curated content, hooks, and DX article layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->