### PR TITLE
test(motd): add BATS coverage for ublue-motd double-execution guard

### DIFF
--- a/system_files/shared/etc/profile.d/ublue-motd.sh
+++ b/system_files/shared/etc/profile.d/ublue-motd.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-[ ! -e "$HOME"/.config/no-show-user-motd ] && ublue-motd
+[ ! -e "$HOME"/.config/no-show-user-motd ] && [ "${UBLUE_MOTD_SHOWN:-0}" != "1" ] && { export UBLUE_MOTD_SHOWN=1; ublue-motd; }

--- a/system_files/shared/usr/bin/ublue-motd
+++ b/system_files/shared/usr/bin/ublue-motd
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 
 MOTD_TEMPLATE_FILE="${MOTD_TEMPLATE_FILE:-/usr/share/ublue-os/motd/template.md}"
-. "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
+if [ -f "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}" ]; then
+  # shellcheck source=/dev/null
+  . "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
+fi
 
 if command -v tput >/dev/null 2>&1 && [ -t 1 ]; then
   cols=$(tput cols 2>/dev/null)

--- a/system_files/shared/usr/share/fish/vendor_conf.d/fish_greeting.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/fish_greeting.fish
@@ -1,5 +1,8 @@
 function fish_greeting
     if test ! -e $HOME/.config/no-show-user-motd
-        ublue-motd
+        if test -z "$UBLUE_MOTD_SHOWN" -or "$UBLUE_MOTD_SHOWN" != "1"
+            set -gx UBLUE_MOTD_SHOWN 1
+            ublue-motd
+        end
     end
 end

--- a/tests/test_ublue_motd.bats
+++ b/tests/test_ublue_motd.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# Tests for the legacy ublue-motd stack modified by PR #795
+# (double-execution guard and missing env.sh graceful handling):
+#   - system_files/shared/etc/profile.d/ublue-motd.sh
+#   - system_files/shared/usr/bin/ublue-motd
+#
+# Covers:
+#   1. First invocation runs ublue-motd and sets UBLUE_MOTD_SHOWN=1
+#   2. Second invocation (UBLUE_MOTD_SHOWN=1 already set) does NOT run again
+#   3. Invocation skipped when ~/.config/no-show-user-motd exists
+#   4. ublue-motd binary: sourcing env.sh skipped gracefully when file is missing
+#
+# Run: bats tests/test_ublue_motd.bats
+
+bats_require_minimum_version 1.5.0
+
+UBLUE_MOTD_PROFILE="${BATS_TEST_DIRNAME}/../system_files/shared/etc/profile.d/ublue-motd.sh"
+UBLUE_MOTD_BIN="${BATS_TEST_DIRNAME}/../system_files/shared/usr/bin/ublue-motd"
+
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/bin" "${WORKDIR}/home/.config"
+
+    # Mock ublue-motd — exits 0, records each invocation to a log
+    printf '#!/bin/sh\necho "ublue-motd $*" >> "%s/ublue-motd.log"\n' \
+        "${WORKDIR}" > "${WORKDIR}/bin/ublue-motd"
+    chmod +x "${WORKDIR}/bin/ublue-motd"
+
+    export HOME="${WORKDIR}/home"
+    export PATH="${WORKDIR}/bin:${PATH}"
+    unset UBLUE_MOTD_SHOWN
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# profile.d/ublue-motd.sh — first invocation
+# ---------------------------------------------------------------------------
+
+@test "ublue-motd.sh: first invocation runs ublue-motd" {
+    run bash "${UBLUE_MOTD_PROFILE}"
+    [ "${status}" -eq 0 ]
+    [ -f "${WORKDIR}/ublue-motd.log" ]
+}
+
+@test "ublue-motd.sh: first invocation exports UBLUE_MOTD_SHOWN=1" {
+    # Source in a wrapper script so we can inspect the exported variable
+    local wrapper="${WORKDIR}/check_shown.sh"
+    printf '#!/bin/bash\nsource "%s"\necho "${UBLUE_MOTD_SHOWN}"\n' \
+        "${UBLUE_MOTD_PROFILE}" > "${wrapper}"
+    chmod +x "${wrapper}"
+
+    run bash "${wrapper}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# profile.d/ublue-motd.sh — double-execution guard
+# ---------------------------------------------------------------------------
+
+@test "ublue-motd.sh: second invocation skipped when UBLUE_MOTD_SHOWN=1" {
+    # run inherits exported variables from the test process
+    export UBLUE_MOTD_SHOWN=1
+    run bash "${UBLUE_MOTD_PROFILE}"
+    # The &&-chain short-circuits (exit code may be non-zero); check behavior only
+    [ ! -f "${WORKDIR}/ublue-motd.log" ]
+}
+
+@test "ublue-motd.sh: two sequential sources only invoke ublue-motd once" {
+    local wrapper="${WORKDIR}/double_source.sh"
+    printf '#!/bin/bash\nsource "%s"\nsource "%s"\nwc -l < "%s/ublue-motd.log"\n' \
+        "${UBLUE_MOTD_PROFILE}" "${UBLUE_MOTD_PROFILE}" "${WORKDIR}" > "${wrapper}"
+    chmod +x "${wrapper}"
+
+    run bash "${wrapper}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# profile.d/ublue-motd.sh — opt-out via no-show-user-motd
+# ---------------------------------------------------------------------------
+
+@test "ublue-motd.sh: skipped when no-show-user-motd file exists" {
+    touch "${WORKDIR}/home/.config/no-show-user-motd"
+    run bash "${UBLUE_MOTD_PROFILE}"
+    # The &&-chain short-circuits (exit code may be non-zero); check behavior only
+    [ ! -f "${WORKDIR}/ublue-motd.log" ]
+}
+
+@test "ublue-motd.sh: no-show-user-motd takes priority even when UBLUE_MOTD_SHOWN is unset" {
+    touch "${WORKDIR}/home/.config/no-show-user-motd"
+    unset UBLUE_MOTD_SHOWN
+    run bash "${UBLUE_MOTD_PROFILE}"
+    [ ! -f "${WORKDIR}/ublue-motd.log" ]
+}
+
+# ---------------------------------------------------------------------------
+# usr/bin/ublue-motd — graceful skip when env.sh is missing
+# ---------------------------------------------------------------------------
+
+@test "ublue-motd binary: succeeds without error when env.sh does not exist" {
+    local template="${WORKDIR}/template.md"
+    echo "Hello MOTD" > "${template}"
+
+    # Mock envsubst — pass stdin through unchanged
+    printf '#!/bin/sh\ncat\n' > "${WORKDIR}/bin/envsubst"
+    chmod +x "${WORKDIR}/bin/envsubst"
+
+    # Mock glow — pass stdin through unchanged
+    printf '#!/bin/sh\ncat\n' > "${WORKDIR}/bin/glow"
+    chmod +x "${WORKDIR}/bin/glow"
+
+    run env \
+        PATH="${WORKDIR}/bin:${PATH}" \
+        MOTD_TEMPLATE_FILE="${template}" \
+        MOTD_ENV_SCRIPT="${WORKDIR}/nonexistent-env.sh" \
+        sh "${UBLUE_MOTD_BIN}"
+
+    [ "${status}" -eq 0 ]
+}
+
+@test "ublue-motd binary: sources env.sh when it exists" {
+    local template="${WORKDIR}/template.md"
+    echo 'Value: $TEST_VAR' > "${template}"
+
+    local env_sh="${WORKDIR}/env.sh"
+    printf 'TEST_VAR=hello_from_env\n' > "${env_sh}"
+
+    printf '#!/bin/sh\ncat\n' > "${WORKDIR}/bin/envsubst"
+    chmod +x "${WORKDIR}/bin/envsubst"
+
+    printf '#!/bin/sh\ncat\n' > "${WORKDIR}/bin/glow"
+    chmod +x "${WORKDIR}/bin/glow"
+
+    run env \
+        PATH="${WORKDIR}/bin:${PATH}" \
+        MOTD_TEMPLATE_FILE="${template}" \
+        MOTD_ENV_SCRIPT="${env_sh}" \
+        sh "${UBLUE_MOTD_BIN}"
+
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Adds `tests/test_ublue_motd.bats` to provide BATS test coverage for the behaviors introduced by PR #795 (`fix(motd): prevent double-execution and missing env.sh errors`), which was identified as missing test coverage in issue #845.

## Tests added (8 total)

**profile.d/ublue-motd.sh — first invocation:**
- First invocation runs `ublue-motd`
- First invocation exports `UBLUE_MOTD_SHOWN=1`

**profile.d/ublue-motd.sh — double-execution guard:**
- Second invocation with `UBLUE_MOTD_SHOWN=1` pre-set is a no-op
- Two sequential `source` calls only invoke `ublue-motd` once

**profile.d/ublue-motd.sh — opt-out:**
- Invocation skipped when `~/.config/no-show-user-motd` exists
- `no-show-user-motd` takes priority even when `UBLUE_MOTD_SHOWN` is unset

**usr/bin/ublue-motd binary:**
- Succeeds without error when `env.sh` does not exist (graceful skip)
- Sources `env.sh` normally when the file is present

## Test approach

Follows the mock + workdir pattern from `test_umotd_integration.bats`. A mock `ublue-motd` binary records invocations to a log file; tests assert presence or absence of that log to verify the guard logic.

Note: this branch includes the PR #795 changes since `ublue-motd.sh` and `ublue-motd` do not exist in `main` yet. Intended to land together with or after PR #795.

Closes #845