### PR TITLE
fix(bonedigger): cleanup trap returns 0 so report exits cleanly

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Run bats (oem-brew hook)
         run: bats tests/test_oem_brew.bats
 
+      - name: Run bats (bonedigger-report)
+        run: bats tests/test_bonedigger_report.bats
+
       - name: Smoke-test brew bundle accepts preinstall Brewfile (real Homebrew)
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,7 @@ test:
     bats tests/test_geoclue_latitude.bats
     bats tests/test_brew_preinstall.bats
     bats tests/test_oem_brew.bats
+    bats tests/test_bonedigger_report.bats
     bats tests/test_hardware_hooks.bats
     bats tests/test_nvidia_flatpak_sync.bats
 

--- a/docs/skills/bonedigger.md
+++ b/docs/skills/bonedigger.md
@@ -111,3 +111,34 @@ directory and removes that directory via `trap cleanup EXIT`. Any optional local
 copy (`summary.md`, `journal.txt`, OTEL attachments) must be copied to a stable
 location before the script exits, and copy failures must never abort a
 successful gist upload.
+
+### EXIT trap return value becomes the script's exit code (2026-07-29)
+
+`cleanup()` was registered via `trap cleanup EXIT`, and its last statement was
+`[[ -n "$OTEL_STDERR" ]] && rm -f "$OTEL_STDERR"`. `OTEL_STDERR` is always empty
+at exit (reset to `""` after the OTEL block), so the `[[ -n "" ]]` test returned
+1 and `cleanup` returned 1. The happy path has no `trap - EXIT` or `exit 0`
+(unlike every other exit path), so `cleanup`'s return code became the script's
+final exit code. `just` saw exit 1 and printed `recipe 'report' failed with
+exit code 1` even though the report fully succeeded.
+
+**Convention:** any function registered to an `EXIT` trap must end with
+`return 0` so it can never override a successful script's exit status. Do not
+rely on every exit path remembering to `trap - EXIT` first — the trap itself
+must be safe to run.
+
+### Fixes must land in common, not the bonedigger repo (2026-07-29)
+
+`projectbluefin/bonedigger` once held `just/report.just`; PR bonedigger#25
+("fix(report): cleanup trap exits 0 when OTEL was not used") fixed the cleanup
+exit code there and closed common#655. But `just/report.just` in the
+bonedigger repo is now a stale `.gitkeep` — the canonical implementation dakota
+and its siblings ship is `common/system_files/bluefin/usr/libexec/bonedigger-report`,
+which never received the fix. The bug persisted for end users for over a month
+after the "fix" merged.
+
+**Convention:** the real script lives in `common`. A fix to `ujust report`
+behavior must edit `common/system_files/bluefin/usr/libexec/bonedigger-report`
+(and/or `60-bonedigger.just`). The `bonedigger` repo holds lifecycle automation
+and templates, not the shipped script. When closing an issue, verify the fix
+landed in the file that actually ships in the image.

--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -94,6 +94,7 @@ cleanup() {
     rm -rf "$REPORT_DIR"
     [[ -n "$OTEL_CONFIG" ]] && rm -f "$OTEL_CONFIG"
     [[ -n "$OTEL_STDERR" ]] && rm -f "$OTEL_STDERR"
+    return 0
 }
 trap cleanup EXIT
 

--- a/tests/test_bonedigger_report.bats
+++ b/tests/test_bonedigger_report.bats
@@ -165,3 +165,26 @@ INNER_EOF
     result="$(echo "User /home/alice/ connected from 192.168.1.5 (MAC: AA:BB:CC:DD:EE:FF)" | "$TEST_HELPER" scrub_kernel_log)"
     [ "$result" = "User /home/[REDACTED]/ connected from [IP-REDACTED] (MAC: [MAC-REDACTED])" ]
 }
+
+@test "cleanup trap returns 0 when OTEL was not used (regression for exit-code-1)" {
+    # The happy path leaves OTEL_CONFIG and OTEL_STDERR empty. The EXIT trap
+    # runs cleanup() as the last statement, so its return value becomes the
+    # script's exit code. Before the fix, the final [[ -n "$OTEL_STDERR" ]]
+    # test returned 1, making just print "recipe 'report' failed with exit
+    # code 1" even though the report fully succeeded.
+    CLEANUP_HELPER="$(mktemp)"
+    cat << 'INNER_EOF' > "$CLEANUP_HELPER"
+#!/usr/bin/bash
+set -euo pipefail
+eval "$(sed -n '/^cleanup() {/,/^}/p' "$BONEDIGGER_SCRIPT")"
+REPORT_DIR="$1"
+OTEL_CONFIG=""
+OTEL_STDERR=""
+cleanup
+INNER_EOF
+    chmod +x "$CLEANUP_HELPER"
+
+    run "$CLEANUP_HELPER" "$WORKDIR"
+    [ "$status" -eq 0 ]
+    rm -f "$CLEANUP_HELPER"
+}


### PR DESCRIPTION
# bluefin-common PR

## What does this change?

Appends `return 0` to the `cleanup()` EXIT trap in `system_files/bluefin/usr/libexec/bonedigger-report` so `ujust report` exits 0 on success instead of 1.

## Why?

`ujust report` fully succeeds (gist uploaded, browser opened) but prints `recipe 'report' failed with exit code 1` because the trap's last statement — `[[ -n "$OTEL_STDERR" ]] && rm -f ...` — returns 1 on an always-empty variable, and the happy path has no `trap - EXIT` to neutralize it.

Triggered by [dakota#940](https://github.com/projectbluefin/dakota/issues/940). This supersedes [bonedigger#25](https://github.com/projectbluefin/bonedigger/pull/25), which correctly fixed this in `just/report.just` in the bonedigger repo on 2026-06-13. Twelve hours later, [bonedigger#26](https://github.com/projectbluefin/bonedigger/pull/26) centralized the report recipe into common as `system_files/bluefin/usr/libexec/bonedigger-report` and deleted the bonedigger copy — but the fix was not re-applied to the new common file, regressing the bug. [common#655](https://github.com/projectbluefin/common/issues/655) stayed closed while the bug returned.

## PR pipeline

```
opened ──▶ review ──▶ approved ──▶ merged
                    [lgtm]      auto-merge
                                when CI green
```

> Add `do-not-merge` at any time to block automation.
> `/approve` or `lgtm` from a maintainer triggers merge queue.

## Checklist

- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`, `ci:`, `refactor:`, etc.)
- [x] `just check` passes
- [x] `pre-commit run --all-files` passes
- [x] Skill doc updated if the change affects agent-facing conventions or behavior (see `docs/skills/skill-improvement.md`)
- [x] `AGENTS.md` / `docs/SKILL.md` / `docs/skills/` links remain valid
- [ ] CI is green after push: `gh run list --repo projectbluefin/common --limit 5`

## AI attribution

```
Assisted-by: GLM 5.2 via opencode
```