### PR TITLE
feat(brew): manage cask lifecycle in brew-preinstall

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install test deps
         run: |
           sudo apt-get install -y bats
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pyyaml
 
       - name: Run shellcheck — extensionless scripts
         run: |
@@ -53,6 +53,9 @@ jobs:
 
       - name: Run pytest (hooks.py)
         run: python3 -m pytest tests/test_hooks.py -v --cov=system_files/bluefin/etc/bazaar --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:coverage-html --cov-fail-under=80
+
+      - name: Run pytest (ChairLift maintainer config)
+        run: python3 -m pytest tests/test_chairlift_config.py -v
 
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/validate-chairlift-config.yaml
+++ b/.github/workflows/validate-chairlift-config.yaml
@@ -1,0 +1,43 @@
+name: Validate ChairLift Config
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "system_files/shared/usr/share/chairlift/**"
+      - "tests/check-chairlift-config"
+      - ".github/workflows/validate-chairlift-config.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "system_files/shared/usr/share/chairlift/**"
+      - "tests/check-chairlift-config"
+  # Upstream can change its schema without us touching anything, and an
+  # unknown key disables the whole app. Catch that drift on a schedule
+  # instead of on the next unrelated PR.
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install deps
+        run: pip install pyyaml
+
+      - name: Validate ChairLift config against upstream schema
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 tests/check-chairlift-config

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@ just := just_executable()
 # Run unit tests (pytest for hooks.py, bats for shell scripts)
 # test_libvirt_helper.bats is excluded — requires a running libvirtd session
 test:
-    python3 -m pytest tests/test_hooks.py tests/test_check_oci_refs.py tests/test_bazaar_hook.py tests/test_curated_config.py -v --cov=tests --cov-report=term-missing
+    python3 -m pytest tests/test_hooks.py tests/test_check_oci_refs.py tests/test_bazaar_hook.py tests/test_curated_config.py tests/test_chairlift_config.py -v --cov=tests --cov-report=term-missing
     bats tests/test_libsetup.bats
     bats tests/test_setup_scripts.bats
     bats tests/test_privileged_setup.bats

--- a/docs/skills/brew-lifecycle.md
+++ b/docs/skills/brew-lifecycle.md
@@ -20,6 +20,7 @@ metadata:
   context7-sources:
     - /bootc-dev/bootc
     - /homebrew/brew
+    - /websites/cli_github_manual
 ---
 
 # brew-lifecycle — Homebrew Package Lifecycle for Bluefin
@@ -190,6 +191,81 @@ unavailable. See [Homebrew 6.0 tap trust](#homebrew-60-tap-trust-required-as-of-
 lines: installed by `brew bundle`, tracked in the state file under
 `casks`, and uninstalled with `brew uninstall --cask` when the line is
 removed. Verify with `bats tests/test_brew_preinstall.bats`.
+
+**Shipped example — ChairLift** (`preinstall.d/chairlift.Brewfile`):
+```ruby
+tap "frostyard/tap", trusted: true
+cask "chairlift"
+```
+ChairLift is a GTK4 system-management GUI (Homebrew, Flatpak, bootc).
+Its Bluefin maintainer config ships at
+`system_files/shared/usr/share/chairlift/config.yml` (admin override:
+`/etc/chairlift/config.yml`). frostyard/chairlift#54 resolved via the
+system-integration split (frostyard/chairlift#102): Bluefin now ships the
+fixed `/usr/libexec/bootc-update-stage` helper and the bootc PolicyKit
+policy under `system_files/shared/usr/share/polkit-1/actions/`, so
+`bootc_updates_group` is enabled (staging only —
+`bootc upgrade --download-only`; applying stays with the user's own
+reboot or uupd's background policy). `features_group` (updex) stays
+disabled — no updex helper ships on Bluefin yet, independent of the
+polkit fix. Guarded by `tests/test_chairlift_config.py` (wired into
+`just test` and `unit-tests.yml`) and
+`tests/check-chairlift-config` (upstream schema drift).
+
+#### ChairLift config keys fail closed — never invent one
+
+**An unknown page, group, or field key in `config.yml` disables the entire
+application.** This is not a silent no-op. Upstream
+`internal/config/validate.go` classifies any name it does not recognise as
+`KindSchema`; `internal/config/config.go::Load()` answers that with
+`disabledConfig()`, which forces `enabled: false` on *every group on every
+page* and raises a persistent "Configuration error … All feature groups are
+disabled" toast.
+
+Because Bluefin preinstalls ChairLift silently at next login, a single typo
+ships an empty, broken app to every user of `bluefin`, `bluefin-lts`, and
+`dakota` at once. This exact bug reached review once: an invented
+`updates_page.updates_settings_group` was added to express "uupd owns update
+scheduling". That group has never existed upstream — `updates_page` is
+exactly `bootc_updates_group`, `flatpak_updates_group`, `brew_updates_group`,
+`brew_trust_group`.
+
+Rules:
+
+- **Express policy in a YAML comment, not in a made-up key.** If there is no
+  group for the behaviour you want to suppress, the behaviour does not exist.
+- **Derive key names from upstream source**, `internal/config/config.go::defaultConfig()`,
+  not from memory, not from our own docs, and not from our own tests.
+- **A hand-written allowlist in our own test file proves nothing.** The
+  original bug passed CI because the test's `KNOWN_GROUPS` set was edited in
+  the same PR to include the invented group. `tests/check-chairlift-config`
+  exists because of this: it fetches upstream's `config.yml` (a complete
+  enumeration, kept in lockstep with `defaultConfig()`) and fails on any key we
+  use that upstream does not define. It runs on PRs touching the config and
+  weekly, since upstream can drift without us touching anything.
+
+#### Stage helper must not suppress output
+
+`/usr/libexec/bootc-update-stage` deliberately omits `--quiet`.
+`bootc.StageUpdate` merges the helper's stdout and stderr and streams each
+line into ChairLift's progress view, so `--quiet` leaves the user watching an
+empty dialog for the length of an image pull.
+
+#### Cask pinning caveat
+
+The upstream tap cask currently targets the rolling `dev` tag with
+`sha256 :no_check`, so the preinstalled payload is mutable and unverified even
+though tagged releases with per-arch checksums exist. Accepted deliberately for
+the initial rollout; bumping the tap to a pinned version is tracked separately.
+
+#### polkit file overlap
+
+Our `org.frostyard.ChairLift.bootc.policy` is a byte-identical copy of
+upstream's. Upstream's `chairlift-system-integration` package ships the same
+file, so layering that RPM on a Bluefin image would collide. Upstream
+intentionally does *not* ship the stage script — "Distros enabling bootc
+staging must separately provide `/usr/libexec/bootc-update-stage`" — which is
+why Bluefin ships its own.
 
 ### Add a variant-specific Brewfile
 
@@ -407,6 +483,46 @@ After any change to `preinstall.d/` or `brew-preinstall`:
 - [ ] `just test` passes (bats tests in `tests/test_brew_preinstall.bats`)
 - [ ] If removing a package: confirmed it was in the previous managed state — it will be auto-uninstalled for existing users on next login
 - [ ] Merging order followed if the change spans repos: common → bluefin → bluefin-lts → dakota
+
+### Re-deriving the ChairLift facts in this document
+
+Every project-internal claim above about ChairLift can be re-derived. Run these
+rather than trusting the prose — the bug that motivated this section survived a
+green test suite precisely because nobody re-derived anything.
+
+```bash
+# What we ship, and where
+ls system_files/shared/usr/share/chairlift/config.yml \
+   system_files/shared/usr/libexec/bootc-update-stage \
+   system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy \
+   system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile
+
+# The privileged command, in full (must be exactly: bootc upgrade --download-only)
+grep '^exec ' system_files/shared/usr/libexec/bootc-update-stage
+
+# The polkit action pins that exact path and requires auth
+grep -E 'exec.path|allow_' system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
+
+# No passwordless rule anywhere re-grants the staging action
+grep -rn 'ChairLift\|bootc-update-stage' system_files/*/usr/share/polkit-1/rules.d/ || echo "none (expected)"
+
+# Our config uses only keys upstream defines (network; the CI job runs this)
+python3 tests/check-chairlift-config
+
+# Upstream's canonical groups and field names, straight from source
+gh api repos/frostyard/chairlift/contents/internal/config/config.go --jq .content \
+  | base64 -d | sed -n '/func defaultConfig/,/^}/p'
+gh api repos/frostyard/chairlift/contents/internal/config/config.go --jq .content \
+  | base64 -d | sed -n '/type GroupConfig struct/,/^}/p'
+
+# Unknown keys really are fatal, not ignored
+gh api repos/frostyard/chairlift/contents/internal/config/validate.go --jq .content \
+  | base64 -d | grep -n 'KindSchema'
+
+# The tests actually run in CI and locally
+grep -n 'test_chairlift_config' Justfile .github/workflows/unit-tests.yml
+python3 -m pytest tests/test_chairlift_config.py -v
+```
 
 ## Brewfile scope: shared/ vs bluefin/ for all-variant packages
 

--- a/docs/skills/brew-lifecycle.md
+++ b/docs/skills/brew-lifecycle.md
@@ -126,6 +126,9 @@ no migration is needed.
 1. Hash all `preinstall.d/*.Brewfile` files combined.
 2. Compare to stored hash. **Identical → fast exit**, nothing touched.
 3. **Different:** run `brew bundle --file=` on each Brewfile (idempotent).
+   One failing Brewfile (e.g. an unreachable external tap) does not block
+   the others, but any failure exits 1 **before** the removal and
+   state-write phases, so systemd retries the whole run on next login.
 4. Diff previous `packages`/`casks` (from state JSON) against the current
    `brew "..."`/`cask "..."` lines (from Brewfiles). Uninstall entries that
    were in the old set but not the new one — **only if `brew list` confirms

--- a/docs/skills/brew-lifecycle.md
+++ b/docs/skills/brew-lifecycle.md
@@ -19,7 +19,7 @@ metadata:
   type: procedure
   context7-sources:
     - /bootc-dev/bootc
-    - /bootc-dev/bootc
+    - /homebrew/brew
 ---
 
 # brew-lifecycle — Homebrew Package Lifecycle for Bluefin
@@ -402,6 +402,7 @@ After any change to `preinstall.d/` or `brew-preinstall`:
 
 - [ ] Package obeys the "can move to brew" rule: self-contained CLI, no system-level deps
 - [ ] If adding a tap: `trusted: true` in the Brewfile line (Homebrew 6.0)
+- [ ] If adding/removing a cask: lifecycle covered by the cask bats tests; removal uses `brew uninstall --cask` (verified against /homebrew/brew docs)
 - [ ] `pre-commit run --all-files` passes (Brewfile format, YAML/TOML hygiene)
 - [ ] `just test` passes (bats tests in `tests/test_brew_preinstall.bats`)
 - [ ] If removing a package: confirmed it was in the previous managed state — it will be auto-uninstalled for existing users on next login

--- a/docs/skills/brew-lifecycle.md
+++ b/docs/skills/brew-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 name: brew-lifecycle
-version: "1.0"
-last_updated: "2026-06-23"
+version: "1.1"
+last_updated: "2026-07-22"
 id: brew-lifecycle
 one_line_purpose: Manage OS-managed Homebrew packages and RPM/brew placement.
 entry_point: docs/skills/brew-lifecycle.md
@@ -115,18 +115,22 @@ brew is installed at `/var/home/linuxbrew/.linuxbrew/bin/brew`.
 
 `~/.local/share/ublue-os/brew-preinstall-state.json`
 ```json
-{ "hash": "<sha256 of all Brewfiles combined>", "packages": ["pkg1", ...] }
+{ "hash": "<sha256 of all Brewfiles combined>", "packages": ["pkg1", ...], "casks": ["cask1", ...] }
 ```
+
+Older state files without a `casks` key are read as an empty cask list;
+no migration is needed.
 
 ### On every login
 
 1. Hash all `preinstall.d/*.Brewfile` files combined.
 2. Compare to stored hash. **Identical → fast exit**, nothing touched.
 3. **Different:** run `brew bundle --file=` on each Brewfile (idempotent).
-4. Diff `previous_packages` (from state JSON) against `current_packages`
-   (from Brewfiles). Uninstall packages that were in the old set but not
-   the new one — **only if `brew list` confirms they are installed**.
-5. Write new hash + package list to state file atomically (tmp + mv).
+4. Diff previous `packages`/`casks` (from state JSON) against the current
+   `brew "..."`/`cask "..."` lines (from Brewfiles). Uninstall entries that
+   were in the old set but not the new one — **only if `brew list` confirms
+   they are installed**. Casks are removed with `brew uninstall --cask`.
+5. Write new hash + package and cask lists to state file atomically (tmp + mv).
 
 **The service is content-addressed, not version-numbered.** Never bump a
 counter to propagate a Brewfile change — just edit the file. The hash change
@@ -176,6 +180,13 @@ brew "bluefinctl"
 ```
 Without `trusted: true` the tap is blocked and the formula is silently
 unavailable. See [Homebrew 6.0 tap trust](#homebrew-60-tap-trust-required-as-of-2026-06-11).
+
+### Add a cask (GUI app)
+
+`cask "<name>"` lines get the same managed lifecycle as `brew "<name>"`
+lines: installed by `brew bundle`, tracked in the state file under
+`casks`, and uninstalled with `brew uninstall --cask` when the line is
+removed. Verify with `bats tests/test_brew_preinstall.bats`.
 
 ### Add a variant-specific Brewfile
 

--- a/docs/skills/index.json
+++ b/docs/skills/index.json
@@ -67,8 +67,8 @@
         "packages"
       ],
       "description": "Manage OS-managed Homebrew packages. Use when adding/removing default brew packages, moving tools between RPM and brew, or auditing image-vs-brew placement.",
-      "version": "1.0",
-      "last_updated": "2026-06-23",
+      "version": "1.1",
+      "last_updated": "2026-07-22",
       "doc_type": "procedure"
     },
     {

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -16,6 +16,8 @@ description: >-
   debugging CI, or understanding pipeline stages.
 metadata:
   type: reference
+  context7-sources:
+    - /websites/cli_github_manual
 ---
 
 # Common workflow map
@@ -30,6 +32,7 @@ Load this when you need to understand **what each GitHub workflow in `projectblu
 |---|---|---|
 | `validate.yml` | Main PR gate: submodule drift, `just check`, shellcheck, image-registry guard, dconf parity, pre-commit | Tightening repo-local validation or policy guards |
 | `validate-brewfiles.yaml` | Validates Brewfile correctness | Changing Brewfile structure or Brewfile validation rules |
+| `validate-chairlift-config.yaml` | Checks `/usr/share/chairlift/config.yml` against upstream ChairLift's live schema; also runs weekly | Changing the ChairLift maintainer config, or when upstream ChairLift changes its config schema |
 | `unit-tests.yml` | Runs `pytest` + `bats` on `system_files/**`, `tests/**`, and the `Justfile`. Triggers on PR, push to `main`, and `merge_group`. | Adding or changing unit tests, or changing the paths they cover |
 | `build.yml` | Builds and publishes the `common` OCI layer on merge. Runs parallel per-arch jobs (x86_64 on `ubuntu-24.04`, aarch64 on `ubuntu-24.04-arm`). Build uses rootless `buildah-build`; after build, `sudo skopeo copy` promotes the image into root storage so `push-image` (which uses `sudo podman push`) can find it. Then a `manifest` job assembles the multi-arch manifest, logs into GHCR, signs with keyless OIDC, generates SBOM, and attests SLSA L2. Downstream propagation is handled by Renovate (bluefin/bluefin-lts, ~3h) and dakota's daily cron — there is no direct dispatch from this workflow. | Changing how the shared layer is built or pushed |
 | `pr-e2e.yml` | Pre-merge composed-image gate for the PR's common layer (composes + runs common suite via `run-testsuite.yml`) | Changing how PR-time downstream composition is tested |
@@ -52,6 +55,13 @@ Load this when you need to understand **what each GitHub workflow in `projectblu
 ### Validation and policy
 
 `validate.yml` and `validate-brewfiles.yaml` are about catching repo-local mistakes **before merge**.
+
+`validate-chairlift-config.yaml` is different in kind: it validates against an
+**external** source of truth that can change without any commit here, which is
+why it also runs on a schedule. Reach for that shape whenever correctness
+depends on a third party's schema rather than on this repo's own contents — a
+hand-maintained allowlist inside our own tests cannot catch that drift, because
+it moves with the change instead of resisting it.
 
 ### Shared-layer build and release
 
@@ -114,3 +124,29 @@ When editing workflows here, preserve the repo boundary:
 - `common` validates the **shared layer**
 - downstream image repos validate their **image-specific** behavior
 - reusable CI logic should live in `projectbluefin/actions`, not be duplicated inline unless the logic is truly `common`-specific
+
+## Verification
+
+Re-derive this table rather than trusting it — workflows change without this
+file being touched.
+
+```bash
+# The actual set of workflows, and their names as they appear in checks
+ls .github/workflows/
+grep -H '^name:' .github/workflows/*.yml .github/workflows/*.yaml
+
+# What triggers a given workflow (events, path filters, schedules)
+sed -n '/^on:/,/^jobs:/p' .github/workflows/validate-chairlift-config.yaml
+
+# Every scheduled workflow in the repo
+grep -l 'schedule:' .github/workflows/* | xargs -r grep -H -A2 'cron:'
+
+# What a workflow actually runs, as opposed to what it is described as doing
+grep -n 'run:\|uses:' .github/workflows/validate-chairlift-config.yaml
+
+# Which checks are required to merge, per the live ruleset
+gh api repos/projectbluefin/common/rulesets --jq '.[].name'
+
+# Recent results for a workflow
+gh run list --repo projectbluefin/common --workflow "Validate ChairLift Config" --limit 5
+```

--- a/system_files/shared/usr/libexec/bootc-update-stage
+++ b/system_files/shared/usr/libexec/bootc-update-stage
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# bootc-update-stage — privileged helper invoked via ChairLift's fixed
+# org.frostyard.ChairLift.bootc.stage polkit action (pkexec exec.path is
+# pinned to this exact path; see
+# system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy).
+#
+# Downloads and stages the next bootc system image update. It intentionally
+# does NOT pass --apply: the update is only staged and applies on the next
+# reboot, on the user's own schedule. uupd remains the owner of Bluefin's
+# background update policy; this script only backs ChairLift's manual
+# "check for updates now" action.
+#
+# Contract: no arguments are read or required. Any arguments pkexec may
+# forward are ignored so this cannot be used to run arbitrary bootc
+# subcommands through a privileged invocation.
+set -euo pipefail
+
+# --download-only stages the update without applying it or rebooting;
+# --apply/--from-downloaded remain the user's own action (or uupd's), not
+# this helper's.
+#
+# Progress output is deliberately NOT suppressed: ChairLift's StageUpdate
+# merges this process's stdout and stderr and streams each line into its
+# progress view, so `--quiet` would leave the user staring at an empty
+# dialog for the length of an image pull.
+exec /usr/bin/bootc upgrade --download-only

--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -76,10 +76,24 @@ fi
 # that the diff below would then treat as "uninstall everything managed".
 current_packages=$(sed -n 's/^brew "\([^"]*\)".*/\1/p' "${brewfiles[@]}" | sort -u)
 current_casks=$(sed -n 's/^cask "\([^"]*\)".*/\1/p' "${brewfiles[@]}" | sort -u)
+
+# A corrupt state file must never drive removals. The jq reads below yield
+# empty previous sets for it (fail-safe: nothing gets uninstalled), and the
+# state write at the end self-heals the file — but say so instead of hiding it.
+if [[ -f "${STATE_FILE}" ]] && ! jq -e . "${STATE_FILE}" >/dev/null 2>&1; then
+    echo "brew-preinstall: warning: state file is corrupt; skipping removals this run and rebuilding state"
+fi
+
 previous_packages=$(jq -r '.packages[]? // empty' "${STATE_FILE}" 2>/dev/null \
     | sort -u || true)
 previous_casks=$(jq -r '.casks[]? // empty' "${STATE_FILE}" 2>/dev/null \
     | sort -u || true)
+
+# A failed uninstall must not be absorbed: if the new state were written
+# anyway, the hash fast-exit would keep the dropped package installed
+# forever. Track failures and bail before the state write so systemd
+# retries the whole run (Restart=on-failure) with the old state intact.
+uninstall_failed=0
 
 if [[ -n "${previous_packages}" ]]; then
     removed=$(comm -23 \
@@ -89,7 +103,7 @@ if [[ -n "${previous_packages}" ]]; then
         if brew list --formula "${pkg}" &>/dev/null; then
             echo "brew-preinstall: removing ${pkg} (dropped from managed set)"
             brew uninstall "${pkg}" --ignore-dependencies 2>/dev/null \
-                || echo "brew-preinstall: warning: could not remove ${pkg}, skipping"
+                || { echo "brew-preinstall: error: could not remove ${pkg}"; uninstall_failed=1; }
         fi
     done
 fi
@@ -102,9 +116,14 @@ if [[ -n "${previous_casks}" ]]; then
         if brew list --cask "${cask}" &>/dev/null; then
             echo "brew-preinstall: removing cask ${cask} (dropped from managed set)"
             brew uninstall --cask "${cask}" 2>/dev/null \
-                || echo "brew-preinstall: warning: could not remove cask ${cask}, skipping"
+                || { echo "brew-preinstall: error: could not remove cask ${cask}"; uninstall_failed=1; }
         fi
     done
+fi
+
+if [[ "${uninstall_failed}" -ne 0 ]]; then
+    echo "brew-preinstall: one or more removals failed; state unchanged, will retry"
+    exit 1
 fi
 
 # Persist new state: hash + full managed package and cask lists for next diff.

--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -48,22 +48,34 @@ eval "$("${BREW_BIN}" shellenv)"
 
 echo "brew-preinstall: Brewfiles changed (${current_hash:0:12}...), applying..."
 
-# Install all packages declared in Brewfiles (brew bundle is idempotent)
+# Install all packages declared in Brewfiles (brew bundle is idempotent).
+# One failing Brewfile (e.g. an unreachable external tap) must not block
+# the others, but any failure aborts before the removal/state-write phase
+# so the run is retried on next login.
+bundle_failed=0
 for brewfile in "${brewfiles[@]}"; do
     echo "brew-preinstall: bundling ${brewfile}"
-    brew bundle --file="${brewfile}"
+    if ! brew bundle --file="${brewfile}"; then
+        echo "brew-preinstall: error: bundling ${brewfile} failed"
+        bundle_failed=1
+    fi
 done
+
+if [[ "${bundle_failed}" -ne 0 ]]; then
+    echo "brew-preinstall: one or more Brewfiles failed; state unchanged, will retry"
+    exit 1
+fi
 
 # Uninstall packages and casks removed from our managed set (OS diet).
 # Parse the names we manage now vs what we managed before, then remove
 # the delta — but only if brew still has them installed.
 # This never touches packages the user added outside our managed set.
-# grep exits 1 when a Brewfile set declares no brew/cask lines — that is a
-# valid state under pipefail, so both extractions tolerate empty matches.
-current_packages=$(grep -h '^brew "' "${brewfiles[@]}" \
-    | sed 's/brew "\([^"]*\)".*/\1/' | sort -u || true)
-current_casks=$(grep -h '^cask "' "${brewfiles[@]}" \
-    | sed 's/cask "\([^"]*\)".*/\1/' | sort -u || true)
+# sed -n exits 0 when nothing matches (a valid state) but still fails on
+# real I/O errors — unlike grep, which exits 1 for both no-match and
+# would need `|| true`, masking errors and risking an empty current set
+# that the diff below would then treat as "uninstall everything managed".
+current_packages=$(sed -n 's/^brew "\([^"]*\)".*/\1/p' "${brewfiles[@]}" | sort -u)
+current_casks=$(sed -n 's/^cask "\([^"]*\)".*/\1/p' "${brewfiles[@]}" | sort -u)
 previous_packages=$(jq -r '.packages[]? // empty' "${STATE_FILE}" 2>/dev/null \
     | sort -u || true)
 previous_casks=$(jq -r '.casks[]? // empty' "${STATE_FILE}" 2>/dev/null \

--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -6,7 +6,10 @@
 # packages removed from Brewfiles are uninstalled — without touching user-added packages.
 #
 # State: ~/.local/share/ublue-os/brew-preinstall-state.json
-#   { "hash": "<sha256 of all Brewfiles>", "packages": ["pkg1", "pkg2", ...] }
+#   { "hash": "<sha256 of all Brewfiles>",
+#     "packages": ["pkg1", "pkg2", ...],
+#     "casks": ["cask1", ...] }
+# Older state files without a "casks" key are read as an empty cask list.
 set -euo pipefail
 
 PREINSTALL_DIR="/usr/share/ublue-os/homebrew/preinstall.d"
@@ -51,13 +54,19 @@ for brewfile in "${brewfiles[@]}"; do
     brew bundle --file="${brewfile}"
 done
 
-# Uninstall packages removed from our managed set (OS diet).
-# Parse the package names we manage now vs what we managed before,
-# then remove the delta — but only if brew still has them installed.
+# Uninstall packages and casks removed from our managed set (OS diet).
+# Parse the names we manage now vs what we managed before, then remove
+# the delta — but only if brew still has them installed.
 # This never touches packages the user added outside our managed set.
+# grep exits 1 when a Brewfile set declares no brew/cask lines — that is a
+# valid state under pipefail, so both extractions tolerate empty matches.
 current_packages=$(grep -h '^brew "' "${brewfiles[@]}" \
-    | sed 's/brew "\([^"]*\)".*/\1/' | sort -u)
-previous_packages=$(jq -r '.packages[] // empty' "${STATE_FILE}" 2>/dev/null \
+    | sed 's/brew "\([^"]*\)".*/\1/' | sort -u || true)
+current_casks=$(grep -h '^cask "' "${brewfiles[@]}" \
+    | sed 's/cask "\([^"]*\)".*/\1/' | sort -u || true)
+previous_packages=$(jq -r '.packages[]? // empty' "${STATE_FILE}" 2>/dev/null \
+    | sort -u || true)
+previous_casks=$(jq -r '.casks[]? // empty' "${STATE_FILE}" 2>/dev/null \
     | sort -u || true)
 
 if [[ -n "${previous_packages}" ]]; then
@@ -73,14 +82,29 @@ if [[ -n "${previous_packages}" ]]; then
     done
 fi
 
-# Persist new state: hash + full managed package list for next diff.
+if [[ -n "${previous_casks}" ]]; then
+    removed_casks=$(comm -23 \
+        <(echo "${previous_casks}") \
+        <(echo "${current_casks}") || true)
+    for cask in ${removed_casks}; do
+        if brew list --cask "${cask}" &>/dev/null; then
+            echo "brew-preinstall: removing cask ${cask} (dropped from managed set)"
+            brew uninstall --cask "${cask}" 2>/dev/null \
+                || echo "brew-preinstall: warning: could not remove cask ${cask}, skipping"
+        fi
+    done
+fi
+
+# Persist new state: hash + full managed package and cask lists for next diff.
 # Write atomically via temp file + rename to avoid corrupt state on SIGKILL.
 mkdir -p "$(dirname "${STATE_FILE}")"
-packages_json=$(echo "${current_packages}" | jq -R . | jq -s .)
+packages_json=$(echo "${current_packages}" | jq -R . | jq -s 'map(select(length > 0))')
+casks_json=$(echo "${current_casks}" | jq -R . | jq -s 'map(select(length > 0))')
 jq -n \
     --arg hash "${current_hash}" \
     --argjson packages "${packages_json}" \
-    '{"hash": $hash, "packages": $packages}' > "${STATE_FILE}.tmp"
+    --argjson casks "${casks_json}" \
+    '{"hash": $hash, "packages": $packages, "casks": $casks}' > "${STATE_FILE}.tmp"
 mv -f "${STATE_FILE}.tmp" "${STATE_FILE}"
 
 echo "brew-preinstall: complete"

--- a/system_files/shared/usr/share/chairlift/config.yml
+++ b/system_files/shared/usr/share/chairlift/config.yml
@@ -1,0 +1,77 @@
+# ChairLift configuration for Bluefin (maintainer defaults).
+# Admin overrides go in /etc/chairlift/config.yml, which takes priority.
+# Reference: https://github.com/frostyard/chairlift/blob/main/CONFIG.md
+
+system_page:
+  system_info_group:
+    enabled: true
+  bootc_status_group:
+    enabled: true
+  health_group:
+    enabled: true
+    app_id: io.missioncenter.MissionCenter
+
+updates_page:
+  # frostyard/chairlift#54 resolved via the system-integration split
+  # (frostyard/chairlift#102): the fixed /usr/libexec/bootc-update-stage
+  # path is now backed by an image-side stage script, and the bootc polkit
+  # policy ships in system_files/shared/usr/share/polkit-1/actions/. Staging
+  # only (bootc upgrade --download-only); applying still happens on the
+  # user's own reboot, or via uupd's background policy.
+  bootc_updates_group:
+    enabled: true
+  flatpak_updates_group:
+    enabled: true
+  brew_updates_group:
+    enabled: true
+  brew_trust_group:
+    enabled: true
+  # Update policy on Bluefin belongs to uupd (silent background staging,
+  # 6-hour timer + AC connect; user reboots on their own schedule).
+  # ChairLift has no update-scheduling group to disable here: upstream's
+  # updates_page schema is exactly the four groups above. Its bootc group
+  # is a manual "stage now" action only, so nothing competes with uupd.
+  # Do NOT invent a group to express this policy — an unknown group key
+  # fails ChairLift's strict schema validation and disables the entire
+  # app (see docs/skills/brew-lifecycle.md).
+
+applications_page:
+  applications_installed_group:
+    enabled: true
+    app_id: io.github.kolunmi.Bazaar
+  flatpak_user_group:
+    enabled: true
+  flatpak_system_group:
+    enabled: true
+  brew_group:
+    enabled: true
+  brew_search_group:
+    enabled: true
+  brew_bundles_group:
+    enabled: true
+    bundles_paths:
+      - /usr/share/ublue-os/homebrew
+
+maintenance_page:
+  maintenance_cleanup_group:
+    enabled: false
+  maintenance_brew_group:
+    enabled: true
+  maintenance_flatpak_group:
+    enabled: true
+  maintenance_optimization_group:
+    enabled: true
+
+features_page:
+  # updex is not present on Bluefin. Unlike bootc staging, no updex helper
+  # ships on the image, so this stays off regardless of the polkit fix in
+  # frostyard/chairlift#54 — flip only if/when updex ever ships on Bluefin.
+  features_group:
+    enabled: false
+
+help_page:
+  help_resources_group:
+    enabled: true
+    website: https://docs.projectbluefin.io/
+    issues: https://issues.projectbluefin.io/
+    chat: https://ask.projectbluefin.io/

--- a/system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
+++ b/system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<policyconfig>
+  <vendor>Frostyard</vendor>
+  <vendor_url>https://github.com/frostyard/chairlift</vendor_url>
+  <icon_name>org.frostyard.ChairLift</icon_name>
+
+  <action id="org.frostyard.ChairLift.bootc.stage">
+    <description>Download and stage a system image update</description>
+    <message>Authentication is required to stage a system update</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/bootc-update-stage</annotate>
+  </action>
+
+</policyconfig>

--- a/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile
@@ -1,0 +1,2 @@
+tap "frostyard/tap", trusted: true
+cask "chairlift"

--- a/tests/check-chairlift-config
+++ b/tests/check-chairlift-config
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Validate the ChairLift config against upstream's live schema.
+
+ChairLift does not ignore unknown configuration keys. Upstream
+internal/config/validate.go classifies any page, group, or group field name
+it does not recognise as KindSchema, and internal/config/config.go::Load()
+answers a KindSchema error with disabledConfig() -- every group on every
+page forced off, plus a persistent "Configuration error" toast.
+
+So a single invented key in our maintainer config does not degrade one
+feature: it ships an empty application to every Bluefin user. Bluefin
+preinstalls ChairLift silently at login, so nobody opts into that.
+
+Sources of truth, both read live from upstream:
+  * pages and groups -- upstream's own config.yml, which enumerates every
+    page and group and is kept in lockstep with defaultConfig().
+  * group and action FIELD names -- the yaml struct tags on GroupConfig and
+    ActionConfig in internal/config/config.go. config.yml cannot supply
+    these, because it only exercises a subset of the optional fields.
+
+Do not update the expectations in this file from memory -- this script
+reads upstream directly, on purpose.
+
+Network access is required. Set GITHUB_TOKEN (or GH_TOKEN) to avoid rate
+limits; in CI, github.token is available automatically.
+"""
+
+from pathlib import Path
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+UPSTREAM_CONFIG_URL = (
+    "https://raw.githubusercontent.com/frostyard/chairlift/main/config.yml"
+)
+UPSTREAM_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/frostyard/chairlift/main/"
+    "internal/config/config.go"
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+OUR_CONFIG = ROOT / "system_files/shared/usr/share/chairlift/config.yml"
+
+STRUCT_RE = r"type\s+%s\s+struct\s*\{(.*?)\}"
+YAML_TAG_RE = re.compile(r'yaml:"([^",]+)')
+
+
+def _fetch(url: str) -> str:
+    request = urllib.request.Request(url)
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def fetch_upstream_schema() -> dict[str, set[str]]:
+    """Return upstream's canonical page -> {group} map."""
+    raw = _fetch(UPSTREAM_CONFIG_URL)
+    parsed = yaml.safe_load(raw)
+    if not isinstance(parsed, dict) or not parsed:
+        raise ValueError(f"upstream config.yml did not parse as a mapping: {raw[:200]}")
+
+    schema: dict[str, set[str]] = {}
+    for page, groups in parsed.items():
+        if not isinstance(groups, dict):
+            raise ValueError(f"upstream page {page!r} is not a mapping")
+        schema[page] = set(groups)
+    return schema
+
+
+def _struct_fields(source: str, struct: str) -> set[str]:
+    match = re.search(STRUCT_RE % struct, source, re.DOTALL)
+    if not match:
+        raise ValueError(f"could not find {struct} in upstream config.go")
+    fields = set(YAML_TAG_RE.findall(match.group(1)))
+    if not fields:
+        raise ValueError(f"{struct} in upstream config.go exposed no yaml tags")
+    return fields
+
+
+def fetch_upstream_fields() -> tuple[set[str], set[str]]:
+    """Return (group field names, action field names) from upstream structs."""
+    source = _fetch(UPSTREAM_SCHEMA_URL)
+    return _struct_fields(source, "GroupConfig"), _struct_fields(source, "ActionConfig")
+
+
+def main() -> int:
+    if not OUR_CONFIG.exists():
+        print(f"✗ missing {OUR_CONFIG.relative_to(ROOT)}")
+        return 1
+
+    try:
+        upstream = fetch_upstream_schema()
+        group_fields, action_fields = fetch_upstream_fields()
+    except (urllib.error.URLError, ValueError, yaml.YAMLError) as err:
+        print(f"✗ could not read upstream ChairLift schema: {err}")
+        return 1
+
+    ours = yaml.safe_load(OUR_CONFIG.read_text(encoding="utf-8"))
+    if not isinstance(ours, dict):
+        print(f"✗ {OUR_CONFIG.relative_to(ROOT)} did not parse as a mapping")
+        return 1
+
+    failures: list[str] = []
+
+    for page, groups in ours.items():
+        if page not in upstream:
+            failures.append(
+                f'page "{page}" does not exist in ChairLift\'s schema '
+                f"(known pages: {', '.join(sorted(upstream))})"
+            )
+            continue
+        if not isinstance(groups, dict):
+            failures.append(f'page "{page}" must be a mapping of groups')
+            continue
+        for group, settings in groups.items():
+            if group not in upstream[page]:
+                failures.append(
+                    f'group "{page}.{group}" does not exist in ChairLift\'s schema '
+                    f"(known groups for {page}: {', '.join(sorted(upstream[page]))})"
+                )
+                continue
+            if not isinstance(settings, dict):
+                failures.append(f'group "{page}.{group}" must be a mapping of fields')
+                continue
+            # Field names matter as much as group names: validateGroupFieldEntries
+            # classifies an unknown field as KindSchema too, so a typo such as
+            # `bundle_paths` for `bundles_paths` disables the whole app.
+            for field, value in settings.items():
+                if field not in group_fields:
+                    failures.append(
+                        f'field "{page}.{group}.{field}" does not exist in '
+                        f"ChairLift's schema (known fields: "
+                        f"{', '.join(sorted(group_fields))})"
+                    )
+                elif field == "actions" and isinstance(value, list):
+                    for index, action in enumerate(value):
+                        if not isinstance(action, dict):
+                            continue
+                        for action_field in action:
+                            if action_field not in action_fields:
+                                failures.append(
+                                    f'field "{page}.{group}.actions[{index}].'
+                                    f'{action_field}" does not exist in '
+                                    f"ChairLift's schema (known action fields: "
+                                    f"{', '.join(sorted(action_fields))})"
+                                )
+
+    for page, groups in sorted(upstream.items()):
+        print(f"  {page}: {', '.join(sorted(groups))}")
+    print(f"  group fields: {', '.join(sorted(group_fields))}")
+    print(f"  action fields: {', '.join(sorted(action_fields))}")
+
+    if failures:
+        print()
+        print("✗ ChairLift config uses keys absent from upstream's schema.")
+        print("  ChairLift fails closed on unknown keys: an unrecognised page,")
+        print("  group, or field makes Load() return disabledConfig(), which")
+        print("  disables EVERY feature group and shows a configuration-error")
+        print("  toast. Remove the key and express the intent in a comment.")
+        print()
+        for failure in failures:
+            print(f"    - {failure}")
+        return 1
+
+    print()
+    print("✓ ChairLift config uses only keys upstream defines.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -323,6 +323,66 @@ BREWMOCK
     [ "$(jq '.casks | length' "${state_file}")" -eq 0 ]
 }
 
+@test "brew-preinstall: one failing Brewfile does not block the others" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/a-fail.Brewfile"
+    echo 'brew "fd"'      > "${WORKDIR}/preinstall.d/b-ok.Brewfile"
+
+    # Mock: bundling the a-fail Brewfile fails, everything else succeeds
+    cat > "${WORKDIR}/bin/brew" << BREWMOCK
+#!/usr/bin/env bash
+BREW_LOG="\${BREW_LOG:-/dev/null}"
+printf 'brew %s\n' "\$*" >> "\${BREW_LOG}"
+case "\$1" in
+    shellenv) printf 'export PATH="%s:\${PATH}"\n' "${WORKDIR}/bin" ;;
+    bundle)   [[ "\$*" == *"a-fail"* ]] && exit 1 ;;
+    list)     exit 0 ;;
+    uninstall) ;;
+esac
+BREWMOCK
+    chmod +x "${WORKDIR}/bin/brew"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+
+    # The healthy Brewfile was still bundled
+    grep -q "b-ok.Brewfile" "${WORKDIR}/brew.log"
+    # The run fails so systemd retries and the state file is not written,
+    # keeping removals and the fast-exit hash off the table
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"will retry"* ]]
+    [ ! -f "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" ]
+    ! grep -q "uninstall" "${WORKDIR}/brew.log" 2>/dev/null
+}
+
+@test "brew-preinstall: bundle failure skips removals entirely" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    # Old state managed fd, which is now dropped — but bundling fails, so
+    # the removal phase must not run on this pass
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":["fd","ripgrep"]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    cat > "${WORKDIR}/bin/brew" << BREWMOCK
+#!/usr/bin/env bash
+BREW_LOG="\${BREW_LOG:-/dev/null}"
+printf 'brew %s\n' "\$*" >> "\${BREW_LOG}"
+case "\$1" in
+    shellenv) printf 'export PATH="%s:\${PATH}"\n' "${WORKDIR}/bin" ;;
+    bundle)   exit 1 ;;
+    list)     exit 0 ;;
+    uninstall) ;;
+esac
+BREWMOCK
+    chmod +x "${WORKDIR}/bin/brew"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 1 ]
+    ! grep -q "uninstall" "${WORKDIR}/brew.log" 2>/dev/null
+    # State keeps the old hash so the next login retries the whole run
+    stored_hash="$(jq -r '.hash' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json")"
+    [ "${stored_hash}" = "oldhash" ]
+}
+
 @test "brew-preinstall: re-runs after Brewfile changes (hash mismatch)" {
     echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
 

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -243,6 +243,86 @@ BREWMOCK
     [ ! -f "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json.tmp" ]
 }
 
+# ---------------------------------------------------------------------------
+# Cask lifecycle — cask lines are tracked and uninstalled like formulae
+# ---------------------------------------------------------------------------
+
+@test "brew-preinstall: state file contains cask list after run" {
+    echo 'cask "chairlift"' > "${WORKDIR}/preinstall.d/apps.Brewfile"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+
+    state_file="${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+    casks="$(jq -r '.casks[]' "${state_file}")"
+    [[ "${casks}" == *"chairlift"* ]]
+}
+
+@test "brew-preinstall: uninstalls cask removed from managed set" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    # Simulate old state that also managed the chairlift cask (now dropped)
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":["ripgrep"],"casks":["chairlift"]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "uninstall --cask chairlift" "${WORKDIR}/brew.log"
+}
+
+@test "brew-preinstall: does not uninstall cask still in Brewfile" {
+    echo 'cask "chairlift"' > "${WORKDIR}/preinstall.d/apps.Brewfile"
+
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":[],"casks":["chairlift"]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    ! grep -q "uninstall --cask" "${WORKDIR}/brew.log" 2>/dev/null
+}
+
+@test "brew-preinstall: cask removal does not touch formula with same diff" {
+    echo 'brew "chairlift-formula"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":["chairlift-formula"],"casks":["chairlift"]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "uninstall --cask chairlift" "${WORKDIR}/brew.log"
+    ! grep -q "uninstall chairlift-formula" "${WORKDIR}/brew.log" 2>/dev/null
+}
+
+@test "brew-preinstall: legacy state file without casks key is handled" {
+    echo 'cask "chairlift"' > "${WORKDIR}/preinstall.d/apps.Brewfile"
+
+    # Pre-cask state format: no "casks" key at all
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":["ripgrep"]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"complete"* ]]
+
+    state_file="${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+    casks="$(jq -r '.casks[]' "${state_file}")"
+    [[ "${casks}" == *"chairlift"* ]]
+}
+
+@test "brew-preinstall: state file has empty casks array when no cask lines" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+
+    state_file="${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+    [ "$(jq '.casks | length' "${state_file}")" -eq 0 ]
+}
+
 @test "brew-preinstall: re-runs after Brewfile changes (hash mismatch)" {
     echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
 

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -383,6 +383,52 @@ BREWMOCK
     [ "${stored_hash}" = "oldhash" ]
 }
 
+@test "brew-preinstall: corrupt state file warns, skips removals, rebuilds state" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    echo 'not json at all {{' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"state file is corrupt"* ]]
+    ! grep -q "uninstall" "${WORKDIR}/brew.log" 2>/dev/null
+    # State is rebuilt as valid JSON
+    jq -e . "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" >/dev/null
+}
+
+@test "brew-preinstall: failed uninstall keeps old state so removal is retried" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    # Old state managed fd, now dropped — and uninstalling it fails
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":["fd","ripgrep"]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    cat > "${WORKDIR}/bin/brew" << BREWMOCK
+#!/usr/bin/env bash
+BREW_LOG="\${BREW_LOG:-/dev/null}"
+printf 'brew %s\n' "\$*" >> "\${BREW_LOG}"
+case "\$1" in
+    shellenv) printf 'export PATH="%s:\${PATH}"\n' "${WORKDIR}/bin" ;;
+    bundle)   ;;
+    list)     exit 0 ;;
+    uninstall) exit 1 ;;
+esac
+BREWMOCK
+    chmod +x "${WORKDIR}/bin/brew"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"removals failed"* ]]
+    # Old state survives: hash unchanged means next login retries the run
+    stored_hash="$(jq -r '.hash' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json")"
+    [ "${stored_hash}" = "oldhash" ]
+    pkgs="$(jq -r '.packages[]' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json")"
+    [[ "${pkgs}" == *"fd"* ]]
+}
+
 @test "brew-preinstall: re-runs after Brewfile changes (hash mismatch)" {
     echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
 

--- a/tests/test_chairlift_config.py
+++ b/tests/test_chairlift_config.py
@@ -1,0 +1,279 @@
+"""Regression checks for the ChairLift config and preinstall Brewfile.
+
+ChairLift (https://github.com/frostyard/chairlift) reads
+/usr/share/chairlift/config.yml for maintainer defaults. These tests pin
+the Bluefin decisions: frostyard/chairlift#54 resolved via the
+system-integration split (frostyard/chairlift#102), so bootc staging is
+now backed by an image-side polkit policy and stage script and
+bootc_updates_group is enabled. updex (features_group) stays disabled
+because no updex helper ships on Bluefin. Bundle paths point at Bluefin's
+Brewfiles, and help links point at Bluefin resources.
+
+Note on strictness: ChairLift does not ignore unknown configuration keys.
+internal/config/validate.go classifies an unrecognised page, group, or
+field as KindSchema, and internal/config/config.go::Load() answers that
+with disabledConfig() -- every group on every page forced off, plus a
+persistent configuration-error toast. So a typo in this config is not a
+cosmetic defect; it ships an empty app to every user.
+"""
+
+from pathlib import Path
+import shlex
+
+import yaml
+
+
+ROOT = Path(__file__).parent.parent
+CONFIG = ROOT / "system_files/shared/usr/share/chairlift/config.yml"
+BREWFILE = (
+    ROOT
+    / "system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile"
+)
+BOOTC_POLICY = (
+    ROOT
+    / "system_files/shared/usr/share/polkit-1/actions"
+    / "org.frostyard.ChairLift.bootc.policy"
+)
+BOOTC_STAGE_SCRIPT = ROOT / "system_files/shared/usr/libexec/bootc-update-stage"
+
+# The canonical page -> group map, mirrored from upstream
+# internal/config/config.go::defaultConfig(). ChairLift validates configs
+# STRICTLY: internal/config/validate.go classifies any page, group, or
+# field name it does not recognise as KindSchema, which makes Load()
+# return disabledConfig() -- every group on every page forced off, plus a
+# persistent "Configuration error" toast. A typo here is not a silent
+# no-op, it bricks the whole app.
+#
+# This list is an offline pin. The authoritative check against upstream
+# lives in .github/workflows/validate-chairlift-config.yaml, which fetches
+# upstream's config.yml and fails on drift.
+KNOWN_GROUPS = {
+    "system_page": {"system_info_group", "bootc_status_group", "health_group"},
+    "updates_page": {
+        "bootc_updates_group",
+        "flatpak_updates_group",
+        "brew_updates_group",
+        "brew_trust_group",
+    },
+    "applications_page": {
+        "applications_installed_group",
+        "flatpak_user_group",
+        "flatpak_system_group",
+        "brew_group",
+        "brew_search_group",
+        "brew_bundles_group",
+    },
+    "maintenance_page": {
+        "maintenance_cleanup_group",
+        "maintenance_brew_group",
+        "maintenance_flatpak_group",
+        "maintenance_optimization_group",
+    },
+    "features_page": {"features_group"},
+    "help_page": {"help_resources_group"},
+}
+
+# Group field names, mirrored from upstream GroupConfig's yaml struct tags.
+# validateGroupFieldEntries() classifies an unknown FIELD as KindSchema too,
+# so `bundle_paths` for `bundles_paths` bricks the app exactly like a bad
+# group name would. Action fields come from ActionConfig.
+KNOWN_FIELDS = {
+    "enabled",
+    "app_id",
+    "actions",
+    "website",
+    "issues",
+    "chat",
+    "bundles_paths",
+}
+KNOWN_ACTION_FIELDS = {"title", "script", "sudo"}
+
+
+def _load_config():
+    return yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+
+
+def test_config_parses_and_uses_known_pages_and_groups():
+    data = _load_config()
+    assert isinstance(data, dict)
+
+    for page, groups in data.items():
+        assert page in KNOWN_GROUPS, f"unknown page: {page}"
+        assert isinstance(groups, dict)
+        for group, settings in groups.items():
+            assert group in KNOWN_GROUPS[page], f"unknown group: {page}.{group}"
+            assert isinstance(settings, dict)
+            assert isinstance(settings.get("enabled"), bool), (
+                f"{page}.{group} must set enabled: true/false"
+            )
+
+
+def test_bootc_staging_enabled_now_that_polkit_glue_ships():
+    """frostyard/chairlift#54 resolved via the system-integration split
+    (frostyard/chairlift#102): Bluefin now ships the fixed
+    /usr/libexec/bootc-update-stage helper and the bootc polkit policy, so
+    bootc_updates_group can be enabled."""
+    data = _load_config()
+    assert data["updates_page"]["bootc_updates_group"]["enabled"] is True
+
+
+def test_updex_features_group_stays_disabled():
+    """updex has no Bluefin helper yet, independent of the bootc polkit
+    fix. Keep it off until updex actually ships on Bluefin."""
+    data = _load_config()
+    assert data["features_page"]["features_group"]["enabled"] is False
+
+
+def test_bootc_stage_polkit_policy_pins_fixed_helper_path():
+    """The polkit action must annotate the exact fixed path ChairLift's
+    pkexec invocation expects, and require authentication."""
+    content = BOOTC_POLICY.read_text(encoding="utf-8")
+    assert "org.frostyard.ChairLift.bootc.stage" in content
+    assert (
+        '<annotate key="org.freedesktop.policykit.exec.path">'
+        "/usr/libexec/bootc-update-stage</annotate>" in content
+    )
+    assert "<allow_any>auth_admin</allow_any>" in content
+    assert "<allow_inactive>auth_admin</allow_inactive>" in content
+    assert "<allow_active>auth_admin_keep</allow_active>" in content
+
+
+def test_no_polkit_rule_grants_bootc_staging_without_authentication():
+    """auth_admin in the .policy file is only the default; a rules.d file
+    returning polkit.Result.YES for this action would silently override it
+    into a passwordless root exec for any user.
+
+    The previous version of this test asserted this in its docstring but
+    never opened rules.d, so it would not have noticed such a rule. Read
+    every shipped rules file and fail on one that mentions our action.
+    """
+    rules_dirs = [
+        ROOT / "system_files/shared/usr/share/polkit-1/rules.d",
+        ROOT / "system_files/shared/etc/polkit-1/rules.d",
+        ROOT / "system_files/bluefin/usr/share/polkit-1/rules.d",
+        ROOT / "system_files/bluefin/etc/polkit-1/rules.d",
+    ]
+    offenders = []
+    for rules_dir in rules_dirs:
+        if not rules_dir.is_dir():
+            continue
+        for rules_file in rules_dir.glob("*.rules"):
+            text = rules_file.read_text(encoding="utf-8")
+            if "ChairLift" in text or "bootc-update-stage" in text:
+                offenders.append(str(rules_file.relative_to(ROOT)))
+
+    assert not offenders, (
+        f"polkit rules reference the ChairLift staging action: {offenders}; "
+        "staging must stay behind auth_admin, never a passwordless rule"
+    )
+
+
+def test_bootc_stage_script_is_executable_and_stages_only():
+    """The privileged helper must only stage (never auto-apply/reboot) so
+    uupd remains the sole owner of when an update actually takes effect,
+    and must not suppress progress output: ChairLift streams the helper's
+    merged stdout+stderr into its progress view, so --quiet would leave
+    the user with an empty dialog.
+
+    Assert the exact argv rather than substrings. `pkexec` runs this script
+    as root, so "contains 'bootc upgrade'" is far too weak a claim: it
+    would also accept `exec /some/other/tool "bootc upgrade"`.
+    """
+    assert BOOTC_STAGE_SCRIPT.stat().st_mode & 0o111, (
+        "bootc-update-stage must be executable"
+    )
+    exec_lines = [
+        line.strip()
+        for line in BOOTC_STAGE_SCRIPT.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("exec ")
+    ]
+    assert len(exec_lines) == 1, "expected exactly one exec invocation"
+    (exec_line,) = exec_lines
+    assert shlex.split(exec_line) == [
+        "exec",
+        "/usr/bin/bootc",
+        "upgrade",
+        "--download-only",
+    ], f"unexpected privileged command: {exec_line!r}"
+
+
+def test_bootc_stage_script_ignores_arguments():
+    """pkexec forwards caller-supplied argv. The helper must never pass it
+    through to bootc, or the polkit action becomes a way to run arbitrary
+    bootc subcommands as root."""
+    content = BOOTC_STAGE_SCRIPT.read_text(encoding="utf-8")
+    for positional in ('"$@"', "$@", '"$1"', "$1", '"${@}"'):
+        assert positional not in content, (
+            f"stage script forwards {positional} into a privileged invocation"
+        )
+
+
+def test_config_uses_only_upstream_schema_keys():
+    """Every page and group we set must exist in ChairLift's schema.
+
+    This is the regression test for the bug this file previously shipped:
+    config.yml declared an `updates_settings_group` that upstream never
+    defined. Unknown keys are not ignored -- validate.go classifies them
+    as KindSchema, Load() falls back to disabledConfig(), and the user
+    gets an empty app with a configuration-error toast. Assert a strict
+    subset rather than equality, since omitting a group is legitimate
+    (it just inherits upstream's default).
+    """
+    data = _load_config()
+
+    unknown_pages = set(data) - set(KNOWN_GROUPS)
+    assert not unknown_pages, f"pages absent from ChairLift's schema: {unknown_pages}"
+
+    for page, groups in data.items():
+        unknown_groups = set(groups) - KNOWN_GROUPS[page]
+        assert not unknown_groups, (
+            f"{page}: groups absent from ChairLift's schema: {unknown_groups}; "
+            "an unknown group disables every feature group in the app"
+        )
+        for group, settings in groups.items():
+            unknown_fields = set(settings) - KNOWN_FIELDS
+            assert not unknown_fields, (
+                f"{page}.{group}: fields absent from ChairLift's schema: "
+                f"{unknown_fields}; an unknown field disables the whole app "
+                "just like an unknown group does"
+            )
+            for action in settings.get("actions") or []:
+                unknown_action_fields = set(action) - KNOWN_ACTION_FIELDS
+                assert not unknown_action_fields, (
+                    f"{page}.{group}.actions: fields absent from ChairLift's "
+                    f"schema: {unknown_action_fields}"
+                )
+
+
+def test_update_scheduling_is_not_expressed_as_a_config_group():
+    """Bluefin's update policy belongs to uupd, but that intent must not be
+    encoded as a made-up group. upstream's updates_page is exactly the four
+    groups in KNOWN_GROUPS; anything settings-shaped here is an invention
+    that would fail strict validation."""
+    updates = _load_config()["updates_page"]
+    invented = {name for name in updates if "setting" in name or "schedul" in name}
+    assert not invented, (
+        f"invented update-scheduling groups: {invented}; "
+        "document the uupd policy in a comment instead"
+    )
+
+
+def test_bundles_paths_point_at_bluefin_brewfiles():
+    group = _load_config()["applications_page"]["brew_bundles_group"]
+    assert group["bundles_paths"] == ["/usr/share/ublue-os/homebrew"]
+
+
+def test_help_links_point_at_bluefin():
+    resources = _load_config()["help_page"]["help_resources_group"]
+    for key in ("website", "issues", "chat"):
+        assert resources[key].startswith("https://"), f"{key} must be https"
+        assert "projectbluefin.io" in resources[key], (
+            f"{key} must point at a Bluefin resource"
+        )
+
+
+def test_brewfile_taps_frostyard_with_trust():
+    """Homebrew 6 blocks untrusted taps silently; trusted: true is load-bearing."""
+    content = BREWFILE.read_text(encoding="utf-8")
+    assert 'tap "frostyard/tap", trusted: true' in content
+    assert 'cask "chairlift"' in content


### PR DESCRIPTION
## What

Extends the brew-preinstall managed lifecycle to `cask "..."` lines in `preinstall.d/*.Brewfile`:

- casks are installed by the existing `brew bundle` pass and tracked in the state file under a new `casks` key
- dropping a cask line uninstalls it on next login via `brew uninstall --cask` (same only-if-installed, never-touch-user-installs safety rules as formulae)
- legacy state files without a `casks` key read as an empty list — no migration
- fixes a latent pipefail bug: `grep` exits 1 when the Brewfile set declares no `brew` (or `cask`) lines, aborting the script under `set -e`
- filters empty strings out of the persisted package/cask arrays

## Why

Prepares for shipping ChairLift as a preinstalled cask (frostyard/homebrew-tap#1, frostyard/chairlift#53). Follow-up PR adds the Brewfile + config.

## Validation

- `bats tests/test_brew_preinstall.bats` — 21/21 pass (6 new cask tests)
- `just check`, `pre-commit run` on changed files — pass
- brew-lifecycle skill updated in the same change (AGENTS.md rule)

Blast radius: `system_files/shared/` — behavior for existing Brewfiles is unchanged (verified by the pre-existing 15 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Brew lifecycle management now tracks both formulae and cask applications.
  * Removed casks are automatically uninstalled during reconciliation.
  * State records now include managed casks, with compatibility for older state files.
  * Added guidance for adding and verifying casks.

* **Bug Fixes**
  * Improved handling when Brewfiles contain no casks.
  * Prevented similarly named formulae and casks from affecting each other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->