### PR TITLE
fix: add consistent bootc sudo policy

### DIFF
--- a/system_files/shared/etc/sudoers.d/001-bootc
+++ b/system_files/shared/etc/sudoers.d/001-bootc
@@ -1,0 +1,1 @@
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/bootc update, /usr/bin/bootc status, /usr/bin/bootc upgrade


### PR DESCRIPTION
Adds the shared `/etc/sudoers.d/001-bootc` rule for wheel users, allowing passwordless `bootc update`, `bootc status`, and `bootc upgrade`. This restores the policy previously provided by `ublue-polkit-rules` and addresses #142.