### PR TITLE
fix(ujust): fall back to gum filter when fzf is not installed

### DIFF
--- a/system_files/shared/usr/bin/ujust
+++ b/system_files/shared/usr/bin/ujust
@@ -1,3 +1,11 @@
 #!/usr/bin/bash
 
+# fzf is the default just chooser but is not installed by default on Bluefin.
+# Fall back to gum filter (always present) so that `ujust --choose` works
+# out of the box. If the user later installs fzf (e.g. via brew) it takes
+# priority automatically via JUST_CHOOSER only when fzf is absent.
+if ! command -v fzf &>/dev/null && command -v gum &>/dev/null; then
+    export JUST_CHOOSER="gum filter --no-limit"
+fi
+
 just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"

--- a/tests/test_ujust.bats
+++ b/tests/test_ujust.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# Tests for system_files/shared/usr/bin/ujust
+#
+# Covers the fzf → gum-filter chooser fallback added to fix:
+#   https://github.com/projectbluefin/common/issues/861
+#
+# Run: bats tests/test_ujust.bats
+
+bats_require_minimum_version 1.5.0
+
+UJUST="${BATS_TEST_DIRNAME}/../system_files/shared/usr/bin/ujust"
+
+WORKDIR=""
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/bin"
+
+    # Stub just — records JUST_CHOOSER and argv to a log, then exits 0
+    cat > "${WORKDIR}/bin/just" << 'EOF'
+#!/bin/sh
+echo "JUST_CHOOSER=${JUST_CHOOSER}" >> "${WORKDIR}/just.log"
+echo "argv=$*" >> "${WORKDIR}/just.log"
+EOF
+    # WORKDIR is not expanded inside heredoc; write it via printf instead
+    printf '#!/bin/sh\necho "JUST_CHOOSER=${JUST_CHOOSER}" >> "%s/just.log"\necho "argv=$*" >> "%s/just.log"\n' \
+        "${WORKDIR}" "${WORKDIR}" > "${WORKDIR}/bin/just"
+    chmod +x "${WORKDIR}/bin/just"
+
+    export PATH="${WORKDIR}/bin:${PATH}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Chooser fallback: fzf absent, gum present → use gum filter
+# ---------------------------------------------------------------------------
+
+@test "ujust: sets JUST_CHOOSER=gum filter --no-limit when fzf absent and gum present" {
+    # Provide gum stub but NO fzf
+    printf '#!/bin/sh\n' > "${WORKDIR}/bin/gum"
+    chmod +x "${WORKDIR}/bin/gum"
+
+    run bash "${UJUST}"
+    [ "${status}" -eq 0 ]
+    grep -q 'JUST_CHOOSER=gum filter --no-limit' "${WORKDIR}/just.log"
+}
+
+# ---------------------------------------------------------------------------
+# Chooser passthrough: fzf present → do not override JUST_CHOOSER
+# ---------------------------------------------------------------------------
+
+@test "ujust: does not set JUST_CHOOSER when fzf is present" {
+    # Provide both fzf and gum stubs
+    printf '#!/bin/sh\n' > "${WORKDIR}/bin/fzf"
+    chmod +x "${WORKDIR}/bin/fzf"
+    printf '#!/bin/sh\n' > "${WORKDIR}/bin/gum"
+    chmod +x "${WORKDIR}/bin/gum"
+
+    run bash "${UJUST}"
+    [ "${status}" -eq 0 ]
+    # JUST_CHOOSER must be empty (not overridden)
+    grep -q 'JUST_CHOOSER=$' "${WORKDIR}/just.log"
+}
+
+# ---------------------------------------------------------------------------
+# Neither fzf nor gum: do not crash ujust itself, let just handle it
+# ---------------------------------------------------------------------------
+
+@test "ujust: does not set JUST_CHOOSER when neither fzf nor gum is present" {
+    # No fzf, no gum — ujust should still invoke just without modifying the env
+    run bash "${UJUST}"
+    [ "${status}" -eq 0 ]
+    grep -q 'JUST_CHOOSER=$' "${WORKDIR}/just.log"
+}
+
+# ---------------------------------------------------------------------------
+# Argument passthrough
+# ---------------------------------------------------------------------------
+
+@test "ujust: passes arguments through to just" {
+    run bash "${UJUST}" --list
+    [ "${status}" -eq 0 ]
+    grep -q 'argv=.*--list' "${WORKDIR}/just.log"
+}


### PR DESCRIPTION
## Problem

`ujust --choose` crashes on Bluefin with:
```
sh: line 1: fzf: command not found
error: chooser `fzf --multi ...` failed: exit status: 127
```

`just`'s default chooser is `fzf`, but `fzf` is not installed by default on Bluefin (it is available via brew, not as a system package).

Fixes #861.

## Fix

`gum` is always present on Bluefin — it is used throughout `shared.just`, `default.just`, `apps.just`, and several system scripts. `gum filter` reads recipe names from stdin and writes the selection to stdout, which is exactly the interface `just` expects from a chooser (`--no-limit` enables multi-select to match `fzf --multi`).

The fallback in `ujust` only activates when `fzf` is absent **and** `gum` is present, so:
- Users without `fzf` installed get a working interactive chooser immediately
- Users who install `fzf` (e.g. via `brew install fzf`) automatically get `fzf` back — no config needed
- Neither `JUST_CHOOSER` nor any justfile is modified when `fzf` is already available

## Changes

- **`system_files/shared/usr/bin/ujust`**: Export `JUST_CHOOSER=gum filter --no-limit` when `fzf` is absent and `gum` is present
- **`tests/test_ujust.bats`**: 4 BATS tests covering the fallback logic and argument passthrough

## Testing

```
bats tests/test_ujust.bats
1..4
ok 1 ujust: sets JUST_CHOOSER=gum filter --no-limit when fzf absent and gum present
ok 2 ujust: does not set JUST_CHOOSER when fzf is present
ok 3 ujust: does not set JUST_CHOOSER when neither fzf nor gum is present
ok 4 ujust: passes arguments through to just
```