### PR TITLE
fix(ujust): select LTS changelog repository

### DIFF
--- a/docs/skills/image-registry.md
+++ b/docs/skills/image-registry.md
@@ -109,6 +109,21 @@ To make Dakota show up on the public active users count badges and charts:
 
 Because of the **Absolute Prohibition** against write operations on `ublue-os/*` repositories, these updates cannot be automated or programmatically committed by agents, and must be submitted manually as a PR by a human maintainer.
 
+## Runtime changelog repository selection
+
+The `ujust changelogs` fallback chooses the upstream release repository from
+`image-info.json`: `dakota` images use `projectbluefin/dakota`, image names
+starting with `bluefin-lts` use `projectbluefin/bluefin-lts`, and other Bluefin
+image names use `projectbluefin/bluefin`. Do not infer the LTS repository from
+the tag alone: LTS images may use `stable`, `testing`, or `lts` aliases.
+
+Verify the runtime metadata and recipe together:
+
+```bash
+jq -r '."image-name", ."image-tag"' /usr/share/ublue-os/image-info.json
+rg -n 'IMAGE_NAME|bluefin-lts|REPO=' system_files/bluefin/usr/share/ublue-os/just/changelog.just
+```
+
 ## Verification
 
 **Before editing this file or writing any image name or tag anywhere in the factory,

--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -15,7 +15,7 @@ changelogs:
     IMAGE_NAME="$(jq -r '.["image-name"] // empty' < "${IMAGE_INFO_FILE}")"
     if [[ "$IMAGE_NAME" == "dakota" ]]; then
         REPO="projectbluefin/dakota"
-    elif [[ "$TAG" =~ ^lts ]]; then
+    elif [[ "$IMAGE_NAME" =~ ^bluefin-lts ]] || [[ "$TAG" =~ ^lts ]]; then
         REPO="projectbluefin/bluefin-lts"
     else
         REPO="projectbluefin/bluefin"

--- a/tests/test_changelog.bats
+++ b/tests/test_changelog.bats
@@ -85,7 +85,9 @@ fi
 EOF
     chmod +x "${MOCKDIR}/grep"
 
-    export PATH="${MOCKDIR}:${PATH}"
+    # Keep the fallback recipe under test; a developer's host bctl must not
+    # short-circuit repository selection before the mocked curl calls.
+    export PATH="${MOCKDIR}:$(printf '%s' "${PATH}" | tr ':' '\n' | grep -v '/.local/bin' | paste -sd: -)"
 
     SCRIPT_FILE="${WORKDIR}/changelog.sh"
     _extract_script "${SCRIPT_FILE}"
@@ -190,4 +192,17 @@ teardown() {
     MOCK_NAME="dakota" MOCK_TAG="latest" run bash "${SCRIPT_FILE}"
     [ "${status}" -eq 0 ]
     grep -q "projectbluefin/dakota" "${CURL_CALLS}"
+}
+
+@test "changelog: bluefin-lts image name selects bluefin-lts repo with stable tag" {
+    MOCK_NAME="bluefin-lts" MOCK_TAG="stable" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin-lts" "${CURL_CALLS}"
+    ! grep -q "projectbluefin/bluefin[^-]" "${CURL_CALLS}"
+}
+
+@test "changelog: bluefin-lts-nvidia image name selects bluefin-lts repo" {
+    MOCK_NAME="bluefin-lts-nvidia" MOCK_TAG="testing" run bash "${SCRIPT_FILE}"
+    [ "${status}" -eq 0 ]
+    grep -q "projectbluefin/bluefin-lts" "${CURL_CALLS}"
 }


### PR DESCRIPTION
## Summary
- select projectbluefin/bluefin-lts for bluefin-lts image names even with stable/testing tags
- add regression coverage for bluefin-lts and bluefin-lts-nvidia

Closes #819

## Validation
- bats tests/test_changelog.bats: 15/15
- just check
- pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved changelog repository selection for Bluefin LTS images, including images with stable or testing tags.
  - Prevented standard Bluefin repositories from being selected when an image is identified as LTS.

- **Documentation**
  - Added guidance explaining repository selection rules and verification steps for runtime changelog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->