### PR TITLE
ci: free disk space in pr-e2e compose job to prevent ENOSPC

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Free disk space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+        with:
+          extra-squeeze: "true"
+
       - name: Generate tags
         id: image-meta
         shell: bash


### PR DESCRIPTION
## What

Adds `ublue-os/remove-unwanted-software@v10` (with `extra-squeeze: true`) as the first step after checkout in the `pr-e2e.yml` `compose` job.

## Why

The `compose` job runs on `ubuntu-latest` (no `setup-runner`, no BTRFS loopback), pulls `ghcr.io/projectbluefin/bluefin:testing` and builds a composed OCI image with buildah. Unpacking many layers onto a default runner with ~14 GB free is the same ENOSPC pattern identified in issue #796 for `dakota-iso`'s `build-iso-bluefin.yml`.

The `build.yml` already gets disk cleanup via `projectbluefin/actions/bootc-build/setup-runner` (calls `remove-unwanted-software@v10` with `extra-squeeze: true`). The `pr-e2e.yml` compose job was the remaining workflow producing OCI artifacts on a runner without disk cleanup.

Uses the same SHA pin already present in the org's `setup-runner` action:
```
ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
```

Closes #796