### PR TITLE
fix(gnome): use distro dconf settings for relocatable blur-my-shell schemas

### DIFF
--- a/docs/skills/dconf-consistency.md
+++ b/docs/skills/dconf-consistency.md
@@ -115,3 +115,18 @@ This means any `gsettings get org.gnome.shell enabled-extensions` call in a test
 `enabled-extensions` for `org.gnome.shell` is set in `system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override` — this sets the schema DEFAULT. It is NOT in `distro.d/` and is not a locked key, so users can override it.
 
 The CI's `local.d/00-ci-testing` write overrides it in every test VM. Tests must use `get_default_value()` to validate this config, not `gsettings get`.
+
+## Relocatable Schemas and GNOME Extensions
+
+GSettings overrides (`.gschema.override` files) **do not support relocatable schemas** (schemas with omitted fixed paths, such as those used by many GNOME extensions like `blur-my-shell`). 
+
+If you try to write an override block for a relocatable schema in `.gschema.override`, it will fail to compile or be discarded at compile time.
+
+### How to configure relocatable schema defaults
+
+To configure system-wide defaults for relocatable schemas, place them in path-based **dconf distro.d keyfiles** under `system_files/bluefin/etc/dconf/db/distro.d/` (such as `05-bluefin-searchlight-extension`) using slash-separated paths:
+
+```ini
+[org/gnome/shell/extensions/blur-my-shell/popup]
+blur=false
+```

--- a/system_files/bluefin/etc/dconf/db/distro.d/05-bluefin-searchlight-extension
+++ b/system_files/bluefin/etc/dconf/db/distro.d/05-bluefin-searchlight-extension
@@ -9,3 +9,9 @@ border-thickness=1
 border-radius=1.65
 border-color=(0.23, 0.23, 0.23, 1.0)
 background-color=(0.0, 0.0, 0.0, 0.8)
+
+[org/gnome/shell/extensions/blur-my-shell/dash-to-dock]
+blur=true
+
+[org/gnome/shell/extensions/blur-my-shell/popup]
+blur=false

--- a/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -94,12 +94,6 @@ border-radius=1.65
 border-color=(0.23, 0.23, 0.23, 1.0)
 background-color=(0.0, 0.0, 0.0, 0.8)
 
-[org.gnome.shell.extensions.blur-my-shell.dash-to-dock]
-blur=true
-
-[org.gnome.shell.extensions.blur-my-shell.popup]
-blur=false
-
 #-------------- REMAINING SCHEMAS IN THIS SETTING SECTION ARE LOCATED IN DCONF --------------#
 # Settings bellow are supported with gschema override, but other settings, which are relocatable schemas, are not. Edit dconfs if you need to modify relocatable schemas.
 


### PR DESCRIPTION
The GSettings overrides in `zz0-bluefin-modifications.gschema.override` (such as `blur=false` for `blur-my-shell`) were silently ignored because `blur-my-shell` uses relocatable GSettings schemas. Relocatable schemas do not have a fixed path, which means GSettings overrides (`.gschema.override`) are not supported for them and are discarded at compile time.

This PR moves the `blur-my-shell` popup and dash-to-dock settings from `zz0-bluefin-modifications.gschema.override` to the distro-wide dconf default file `05-bluefin-searchlight-extension` where relocatable schemas belong.

Assisted-by: Gemini 3.5 Flash via GitHub Copilot CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated desktop extension settings to adjust blur behavior for dock and popup elements.
  * Refined the default shell configuration so the new settings take effect consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->