### PR TITLE
fix(ujust): install fzf before choosing recipes

### DIFF
--- a/system_files/shared/usr/bin/ujust
+++ b/system_files/shared/usr/bin/ujust
@@ -1,3 +1,20 @@
 #!/usr/bin/bash
 
-just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"
+if [[ " ${*} " == *" --choose "* ]] && ! command -v fzf >/dev/null 2>&1; then
+    BREW_BIN="$(command -v brew 2>/dev/null || true)"
+    BREW_BIN="${BREW_BIN:-/var/home/linuxbrew/.linuxbrew/bin/brew}"
+
+    if [[ ! -x "${BREW_BIN}" ]]; then
+        echo "ujust: fzf is missing and Homebrew was not found" >&2
+        exit 127
+    fi
+
+    echo "ujust: installing missing fzf with Homebrew..." >&2
+    if ! "${BREW_BIN}" install fzf; then
+        echo "ujust: failed to install fzf" >&2
+        exit 1
+    fi
+    eval "$("${BREW_BIN}" shellenv)"
+fi
+
+exec just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"

--- a/system_files/shared/usr/bin/ujust
+++ b/system_files/shared/usr/bin/ujust
@@ -1,7 +1,15 @@
 #!/usr/bin/bash
 
-if [[ " ${*} " == *" --choose "* ]] && ! command -v fzf >/dev/null 2>&1; then
-    BREW_BIN="$(command -v brew 2>/dev/null || true)"
+CHOOSE=false
+for arg in "$@"; do
+    if [[ "$arg" == "--choose" ]]; then
+        CHOOSE=true
+        break
+    fi
+done
+
+if [[ "${CHOOSE}" == true ]] && ! command -v fzf >/dev/null 2>&1; then
+    BREW_BIN="${BREW_BIN:-$(command -v brew 2>/dev/null || true)}"
     BREW_BIN="${BREW_BIN:-/var/home/linuxbrew/.linuxbrew/bin/brew}"
 
     if [[ ! -x "${BREW_BIN}" ]]; then
@@ -14,7 +22,17 @@ if [[ " ${*} " == *" --choose "* ]] && ! command -v fzf >/dev/null 2>&1; then
         echo "ujust: failed to install fzf" >&2
         exit 1
     fi
-    eval "$("${BREW_BIN}" shellenv)"
+
+    SHELLENV_OUTPUT="$("${BREW_BIN}" shellenv)" || {
+        echo "ujust: failed to initialize Homebrew environment" >&2
+        exit 1
+    }
+    eval "${SHELLENV_OUTPUT}"
+
+    if ! command -v fzf >/dev/null 2>&1; then
+        echo "ujust: fzf is still unavailable after Homebrew setup" >&2
+        exit 127
+    fi
 fi
 
 exec just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"

--- a/tests/test_ujust.bats
+++ b/tests/test_ujust.bats
@@ -6,20 +6,34 @@ WORKDIR=""
 
 setup() {
     WORKDIR="$(mktemp -d)"
-    mkdir -p "${WORKDIR}/bin"
+    mkdir -p "${WORKDIR}/bin" "${WORKDIR}/prefix/bin"
     : > "${WORKDIR}/calls.log"
 
     cat > "${WORKDIR}/bin/brew" <<'EOF'
 #!/usr/bin/bash
 printf 'brew %s\n' "$*" >> "${CALLS}"
-if [[ "$1" == shellenv ]]; then
-    printf 'export PATH="%s:$PATH"\n' "${MOCK_BIN}"
-fi
+case "$1" in
+    install)
+        /usr/bin/mkdir -p "${MOCK_PREFIX}/bin"
+        printf '#!/usr/bin/bash\nexit 0\n' > "${MOCK_PREFIX}/bin/fzf"
+        /usr/bin/chmod +x "${MOCK_PREFIX}/bin/fzf"
+        ;;
+    shellenv)
+        printf 'export PATH="%s/bin:$PATH"\n' "${MOCK_PREFIX}"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
 EOF
 
     cat > "${WORKDIR}/bin/just" <<'EOF'
 #!/usr/bin/bash
 printf 'just %s\n' "$*" >> "${CALLS}"
+if [[ " $* " == *" --choose "* ]] && ! command -v fzf >/dev/null 2>&1; then
+    echo "ujust: fzf is unavailable for --choose" >&2
+    exit 127
+fi
 EOF
 
     chmod +x "${WORKDIR}/bin/brew" "${WORKDIR}/bin/just"
@@ -30,22 +44,86 @@ teardown() {
 }
 
 @test "ujust installs fzf before --choose when fzf is missing" {
-    run env PATH="${WORKDIR}/bin:/usr/bin:/bin" \
-        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" \
-        bash "${UJUST}" --choose
+    run /usr/bin/env PATH="${WORKDIR}/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" MOCK_PREFIX="${WORKDIR}/prefix" \
+        /usr/bin/bash "${UJUST}" --choose
 
     [ "${status}" -eq 0 ]
-    grep -qF "brew install fzf" "${WORKDIR}/calls.log"
-    grep -qF "brew shellenv" "${WORKDIR}/calls.log"
-    grep -qF "just --justfile /usr/share/ublue-os/just/00-entry.just --choose" "${WORKDIR}/calls.log"
+    install_line=$(grep -nF "brew install fzf" "${WORKDIR}/calls.log" | head -n1 | cut -d: -f1)
+    shellenv_line=$(grep -nF "brew shellenv" "${WORKDIR}/calls.log" | head -n1 | cut -d: -f1)
+    just_line=$(grep -nF "just --justfile /usr/share/ublue-os/just/00-entry.just --choose" "${WORKDIR}/calls.log" | head -n1 | cut -d: -f1)
+    [ -n "${install_line}" ]
+    [ -n "${shellenv_line}" ]
+    [ -n "${just_line}" ]
+    [ "${install_line}" -lt "${shellenv_line}" ]
+    [ "${shellenv_line}" -lt "${just_line}" ]
 }
 
 @test "ujust does not install fzf for other commands" {
-    run env PATH="${WORKDIR}/bin:/usr/bin:/bin" \
-        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" \
-        bash "${UJUST}" --list
+    run /usr/bin/env PATH="${WORKDIR}/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" MOCK_PREFIX="${WORKDIR}/prefix" \
+        /usr/bin/bash "${UJUST}" --list
 
     [ "${status}" -eq 0 ]
-    ! grep -qF "brew install fzf" "${WORKDIR}/calls.log"
+    [ "$(grep -cF "brew install fzf" "${WORKDIR}/calls.log" || true)" -eq 0 ]
     grep -qF "just --justfile /usr/share/ublue-os/just/00-entry.just --list" "${WORKDIR}/calls.log"
+}
+
+@test "ujust skips fzf install when fzf is already present" {
+    printf '#!/usr/bin/bash\nexit 0\n' > "${WORKDIR}/bin/fzf"
+    chmod +x "${WORKDIR}/bin/fzf"
+
+    run /usr/bin/env PATH="${WORKDIR}/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" MOCK_PREFIX="${WORKDIR}/prefix" \
+        /usr/bin/bash "${UJUST}" --choose
+
+    [ "${status}" -eq 0 ]
+    [ "$(grep -cF "brew install fzf" "${WORKDIR}/calls.log" || true)" -eq 0 ]
+    [ "$(grep -cF "brew shellenv" "${WORKDIR}/calls.log" || true)" -eq 0 ]
+    grep -qF "just --justfile /usr/share/ublue-os/just/00-entry.just --choose" "${WORKDIR}/calls.log"
+}
+
+@test "ujust fails when Homebrew is missing" {
+    run /usr/bin/env PATH="${WORKDIR}/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" MOCK_PREFIX="${WORKDIR}/prefix" \
+        BREW_BIN="${WORKDIR}/no-such-brew" \
+        /usr/bin/bash "${UJUST}" --choose
+
+    [ "${status}" -eq 127 ]
+    [ "$(grep -cF "brew install fzf" "${WORKDIR}/calls.log" || true)" -eq 0 ]
+    [ "$(grep -cF "just" "${WORKDIR}/calls.log" || true)" -eq 0 ]
+}
+
+@test "ujust fails when brew install fzf fails" {
+    cat > "${WORKDIR}/bin/brew" <<'EOF'
+#!/usr/bin/bash
+printf 'brew %s\n' "$*" >> "${CALLS}"
+exit 1
+EOF
+    chmod +x "${WORKDIR}/bin/brew"
+
+    run /usr/bin/env PATH="${WORKDIR}/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" MOCK_PREFIX="${WORKDIR}/prefix" \
+        /usr/bin/bash "${UJUST}" --choose
+
+    [ "${status}" -eq 1 ]
+    grep -qF "brew install fzf" "${WORKDIR}/calls.log"
+    [ "$(grep -cF "just" "${WORKDIR}/calls.log" || true)" -eq 0 ]
+}
+
+@test "ujust fails when brew shellenv fails" {
+    cat > "${WORKDIR}/bin/brew" <<'EOF'
+#!/usr/bin/bash
+printf 'brew %s\n' "$*" >> "${CALLS}"
+[[ "$1" == shellenv ]] && exit 1
+exit 0
+EOF
+    chmod +x "${WORKDIR}/bin/brew"
+
+    run /usr/bin/env PATH="${WORKDIR}/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" MOCK_PREFIX="${WORKDIR}/prefix" \
+        /usr/bin/bash "${UJUST}" --choose
+
+    [ "${status}" -ne 0 ]
+    [ "$(grep -cF "just" "${WORKDIR}/calls.log" || true)" -eq 0 ]
 }

--- a/tests/test_ujust.bats
+++ b/tests/test_ujust.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Tests for the ujust wrapper's on-demand fzf installation.
+
+UJUST="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/ujust"
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/bin"
+    : > "${WORKDIR}/calls.log"
+
+    cat > "${WORKDIR}/bin/brew" <<'EOF'
+#!/usr/bin/bash
+printf 'brew %s\n' "$*" >> "${CALLS}"
+if [[ "$1" == shellenv ]]; then
+    printf 'export PATH="%s:$PATH"\n' "${MOCK_BIN}"
+fi
+EOF
+
+    cat > "${WORKDIR}/bin/just" <<'EOF'
+#!/usr/bin/bash
+printf 'just %s\n' "$*" >> "${CALLS}"
+EOF
+
+    chmod +x "${WORKDIR}/bin/brew" "${WORKDIR}/bin/just"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+@test "ujust installs fzf before --choose when fzf is missing" {
+    run env PATH="${WORKDIR}/bin:/usr/bin:/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" \
+        bash "${UJUST}" --choose
+
+    [ "${status}" -eq 0 ]
+    grep -qF "brew install fzf" "${WORKDIR}/calls.log"
+    grep -qF "brew shellenv" "${WORKDIR}/calls.log"
+    grep -qF "just --justfile /usr/share/ublue-os/just/00-entry.just --choose" "${WORKDIR}/calls.log"
+}
+
+@test "ujust does not install fzf for other commands" {
+    run env PATH="${WORKDIR}/bin:/usr/bin:/bin" \
+        CALLS="${WORKDIR}/calls.log" MOCK_BIN="${WORKDIR}/bin" \
+        bash "${UJUST}" --list
+
+    [ "${status}" -eq 0 ]
+    ! grep -qF "brew install fzf" "${WORKDIR}/calls.log"
+    grep -qF "just --justfile /usr/share/ublue-os/just/00-entry.just --list" "${WORKDIR}/calls.log"
+}


### PR DESCRIPTION
## Summary
- install the Homebrew-managed `fzf` on demand when `ujust --choose` runs before brew-preinstall
- preserve existing behavior for all other ujust commands
- add Bats coverage for the on-demand install path

Fixes #861

## Validation
- `bats tests/test_ujust.bats`
- `just check`
- `just test`
- `shellcheck -S warning system_files/shared/usr/bin/ujust`
- `actionlint` workflow validation

`pre-commit run --all-files` is currently blocked by pre-existing untracked docs artifacts (`docs/skills/INDEX.md` front matter/index-link checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically installs the `fzf` utility when using `ujust --choose` and it isn’t available.
  * Continues supporting standard `ujust` commands without installing unnecessary tools.

* **Tests**
  * Added coverage verifying on-demand `fzf` installation and correct command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->