### PR TITLE
docs(security): retire SIGNING_SECRET from approved secrets inventory

### DIFF
--- a/docs/skills/secrets-policy.md
+++ b/docs/skills/secrets-policy.md
@@ -1,7 +1,7 @@
 ---
 name: secrets-policy
 version: "1.0"
-last_updated: "2026-07-20"
+last_updated: "2026-07-28"
 tags: [secrets, security, ci]
 description: >-
   Approved secrets inventory for the Bluefin factory. Use when adding a secret,
@@ -35,15 +35,13 @@ Additions require a **security review issue** in `projectbluefin/common` before 
 | `MERGERAPTOR_APP_ID` | GitHub App ID | common, dakota, bonedigger | MERGERAPTOR bot identity |
 | `MERGERAPTOR_PRIVATE_KEY` | GitHub App private key | common, dakota, bonedigger | MERGERAPTOR bot auth |
 | `CASD_CLIENT_KEY` | TLS client certificate key | dakota | BuildStream remote CAS auth |
-| `SIGNING_SECRET` | cosign private key | common | Legacy key-based image signing — pending keyless migration (#513) |
 
 ## Rules
 
 1. **No new PATs.** If you think you need a PAT, you don't. Use `GITHUB_TOKEN` or a GitHub App token.
 2. **No new secrets without a security review issue.** File an issue in `projectbluefin/common` tagged `kind/security` before provisioning or referencing any new secret name.
 3. **GitHub App tokens for cross-repo bot operations.** MERGERAPTOR and BLUEFINBOT are the approved bots. Adding a new bot requires maintainer approval.
-4. **`SIGNING_SECRET` is frozen.** It will be removed when keyless signing migration (#513) lands. Do not reference it in any new workflow.
-5. **Infrastructure keys** (`CASD_CLIENT_KEY`, Cloudflare R2 keys) are reviewed at provisioning time by org admins and frozen thereafter.
+4. **Infrastructure keys** (`CASD_CLIENT_KEY`, Cloudflare R2 keys) are reviewed at provisioning time by org admins and frozen thereafter.
 
 ## Enforcement
 


### PR DESCRIPTION
## Summary

The keyless OIDC signing migration (common#513 / common#595) is complete. `build.yml` now uses `id-token: write` and delegates to the `sign-and-publish` composite action in `projectbluefin/actions`. No active workflow references `SIGNING_SECRET` (zero grep hits in `.github/workflows/`).

## Changes

- **`docs/skills/secrets-policy.md`**: Remove `SIGNING_SECRET` row from the approved secrets table; remove the now-stale frozen-key rule (#4) and renumber; update `last_updated`.

The `release-promotion.md` skill already has the correct language (`SIGNING_SECRET removed — do not reference in new workflows`) and needs no update.

## What a maintainer still needs to do

This PR cannot delete the actual repository secret — that requires write access to repo settings. A maintainer should:
1. Go to **Settings → Secrets and variables → Actions**
2. Delete the `SIGNING_SECRET` secret

Once deleted, the orphaned credential can no longer be accidentally referenced or exposed.

Closes #848