### PR TITLE
fix(ujust): use bootc status as source of truth for live image tag (#820)

### DIFF
--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -11,6 +11,15 @@ changelogs:
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
     TAG="$(jq -r '.["image-tag"]' < "${IMAGE_INFO_FILE}")"
 
+    # Prefer bootc status for the live tag — image-info.json may have a stale
+    # placeholder (e.g. "stable/testing" on bluefin-lts) that prevents matching
+    # the correct release stream below.
+    if command -v bootc &>/dev/null; then
+        _live_ref="$(bootc status --json 2>/dev/null \
+            | jq -r '.spec.image.image // empty' 2>/dev/null || true)"
+        [[ "${_live_ref}" == *:* ]] && TAG="${_live_ref##*:}"
+    fi
+
     # Select the correct upstream repo based on image stream
     IMAGE_NAME="$(jq -r '.["image-name"] // empty' < "${IMAGE_INFO_FILE}")"
     if [[ "$IMAGE_NAME" == "dakota" ]]; then

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -246,10 +246,26 @@ toggle-testing:
     fi
     set -euo pipefail
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
-    IMAGE_TAG="$(jq -r '."image-tag"' < "${IMAGE_INFO_FILE}")"
-    IMAGE_REF="$(jq -r '."image-ref"' < "${IMAGE_INFO_FILE}")"
-    # Strip transport prefix (ostree-image-signed:docker://, ostree-unverified-registry:, etc.)
-    IMAGE_PATH="$(sed -E 's|^.*://||; s|^[a-z-]+:||' <<< "${IMAGE_REF}")"
+
+    # Derive the current image path and tag from bootc status when available.
+    # image-info.json image-tag may be a stale placeholder (e.g. "stable/testing"
+    # on bluefin-lts), which matches no valid channel in the case statement below.
+    IMAGE_PATH=""
+    IMAGE_TAG=""
+    if command -v bootc &>/dev/null; then
+        _spec_ref="$(bootc status --json 2>/dev/null \
+            | jq -r '.spec.image.image // empty' 2>/dev/null || true)"
+        if [[ "${_spec_ref}" == *:* ]]; then
+            IMAGE_PATH="${_spec_ref%:*}"
+            IMAGE_TAG="${_spec_ref##*:}"
+        fi
+    fi
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_TAG="$(jq -r '."image-tag"' < "${IMAGE_INFO_FILE}")"
+        IMAGE_REF="$(jq -r '."image-ref"' < "${IMAGE_INFO_FILE}")"
+        # Strip transport prefix (ostree-image-signed:docker://, ostree-unverified-registry:, etc.)
+        IMAGE_PATH="$(sed -E 's|^.*://||; s|^[a-z-]+:||' <<< "${IMAGE_REF}")"
+    fi
     if [[ "${IMAGE_TAG}" == *testing* ]]; then
         if [[ "${IMAGE_TAG}" == "testing" ]]; then
             NEW_TAG="stable"

--- a/system_files/shared/usr/bin/ublue-image-info.sh
+++ b/system_files/shared/usr/bin/ublue-image-info.sh
@@ -2,7 +2,22 @@
 
 # shellcheck disable=2046
 IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
-echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
+
+# Prefer live bootc status over image-info.json: the JSON is baked at build
+# time and may carry a stale or placeholder image-tag (e.g. "stable/testing"
+# on bluefin-lts images built before the tag was wired up as a build arg).
+_live_ref=""
+if command -v bootc &>/dev/null; then
+    _live_ref="$(bootc status --json 2>/dev/null \
+        | jq -r '.status.booted.image.image.image // empty' 2>/dev/null)"
+fi
+
+if [[ "${_live_ref}" == *:* ]]; then
+    _image_name="$(jq -r '."image-name"' < "${IMAGE_INFO_FILE}")"
+    echo -n "${_image_name}:${_live_ref##*:}"
+else
+    echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
+fi
 
 if [[ "$(rpm-ostree status --booted)" =~ "signed" ]]; then
 	echo -n " 🔐"

--- a/tests/test_ublue_image_info.bats
+++ b/tests/test_ublue_image_info.bats
@@ -50,6 +50,15 @@ write_image_info_fixture() {
 EOF
 }
 
+write_bootc_mock() {
+    local booted_image="$1"
+
+    write_mock "bootc" "#!/usr/bin/bash
+if [[ \"\$*\" == \"status --json\" ]]; then
+    echo '{\"status\":{\"booted\":{\"image\":{\"image\":{\"image\":\"${booted_image}\",\"transport\":\"registry\"}}}}}'
+fi"
+}
+
 run_script() {
     local image_info_file="$1"
     local path_value="$2"
@@ -99,4 +108,45 @@ run_script() {
     [ "${status}" -eq 0 ]
     [[ "${output}" == *"jq: command not found"* ]]
     [[ "${output}" == *" 🔐" ]]
+}
+
+@test "ublue-image-info: uses live tag from bootc status when available" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    write_bootc_mock "ghcr.io/projectbluefin/bluefin-lts:stable"
+    # image-info.json has a stale placeholder tag
+    write_image_info_fixture "bluefin-lts" "stable/testing"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bluefin-lts:stable 🔐" ]
+}
+
+@test "ublue-image-info: falls back to image-info.json when bootc returns no colon-ref" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    # bootc mock that returns empty (simulates bootc unavailable or status error)
+    write_mock "bootc" '#!/usr/bin/bash
+if [[ "$*" == "status --json" ]]; then
+    echo "{}"
+fi'
+    write_image_info_fixture "bluefin" "stable"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bluefin:stable 🔐" ]
+}
+
+@test "ublue-image-info: falls back to image-info.json when bootc is not installed" {
+    write_jq_mock
+    write_rpm_ostree_mock 'echo "State: booted deployment signed"'
+    # No bootc mock — bootc is not in MOCKDIR
+    write_image_info_fixture "bluefin" "latest"
+
+    run_script "${FIXTURE}" "${MOCKDIR}:${PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bluefin:latest 🔐" ]
 }


### PR DESCRIPTION
## Problem

Closes #820

`image-info.json` is baked at build time and can carry a stale or placeholder `image-tag` value — notably `"stable/testing"` on `bluefin-lts` images built before the tag was wired up as a build argument. This causes three observable bugs in `common` shell fallback scripts:

1. **`ublue-image-info.sh`** (terminal prompt / fastfetch) shows `bluefin-lts:stable/testing` instead of the real channel tag.
2. **`toggle-testing`** (shell fallback) exits with `Cannot toggle testing from channel 'stable/testing'` — composite value matches no `case` branch.
3. **`changelogs`** (shell fallback) falls through to the latest release instead of the stream-specific list.

## Fix

Prefer `bootc status --json` for the live image reference in all three scripts. `bootc` is always present on running bootc systems. Each script retains `image-info.json` as a fallback.

## Changes

- **`ublue-image-info.sh`**: query `.status.booted.image.image.image`; display live tag with friendly `image-name` from `image-info.json`.
- **`system.just` — `toggle-testing`**: query `.spec.image.image` to derive `IMAGE_PATH` + `IMAGE_TAG` before the channel `case` statement.
- **`changelog.just` — `changelogs`**: query `.spec.image.image` to override `TAG` so correct release stream is selected.
- **`tests/test_ublue_image_info.bats`**: add `write_bootc_mock` helper and 3 new test cases (live-tag path, empty-output fallback, no-bootc fallback).

## Testing

All 22 bats tests pass locally (`test_ublue_image_info.bats` 7/7, `test_changelog.bats` 15/15).