### PR TITLE
chore(deps): update actions/cache action to v6.1.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -131,7 +131,7 @@ jobs:
         run: pip install pre-commit
 
       - name: Cache pre-commit hooks
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-${{ runner.arch }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
## Summary

Update the actions/cache GitHub Action to v6.1.0.

## Validation

- [x] pre-commit run --all-files
- [x] just check