### PR TITLE
fix(ci): make merge queue lane build-only in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
             "docker-archive:/tmp/scan-image.tar:${{ env.IMAGE_NAME }}:${{ steps.generate-tags.outputs.local_tag }}"
 
       - name: Promote image to root storage for push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         shell: bash
         run: |
           set -eoux pipefail
@@ -121,7 +121,7 @@ jobs:
 
       - name: Push image
         id: push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: projectbluefin/actions/bootc-build/push-image@74c4356b36dd94c0eadf15bbe63a26b58a0e7468 # v1
         with:
           image-name: ${{ env.IMAGE_NAME }}
@@ -129,14 +129,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write digest to file
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         shell: bash
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.push.outputs.digest }}" > "/tmp/digests/${{ matrix.arch_suffix }}.txt"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: digest-${{ matrix.arch_suffix }}
@@ -147,7 +147,7 @@ jobs:
   manifest:
     name: Create and sign multi-arch manifest
     needs: [build_push]
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -817,6 +817,17 @@ The ephemeral `gh-readonly-queue/...` refs are not resolvable by `upload-sarif`.
 
 *Observed: blocked every PR in the merge queue until fixed in common #660.*
 
+**Follow-up trap (common #826):** #660 skipped only the export/scan steps, but
+`Promote image to root storage`, `Push image`, `Write digest to file`,
+`Upload digest`, and the `manifest` job all ran on `!= 'pull_request'` — which
+includes `merge_group`. The promote step then read the never-exported
+`/tmp/scan-image.tar` and failed, silently ejecting every queue entry for two
+weeks. **Rule: the merge queue lane is build-only.** Any step that consumes an
+artifact from a step skipped in `merge_group`, or that pushes/signs/tags, must
+carry `github.event_name != 'pull_request' && github.event_name != 'merge_group'`.
+When adding a step to `build.yml`, trace which lanes (`pull_request`,
+`merge_group`, `push`) produce every file it reads.
+
 ---
 
 ## Renovate automerge — how it works in `common`


### PR DESCRIPTION
## Root cause

The merge queue has silently ejected every entry since 2026-07-06 (PRs #802, #815, #817, #824, #825 — nothing has merged in two weeks). common#660 added `if: github.event_name != 'merge_group'` to the **Export image for scanning** and **Scan image for CVEs** steps, but left these on `!= 'pull_request'` (which matches merge_group):

- **Promote image to root storage** — reads `/tmp/scan-image.tar`, which the skipped export never produced: `open /tmp/scan-image.tar: no such file or directory` ([failing merge-group run](https://github.com/projectbluefin/common/actions/runs/29701193456))
- **Push image / Write digest / Upload digest / manifest job** — these would push per-arch tags and re-sign `:latest` from a throwaway queue ref if the promote step hadn't failed first

## Fix

Merge queue lane is now build-only: every push-lane step carries `github.event_name != 'pull_request' && github.event_name != 'merge_group'`. The queue verifies the combined commit builds; pushing, digests, manifests, and signing stay exclusive to the push/dispatch lanes.

Self-healing: merge_group runs execute the workflow from the merged ref, so this PR's own queue run uses the fixed YAML.

## Skill update (same PR)

`docs/skills/ci-tooling.md` merge_group section extended with the build-only rule and the artifact-lane tracing checklist.

## Validation

- actionlint + full pre-commit: pass
- `just check`: pass

Unblocks #824 (MIME defaults) and #825 (game-devices-udev checksum), plus the stalled Renovate queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented merge queue builds from attempting image promotion, publishing, manifest creation, or digest uploads when required artifacts are unavailable.

* **Documentation**
  * Added guidance for correctly gating merge queue workflow steps and tracing artifact availability across build lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->