### PR TITLE
docs: document clanker-queue label and human-advisor repo model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,41 @@ This repository is the **shared OCI layer** consumed by all Bluefin image varian
 - For dakota changes: [projectbluefin/dakota](https://github.com/projectbluefin/dakota)
 - For shared system config (Aurora-compatible files): edit `system_files/shared/` directly in this repo
 
+## How this repo uses agents
+
+This repo is **human-first for issues.** Humans file issues, triage them, and decide what gets built.
+Automated agents (clanker, kubestellar-bot, etc.) implement approved work — they do not self-direct
+triage or close issues without human approval.
+
+### Queueing work for clanker
+
+Add the `clanker-queue` label to any triaged issue you want an autonomous agent to implement.
+
+```
+You (human): add clanker-queue  →  clanker picks it up and opens a PR
+```
+
+Requirements before adding `clanker-queue`:
+1. The issue must have at least one `kind/` label and one `area/` label set.
+2. The issue description must be clear enough for an agent to implement without follow-up questions.
+   Vague issues stay in `clanker-queue` indefinitely — no agent will guess at the spec.
+
+To add the label via CLI:
+```bash
+gh issue edit <number> --repo projectbluefin/common --add-label clanker-queue
+```
+
+### Where other automation lives
+
+Broader factory automation (E2E testing, image promotion gating, regression detection) is
+handled in [projectbluefin/testing](https://github.com/projectbluefin/testing), not here.
+If you want to improve automated test coverage or CI pipelines, that's the right place.
+
+### Full label and lifecycle docs
+
+See [`docs/skills/label-workflow.md`](docs/skills/label-workflow.md) for the complete label
+taxonomy, slash commands (`/approve`, `/claim`, `/unclaim`), and the agent–human handoff model.
+
 ## CI
 
 PRs require only `validate-just` and `build` to pass — no expensive VM boots. Full layer validation (`common` behave suite via [`projectbluefin/testsuite`](https://github.com/projectbluefin/testsuite)) runs automatically on every merge to main.

--- a/docs/skills/label-workflow.md
+++ b/docs/skills/label-workflow.md
@@ -1,8 +1,8 @@
 ---
 name: label-workflow
-version: "1.0"
-last_updated: "2026-06-23"
-tags: [labels, issues, workflow]
+version: "1.1"
+last_updated: "2026-07-28"
+tags: [labels, issues, workflow, clanker]
 description: >-
   Label taxonomy, issue lifecycle (filed→triage→queued→claimed→done), slash
   commands, and the agent/human handoff model for projectbluefin factory
@@ -22,6 +22,7 @@ metadata:
 - [Agent workflow](#agent-workflow)
 - [Label reference](#label-reference)
 - [Epics](#epics)
+- [clanker-queue — human-directed agent work](#clanker-queue--human-directed-agent-work)
 
 ---
 
@@ -391,6 +392,7 @@ Applied to issues or PRs to request a specific agent workflow. The agent removes
 
 | Label | Meaning |
 |---|---|
+| `clanker-queue` | Human-directed: route this issue to the clanker autonomous agent. See [clanker-queue](#clanker-queue--human-directed-agent-work). |
 | `ai-context` | ACMM audit finding — AI/LLM context gap that improves agent reliability org-wide |
 | `stale` | No recent activity; will auto-close unless updated |
 | `stale-digest` | Filed against an outdated image digest — may not reproduce on current build |
@@ -456,5 +458,61 @@ Do not set these labels manually unless the workflow is down.
 2. Comment `/approve`
 3. Done — automation queues it immediately
 
+**I want to hand an issue directly to clanker:**
+1. Make sure the issue has `kind/` + `area/` labels and a clear spec
+2. Add `clanker-queue` label
+3. Done — clanker picks it up on its next run
+
 **I need to stop automation from touching something:**
 → Comment `/hold` with a reason, or add `status/hold` manually
+
+---
+
+## clanker-queue — human-directed agent work
+
+`clanker-queue` is the label that routes an issue to the clanker autonomous agent.
+
+### This repo is human-first
+
+`projectbluefin/common` uses a **human-advisor model**: humans own issue filing, triage, and
+approval. Agents implement approved work. Bots do not self-triage, self-approve, or close
+issues without explicit human sign-off.
+
+Broader factory automation (E2E testing, image promotion gating, regression detection) runs in
+[projectbluefin/testing](https://github.com/projectbluefin/testing).
+
+### When to use clanker-queue
+
+Add `clanker-queue` when:
+- The issue is fully triaged (has `kind/` + `area/` + a clear implementation spec)
+- You want clanker specifically (not just any contributor or agent via `status/queued`)
+- The work is self-contained enough for autonomous implementation
+
+### How clanker-queue differs from status/queued
+
+| | `status/queued` | `clanker-queue` |
+|---|---|---|
+| Who picks it up | Any contributor or agent via `/claim` | Clanker specifically |
+| Set by | `/approve` slash command | Human maintainer directly |
+| Lifecycle integration | Full widget + stale sweep | Separate; clanker manages its own claim |
+| Use when | Normal factory workflow | You specifically want clanker |
+
+Both labels can coexist. A maintainer can add `clanker-queue` to an issue that already has
+`status/queued` to fast-path it to clanker without removing it from the general pool.
+
+### Adding clanker-queue
+
+Via the GitHub UI: add the label from the issue sidebar.
+
+Via CLI:
+```bash
+gh issue edit <number> --repo projectbluefin/common --add-label clanker-queue
+```
+
+### Prerequisites before adding clanker-queue
+
+An issue without these will sit idle in the queue — clanker will not guess at a missing spec:
+- [ ] At least one `kind/` label
+- [ ] At least one `area/` label
+- [ ] Issue body contains a clear, actionable description (no open design questions)
+- [ ] No `status/hold` or `agent/blocked` — those block all agent work


### PR DESCRIPTION
# bluefin-common PR

## What does this change?

Documents the `clanker-queue` label and the human-advisor issue model for this repo.

## Why?

Closes #877

The repo is moving to a human-first model for issues. Humans file and triage; agents implement approved work. The `clanker-queue` label was already created but undocumented — contributors and agents had no way to know it existed or how to use it.

**CONTRIBUTING.md** — new "How this repo uses agents" section:
- Explains the human-advisor model (humans own issues, agents implement)
- Documents the `clanker-queue` label: when to use it, requirements before adding it, CLI command
- Notes that broader factory automation lives in `projectbluefin/testing`

**docs/skills/label-workflow.md** — three additions:
- `clanker-queue` entry in the Special and automation labels table
- Quick-reference entry: "I want to hand an issue directly to clanker"
- New `clanker-queue` section at the end documenting the label in full (when to use, how it differs from `status/queued`, prerequisites)

## PR pipeline

```
opened ──▶ review ──▶ approved ──▶ merged
                    [lgtm]      auto-merge
                                when CI green
```

## Checklist

- [x] PR title follows Conventional Commits (`docs:`)
- [ ] `just check` passes (tooling unavailable in this environment)
- [ ] `pre-commit run --all-files` passes (tooling unavailable in this environment)
- [x] Skill doc updated (`docs/skills/label-workflow.md`)
- [x] `AGENTS.md` / `docs/SKILL.md` / `docs/skills/` links remain valid
- [ ] CI is green after push

## AI attribution

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
