### PR TITLE
fix: guard ublue-fastfetch when fastfetch is missing

### DIFF
--- a/system_files/shared/usr/bin/ublue-fastfetch
+++ b/system_files/shared/usr/bin/ublue-fastfetch
@@ -1,5 +1,9 @@
 #!/usr/bin/bash
 
+if ! command -v fastfetch >/dev/null 2>&1; then
+	exit 0
+fi
+
 get_config() {
 	FASTFETCH_CONFIG_FILE="${FASTFETCH_CONFIG_FILE:-/etc/ublue-os/fastfetch.json}"
 	QUERY="$1"

--- a/tests/test_ublue_fastfetch.bats
+++ b/tests/test_ublue_fastfetch.bats
@@ -57,6 +57,13 @@ teardown() {
     ! grep -q -- "--logo" "${WORKDIR}/fastfetch.log"
 }
 
+@test "ublue-fastfetch: exits cleanly when fastfetch is unavailable" {
+    mkdir -p "${WORKDIR}/empty-bin"
+    run env PATH="${WORKDIR}/empty-bin" /bin/bash "${SCRIPT_UNDER_TEST}"
+    [ "${status}" -eq 0 ]
+    [ ! -f "${WORKDIR}/fastfetch.log" ]
+}
+
 @test "ublue-fastfetch: passes --config value from json to fastfetch" {
     run bash "${SCRIPT_UNDER_TEST}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
The common layer ships the `ublue-fastfetch` wrapper but does not install the `fastfetch` package in every consumer, such as Dakota. Guard the wrapper so missing fastfetch exits cleanly instead of emitting `exec: fastfetch: not found`, and add a regression test.

Closes #550