### PR TITLE
fix(gnome): disable blur-my-shell popup blur by default

### DIFF
--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -97,6 +97,9 @@ background-color=(0.0, 0.0, 0.0, 0.8)
 [org.gnome.shell.extensions.blur-my-shell.dash-to-dock]
 blur=true
 
+[org.gnome.shell.extensions.blur-my-shell.popup]
+blur=false
+
 #-------------- REMAINING SCHEMAS IN THIS SETTING SECTION ARE LOCATED IN DCONF --------------#
 # Settings bellow are supported with gschema override, but other settings, which are relocatable schemas, are not. Edit dconfs if you need to modify relocatable schemas.
 


### PR DESCRIPTION
## Summary
- set the blur-my-shell popup blur key to false in the existing Bluefin GNOME schema override so the default matches the intended behavior

## Testing
- `just check`
- `pre-commit run --all-files`