### PR TITLE
fix(bling): rearm bash-preexec DEBUG trap on each prompt

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bling/bling.sh
+++ b/system_files/shared/usr/share/ublue-os/bling/bling.sh
@@ -67,3 +67,26 @@ if command -v mise >/dev/null 2>&1; then
     fi
   fi
 fi
+
+# Workaround for bash-preexec 0.6.0 + Fedora array PROMPT_COMMAND
+# (rcaloras/bash-preexec#186): when PROMPT_COMMAND is declared as an
+# indexed array (the Fedora/GNOME Terminal default), bash-preexec's
+# __bp_install can land inside the wrong array slot alongside starship
+# and leave the DEBUG trap unset.  Without the DEBUG trap, tools that
+# rely on bash-preexec (e.g. atuin) silently stop recording commands.
+# Re-arming the trap from a dedicated PROMPT_COMMAND entry ensures it
+# is always set before the next command executes.  Remove this block
+# once rcaloras/bash-preexec#186 is resolved upstream.
+if [ "${BLING_SHELL}" = "bash" ] && type __bp_preexec_invoke_exec >/dev/null 2>&1; then
+    __bling_rearm_debug_trap() { trap '__bp_preexec_invoke_exec "$_"' DEBUG; }
+    # PROMPT_COMMAND may be a plain string (most systems) or an indexed
+    # array (Fedora/GNOME Terminal).  Use declare -p to detect the type
+    # and append with the matching form.  eval hides the bash-only array
+    # append syntax from POSIX sh parsers.
+    # shellcheck disable=SC2039
+    if declare -p PROMPT_COMMAND 2>/dev/null | grep -q '^declare -a'; then
+        eval 'PROMPT_COMMAND+=(__bling_rearm_debug_trap)'
+    else
+        PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}__bling_rearm_debug_trap"
+    fi
+fi

--- a/tests/test_bling_sh.bats
+++ b/tests/test_bling_sh.bats
@@ -179,3 +179,70 @@ fi
     [ "$output" = "missing|missing|missing|missing" ]
     [ ! -s "$CALL_LOG" ]
 }
+
+# ---------------------------------------------------------------------------
+# bash-preexec DEBUG-trap rearm (issue #869)
+# When PROMPT_COMMAND is a bash indexed array (Fedora/GNOME Terminal default),
+# bash-preexec 0.6.0 may leave the DEBUG trap unset.  bling.sh appends
+# __bling_rearm_debug_trap so atuin and other bash-preexec users keep working.
+# ---------------------------------------------------------------------------
+
+@test "bling.sh appends __bling_rearm_debug_trap to array PROMPT_COMMAND when bash-preexec is active" {
+    run_bling '
+declare -a PROMPT_COMMAND=("existing_entry")
+__bp_preexec_invoke_exec() { :; }
+source "$BLING_SCRIPT"
+found=0
+for entry in "${PROMPT_COMMAND[@]}"; do
+    [ "$entry" = "__bling_rearm_debug_trap" ] && found=1 && break
+done
+printf "%d\n" "$found"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "1" ]
+}
+
+@test "bling.sh appends __bling_rearm_debug_trap to string PROMPT_COMMAND when bash-preexec is active" {
+    run_bling '
+PROMPT_COMMAND="existing_entry"
+__bp_preexec_invoke_exec() { :; }
+source "$BLING_SCRIPT"
+case "$PROMPT_COMMAND" in
+    *__bling_rearm_debug_trap*) printf "found\n" ;;
+    *) printf "missing\n" ;;
+esac'
+    [ "$status" -eq 0 ]
+    [ "$output" = "found" ]
+}
+
+@test "bling.sh preserves existing string PROMPT_COMMAND when appending rearm hook" {
+    run_bling '
+PROMPT_COMMAND="existing_entry"
+__bp_preexec_invoke_exec() { :; }
+source "$BLING_SCRIPT"
+case "$PROMPT_COMMAND" in
+    existing_entry*) printf "preserved\n" ;;
+    *) printf "lost\n" ;;
+esac'
+    [ "$status" -eq 0 ]
+    [ "$output" = "preserved" ]
+}
+
+@test "bling.sh __bling_rearm_debug_trap re-sets the bash-preexec DEBUG trap" {
+    run_bling '
+__bp_preexec_invoke_exec() { :; }
+source "$BLING_SCRIPT"
+if type __bling_rearm_debug_trap >/dev/null 2>&1; then
+    trap - DEBUG
+    __bling_rearm_debug_trap
+    trap_output="$(trap -p DEBUG)"
+    case "$trap_output" in
+        *__bp_preexec_invoke_exec*) printf "trap_set\n" ;;
+        *) printf "trap_missing\n" ;;
+    esac
+else
+    printf "skip\n"
+fi'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "trap_set" || "$output" == "skip" ]]
+}
+


### PR DESCRIPTION
Fixes #869

## Root cause

bash-preexec 0.6.0 combined with Fedora's array `PROMPT_COMMAND` (the default in GNOME Terminal on Fedora) causes `__bp_install` to land in the wrong `PROMPT_COMMAND` slot alongside `starship_precmd`. As a result the `DEBUG` trap is never set, and tools that depend on bash-preexec — most notably **atuin** — silently stop recording commands.

See: rcaloras/bash-preexec#186, ublue-os/bluefin#4081

## Fix

After all hooks are initialised, `bling.sh` now appends `__bling_rearm_debug_trap` to `PROMPT_COMMAND`. On every prompt the function runs `trap '__bp_preexec_invoke_exec "$_"' DEBUG`, ensuring the trap is always in place before the next command executes.

Two append paths handle both possible `PROMPT_COMMAND` forms:
- **Indexed array** (Fedora/GNOME Terminal): `eval 'PROMPT_COMMAND+=(__bling_rearm_debug_trap)'`
- **Plain string** (most other systems): semicolon-delimited append

`eval` is used to hide the bash-only array-append syntax from POSIX sh parsers. The entire block is guarded by `type __bp_preexec_invoke_exec` so it is a no-op when bash-preexec is not loaded.

## Tests added (`tests/test_bling_sh.bats`)

- Array `PROMPT_COMMAND`: rearm function appended as a new array element
- String `PROMPT_COMMAND`: rearm function appended, original value preserved
- `__bling_rearm_debug_trap` actually re-sets the `DEBUG` trap to `__bp_preexec_invoke_exec`

## Removal criteria

Drop the rearm block once rcaloras/bash-preexec#186 is resolved and the fix propagates to the Homebrew formula.