### PR TITLE
feat(ujust): confirm existing issue reports

### DIFF
--- a/docs/skills/bonedigger.md
+++ b/docs/skills/bonedigger.md
@@ -47,6 +47,22 @@ bonedigger has two functions:
 real shell implementation in `/usr/libexec/bonedigger-report`. Keep the
 `BONEDIGGER_VERSION` line in the Justfile because Renovate watches that path.
 
+### Confirm an existing issue
+
+Use `ujust report --confirm <issue-number>` when the current system is affected
+by an existing issue. This mode collects and previews a lightweight system
+fingerprint (image, version/digest, kernel, architecture, failed units, and the
+same anonymous device ID used by the full report), then posts it as a comment
+with `gh issue comment`. It does not collect OTel data or create a gist. The
+issue repository is derived from the booted `IMAGE_NAME` using the same routing
+as normal bug reports: Bluefin LTS goes to `projectbluefin/bluefin-lts`, regular
+Bluefin to `projectbluefin/bluefin`, Dakota to `projectbluefin/dakota`, and
+unknown variants to `projectbluefin/common`.
+
+Issue numbers must be positive integers. In a terminal, the exact comment is
+shown and requires confirmation before posting; non-interactive use posts after
+printing the preview. A signed-in GitHub CLI is required (`gh auth login`).
+
 ## bonedigger — what it does NOT do
 
 The **full** issue lifecycle (slash commands, pipeline widget, label transitions, stale sweep, auto-merge on lgtm) lives in `projectbluefin/actions/.github/workflows/lifecycle.yml`. It was first deployed to `common` (2026-06-05) then moved to `actions` ([common#570](https://github.com/projectbluefin/common/issues/570), closed 2026-06-10) to serve all factory repos as a single reusable.

--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -5,6 +5,83 @@ IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
 BONEDIGGER_BRAND="${BONEDIGGER_BRAND:-🫐 Bluefin Bug Report}"
 OTEL_CONFIG_SOURCE="/usr/share/ublue-os/otel/ujust-report-config.yaml"
 REPORT_ROOT="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}}/ujust-report"
+
+confirm_usage() {
+    printf 'Usage: ujust report --confirm <issue-number>\n' >&2
+}
+
+parse_confirm_args() {
+    CONFIRM_ISSUE=""
+
+    while (($# > 0)); do
+        case "$1" in
+            --confirm)
+                if (($# < 2)) || [[ ! "$2" =~ ^[1-9][0-9]*$ ]]; then
+                    confirm_usage
+                    return 1
+                fi
+                CONFIRM_ISSUE="$2"
+                shift 2
+                ;;
+            *)
+                confirm_usage
+                return 1
+                ;;
+        esac
+    done
+}
+
+confirm_report() {
+    local issue_number="$1"
+    local issue_repo="$2"
+    local failed_units
+    local booted_digest
+    local host_id
+    local body
+    local comment_url
+
+    failed_units="$(systemctl list-units --state=failed --no-legend --plain 2>/dev/null | \
+        awk '{print $1}' | head -10 || true)"
+    failed_units="${failed_units:-none}"
+    booted_digest="$(printf '%s' "$BOOTC_JSON" | \
+        jq -r '.status.booted.imageDigest // empty' 2>/dev/null || true)"
+    booted_digest="${booted_digest:-unknown}"
+
+    if [[ -r /etc/machine-id ]]; then
+        host_id="$(printf 'ujust-report:%s' "$(cat /etc/machine-id)" | sha256sum | cut -c1-8)"
+    else
+        host_id="unknown"
+    fi
+
+    body="$(printf '**System fingerprint** (via `ujust report --confirm`)\n\n* Image: %s\n* Version: %s\n* Digest: %s\n* Kernel: %s\n* Arch: %s\n* Failed units: %s\n* Anonymous device ID: %s (truncated sha256)' \
+        "$IMAGE_REF" "$IMAGE_TAG" "$booted_digest" "$(uname -r)" "$(uname -m)" \
+        "$failed_units" "$host_id")"
+
+    printf '\nWill post to: https://github.com/%s/issues/%s\n\n%s\n\n' \
+        "$issue_repo" "$issue_number" "$body"
+
+    if ! gh auth status --active &>/dev/null; then
+        printf 'gh is not authenticated. Run: gh auth login\n' >&2
+        return 1
+    fi
+
+    if [[ -t 0 && -t 1 ]]; then
+        gum confirm "Post this comment?" || return 0
+    fi
+
+    if ! gh issue comment "$issue_number" --repo "$issue_repo" --body "$body"; then
+        printf 'Failed to post the comment.\n' >&2
+        return 1
+    fi
+
+    comment_url="$(gh api "repos/${issue_repo}/issues/${issue_number}/comments" \
+        --jq '.[-1].html_url' 2>/dev/null || true)"
+    comment_url="${comment_url:-https://github.com/${issue_repo}/issues/${issue_number}}"
+    printf 'Comment posted: %s\n' "$comment_url"
+}
+
+parse_confirm_args "$@"
+
 mkdir -p "$REPORT_ROOT"
 REPORT_DIR="$(mktemp -d "${REPORT_ROOT}/report-XXXXXX")"
 LOCAL_REPORT_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/ujust-report"
@@ -60,29 +137,41 @@ IMAGE_FLAVOR="$(jq -r '."image-flavor" // "unknown"' "$IMAGE_INFO_FILE" 2>/dev/n
 
 # Derive issue URLs: bugs go to the image repo, feature requests always go to common.
 # Set BONEDIGGER_ISSUE_URL in the environment to override the auto-detected bug URL.
+case "$IMAGE_NAME" in
+    bluefin)
+        if [[ "$IMAGE_TAG" == lts* ]]; then
+            ISSUE_REPO="projectbluefin/bluefin-lts"
+            DEFAULT_ISSUE_URL_BASE="https://github.com/projectbluefin/bluefin-lts/issues/new?template=bug-report.yml"
+        else
+            ISSUE_REPO="projectbluefin/bluefin"
+            DEFAULT_ISSUE_URL_BASE="https://github.com/projectbluefin/bluefin/issues/new?template=bug-report.yml"
+        fi
+        ;;
+    dakota)
+        ISSUE_REPO="projectbluefin/dakota"
+        DEFAULT_ISSUE_URL_BASE="https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml"
+        ;;
+    *)
+        ISSUE_REPO="projectbluefin/common"
+        DEFAULT_ISSUE_URL_BASE="https://github.com/projectbluefin/common/issues/new?template=bug-report.yml"
+        ;;
+esac
+
 if [[ -n "${BONEDIGGER_ISSUE_URL:-}" ]]; then
     ISSUE_URL_BASE="$BONEDIGGER_ISSUE_URL"
 else
-    case "$IMAGE_NAME" in
-        bluefin)
-            if [[ "$IMAGE_TAG" == lts* ]]; then
-                ISSUE_URL_BASE="https://github.com/projectbluefin/bluefin-lts/issues/new?template=bug-report.yml"
-            else
-                ISSUE_URL_BASE="https://github.com/projectbluefin/bluefin/issues/new?template=bug-report.yml"
-            fi
-            ;;
-        dakota)
-            ISSUE_URL_BASE="https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml"
-            ;;
-        *)
-            ISSUE_URL_BASE="https://github.com/projectbluefin/common/issues/new?template=bug-report.yml"
-            ;;
-    esac
+    ISSUE_URL_BASE="$DEFAULT_ISSUE_URL_BASE"
 fi
 FEATURE_URL="https://github.com/projectbluefin/common/issues/new?template=feature-request.yml"
 BOOTED_IMAGE="$(printf '%s' "$BOOTC_JSON" | jq -r '.status.booted.image.image.image // empty' 2>/dev/null || true)"
 BOOTED_DIGEST="$(printf '%s' "$BOOTC_JSON" | jq -r '.status.booted.imageDigest // empty' 2>/dev/null || true)"
 STAGED_IMAGE="$(printf '%s' "$BOOTC_JSON" | jq -r '.status.staged.image.image.image // empty' 2>/dev/null || true)"
+
+if [[ -n "$CONFIRM_ISSUE" ]]; then
+    confirm_report "$CONFIRM_ISSUE" "$ISSUE_REPO"
+    exit $?
+fi
+
 GNOME_VERSION="$(gnome-shell --version 2>/dev/null || echo unknown)"
 GNOME_EXTENSIONS="$(gnome-extensions list --enabled 2>/dev/null || true)"
 FLATPAK_LIST="$(flatpak list --columns=application,version 2>/dev/null || echo unavailable)"

--- a/system_files/bluefin/usr/share/ublue-os/just/60-bonedigger.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/60-bonedigger.just
@@ -9,7 +9,7 @@ export BONEDIGGER_BRAND := "🫐 Bluefin Bug Report"
 
 # Collect a privacy-respecting diagnostic report and offer to attach it to a new bug report.
 [group('System')]
-report:
+report *args:
     BONEDIGGER_VERSION="{{ BONEDIGGER_VERSION }}" \
     BONEDIGGER_BRAND="${BONEDIGGER_BRAND}" \
-    /usr/libexec/bonedigger-report
+    /usr/libexec/bonedigger-report {{ args }}

--- a/tests/test_bonedigger_report.bats
+++ b/tests/test_bonedigger_report.bats
@@ -3,6 +3,8 @@
 setup() {
     export BONEDIGGER_SCRIPT="$BATS_TEST_DIRNAME/../system_files/bluefin/usr/libexec/bonedigger-report"
 
+    WORKDIR="$(mktemp -d)"
+
     TEST_HELPER="$(mktemp)"
     cat << 'INNER_EOF' > "$TEST_HELPER"
 #!/usr/bin/bash
@@ -17,7 +19,8 @@ INNER_EOF
 }
 
 teardown() {
-    rm -f "$TEST_HELPER"
+    rm -f "$TEST_HELPER" "${CONFIRM_HELPER:-}"
+    rm -rf "$WORKDIR"
 }
 
 @test "scrub_kernel_log redacts MAC addresses" {
@@ -71,33 +74,81 @@ IMAGE_NAME="$1"
 IMAGE_TAG="$2"
 BONEDIGGER_ISSUE_URL="$3"
 
-eval "$(sed -n '/^# Derive issue URLs/,/^fi/p' "$BONEDIGGER_SCRIPT")"
+eval "$(sed -n '/^case "\$IMAGE_NAME"/,/^FEATURE_URL/p' "$BONEDIGGER_SCRIPT")"
 
-echo "$ISSUE_URL_BASE"
+echo "$ISSUE_URL_BASE|$ISSUE_REPO"
 INNER_EOF
     chmod +x "$TEST_URL_ROUTER"
 
     # Bluefin generic
     result="$("$TEST_URL_ROUTER" "bluefin" "latest" "")"
-    [ "$result" = "https://github.com/projectbluefin/bluefin/issues/new?template=bug-report.yml" ]
+    [ "$result" = "https://github.com/projectbluefin/bluefin/issues/new?template=bug-report.yml|projectbluefin/bluefin" ]
 
     # Bluefin LTS
     result="$("$TEST_URL_ROUTER" "bluefin" "lts-39" "")"
-    [ "$result" = "https://github.com/projectbluefin/bluefin-lts/issues/new?template=bug-report.yml" ]
+    [ "$result" = "https://github.com/projectbluefin/bluefin-lts/issues/new?template=bug-report.yml|projectbluefin/bluefin-lts" ]
 
     # Dakota
     result="$("$TEST_URL_ROUTER" "dakota" "latest" "")"
-    [ "$result" = "https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml" ]
+    [ "$result" = "https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml|projectbluefin/dakota" ]
 
     # Common fallback
     result="$("$TEST_URL_ROUTER" "something-else" "latest" "")"
-    [ "$result" = "https://github.com/projectbluefin/common/issues/new?template=bug-report.yml" ]
+    [ "$result" = "https://github.com/projectbluefin/common/issues/new?template=bug-report.yml|projectbluefin/common" ]
 
     # Override
     result="$("$TEST_URL_ROUTER" "bluefin" "latest" "https://example.com/custom")"
-    [ "$result" = "https://example.com/custom" ]
+    [ "$result" = "https://example.com/custom|projectbluefin/bluefin" ]
 
     rm -f "$TEST_URL_ROUTER"
+}
+
+@test "confirm posts a lightweight fingerprint to the routed repository" {
+    mkdir -p "$WORKDIR/bin"
+    cat << 'INNER_EOF' > "$WORKDIR/bin/systemctl"
+#!/usr/bin/bash
+printf 'failed-example.service loaded failed failed\n'
+INNER_EOF
+    cat << 'INNER_EOF' > "$WORKDIR/bin/gh"
+#!/usr/bin/bash
+printf '%s\n' "$*" >> "$CALLS_FILE"
+if [[ "$1" == api ]]; then
+    printf 'https://github.com/projectbluefin/bluefin-lts/issues/42#issuecomment-123\n'
+fi
+INNER_EOF
+    chmod +x "$WORKDIR/bin/systemctl" "$WORKDIR/bin/gh"
+    export CALLS_FILE="$WORKDIR/gh-calls"
+    export PATH="$WORKDIR/bin:$PATH"
+
+    CONFIRM_HELPER="$(mktemp)"
+    cat << 'INNER_EOF' > "$CONFIRM_HELPER"
+#!/usr/bin/bash
+set -euo pipefail
+eval "$(sed -n '/^confirm_report() {/,/^}$/p' "$BONEDIGGER_SCRIPT")"
+BOOTC_JSON='{"status":{"booted":{"imageDigest":"sha256:abc123"}}}'
+IMAGE_REF='ghcr.io/projectbluefin/bluefin'
+IMAGE_TAG='latest'
+confirm_report 42 projectbluefin/bluefin-lts
+INNER_EOF
+    chmod +x "$CONFIRM_HELPER"
+
+    run "$CONFIRM_HELPER"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'**System fingerprint** (via `ujust report --confirm`)'* ]]
+    [[ "$output" == *'Image: ghcr.io/projectbluefin/bluefin'* ]]
+    [[ "$output" == *'Digest: sha256:abc123'* ]]
+    grep -qF 'issue comment 42 --repo projectbluefin/bluefin-lts --body' "$CALLS_FILE"
+    grep -qF 'https://github.com/projectbluefin/bluefin-lts/issues/42#issuecomment-123' <<< "$output"
+}
+
+@test "confirm rejects non-positive issue numbers" {
+    run env HOME="$WORKDIR/home" bash "$BONEDIGGER_SCRIPT" --confirm 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'Usage: ujust report --confirm <issue-number>'* ]]
+
+    run env HOME="$WORKDIR/home" bash "$BONEDIGGER_SCRIPT" --confirm nope
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'Usage: ujust report --confirm <issue-number>'* ]]
 }
 
 @test "home paths with spaces are redacted" {


### PR DESCRIPTION
## Summary
- add `ujust report --confirm <issue-number>` for lightweight me-too reports
- route the target repository from image metadata
- add Bats coverage and document the mode

Closes projectbluefin/dakota#579

## Validation
- bats tests/test_bonedigger_report.bats: 12/12
- bash -n
- shellcheck
- just check
- pre-commit run --all-files

This changes shared common-layer behavior and requires downstream/ghost verification before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ujust report --confirm <issue-number>` to post a lightweight system fingerprint directly to an existing GitHub issue.
  * Added validation for issue numbers and interactive confirmation before posting.
  * Added support for forwarding report command arguments.

* **Bug Fixes**
  * Improved issue repository selection for different image variants, including LTS releases and Dakota.
  * Preserved support for custom issue URL overrides.

* **Documentation**
  * Documented the confirmation workflow, generated information, requirements, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->