### PR TITLE
feat(bazaar): add Freelens to curated developer tools

### DIFF
--- a/system_files/bluefin/etc/bazaar/curated.yaml
+++ b/system_files/bluefin/etc/bazaar/curated.yaml
@@ -432,6 +432,7 @@ rows:
             - com.getpostman.Postman
             - me.iepure.devtoolbox
             - io.kinvolk.Headlamp
+            - app.freelens.Freelens
             - de.leopoldluley.Clapgrep
             - com.mardojai.ForgeSparks
             - io.dbeaver.DBeaverCommunity


### PR DESCRIPTION
## Summary

Add Freelens to the curated developer tools list in Bazaar so it appears alongside other developer utilities.

## Why

Closes #827

## Validation

- [x] pre-commit run --all-files
- [x] just check