### PR TITLE
feat(brew): re-enable ChairLift bootc staging via system-integration split

### DIFF
--- a/docs/skills/brew-lifecycle.md
+++ b/docs/skills/brew-lifecycle.md
@@ -191,13 +191,19 @@ cask "chairlift"
 ChairLift is a GTK4 system-management GUI (Homebrew, Flatpak, bootc).
 Its Bluefin maintainer config ships at
 `system_files/shared/usr/share/chairlift/config.yml` (admin override:
-`/etc/chairlift/config.yml`); bootc staging and updex stay disabled
-until frostyard/chairlift#54 resolves the polkit integration. Guarded
-by `tests/test_chairlift_config.py`. The cask is now reviewable from the
-common side because the upstream ChairLift release assets include the needed
-`data/` files and arm64 tarballs; the remaining dependency for full Brewfile
-validation is the upstream Homebrew tap PR publishing the cask to the
-Homebrew resolvers that CI uses.
+`/etc/chairlift/config.yml`). frostyard/chairlift#54 resolved via the
+system-integration split (frostyard/chairlift#102): Bluefin now ships the
+fixed `/usr/libexec/bootc-update-stage` helper and the bootc PolicyKit
+policy under `system_files/shared/usr/share/polkit-1/actions/`, so
+`bootc_updates_group` is enabled (staging only —
+`bootc upgrade --download-only`; applying stays with the user's own
+reboot or uupd's background policy). `features_group` (updex) stays
+disabled — no updex helper ships on Bluefin yet, independent of the
+polkit fix. Guarded by `tests/test_chairlift_config.py`. The cask is now
+reviewable from the common side because the upstream ChairLift release
+assets include the needed `data/` files and arm64 tarballs; the remaining
+dependency for full Brewfile validation is the upstream Homebrew tap PR
+publishing the cask to the Homebrew resolvers that CI uses.
 
 ### Add a variant-specific Brewfile
 

--- a/system_files/shared/usr/libexec/bootc-update-stage
+++ b/system_files/shared/usr/libexec/bootc-update-stage
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# bootc-update-stage — privileged helper invoked via ChairLift's fixed
+# org.frostyard.ChairLift.bootc.stage polkit action (pkexec exec.path is
+# pinned to this exact path; see
+# system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy).
+#
+# Downloads and stages the next bootc system image update. It intentionally
+# does NOT pass --apply: the update is only staged and applies on the next
+# reboot, on the user's own schedule. uupd remains the owner of Bluefin's
+# background update policy; this script only backs ChairLift's manual
+# "check for updates now" action.
+#
+# Contract: no arguments are read or required. Any arguments pkexec may
+# forward are ignored so this cannot be used to run arbitrary bootc
+# subcommands through a privileged invocation.
+set -euo pipefail
+
+# --download-only stages the update without applying it or rebooting;
+# --apply/--from-downloaded remain the user's own action (or uupd's), not
+# this helper's.
+exec /usr/bin/bootc upgrade --quiet --download-only

--- a/system_files/shared/usr/share/chairlift/config.yml
+++ b/system_files/shared/usr/share/chairlift/config.yml
@@ -12,10 +12,14 @@ system_page:
     app_id: io.missioncenter.MissionCenter
 
 updates_page:
-  # Staged bootc updates need polkit glue Bluefin does not ship yet.
-  # Tracked upstream: https://github.com/frostyard/chairlift/issues/54
+  # frostyard/chairlift#54 resolved via the system-integration split
+  # (frostyard/chairlift#102): the fixed /usr/libexec/bootc-update-stage
+  # path is now backed by an image-side stage script, and the bootc polkit
+  # policy ships in system_files/shared/usr/share/polkit-1/actions/. Staging
+  # only (bootc upgrade --download-only); applying still happens on the
+  # user's own reboot, or via uupd's background policy.
   bootc_updates_group:
-    enabled: false
+    enabled: true
   flatpak_updates_group:
     enabled: true
   brew_updates_group:
@@ -57,8 +61,9 @@ maintenance_page:
     enabled: true
 
 features_page:
-  # updex is not present on Bluefin; the pkexec helper also needs polkit
-  # files a user-scope install cannot provide (frostyard/chairlift#54).
+  # updex is not present on Bluefin. Unlike bootc staging, no updex helper
+  # ships on the image, so this stays off regardless of the polkit fix in
+  # frostyard/chairlift#54 — flip only if/when updex ever ships on Bluefin.
   features_group:
     enabled: false
 

--- a/system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
+++ b/system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<policyconfig>
+  <vendor>Frostyard</vendor>
+  <vendor_url>https://github.com/frostyard/chairlift</vendor_url>
+  <icon_name>org.frostyard.ChairLift</icon_name>
+
+  <action id="org.frostyard.ChairLift.bootc.stage">
+    <description>Download and stage a system image update</description>
+    <message>Authentication is required to stage a system update</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/bootc-update-stage</annotate>
+  </action>
+
+</policyconfig>

--- a/tests/test_chairlift_config.py
+++ b/tests/test_chairlift_config.py
@@ -2,8 +2,11 @@
 
 ChairLift (https://github.com/frostyard/chairlift) reads
 /usr/share/chairlift/config.yml for maintainer defaults. These tests pin
-the Bluefin decisions: features that need polkit glue stay disabled until
-frostyard/chairlift#54 is resolved, bundle paths point at Bluefin's
+the Bluefin decisions: frostyard/chairlift#54 resolved via the
+system-integration split (frostyard/chairlift#102), so bootc staging is
+now backed by an image-side polkit policy and stage script and
+bootc_updates_group is enabled. updex (features_group) stays disabled
+because no updex helper ships on Bluefin. Bundle paths point at Bluefin's
 Brewfiles, and help links point at Bluefin resources.
 """
 
@@ -18,6 +21,12 @@ BREWFILE = (
     ROOT
     / "system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile"
 )
+BOOTC_POLICY = (
+    ROOT
+    / "system_files/shared/usr/share/polkit-1/actions"
+    / "org.frostyard.ChairLift.bootc.policy"
+)
+BOOTC_STAGE_SCRIPT = ROOT / "system_files/shared/usr/libexec/bootc-update-stage"
 
 # Pages and groups documented in upstream CONFIG.md. Anything outside this
 # set is silently ignored by ChairLift, so it is a typo until proven otherwise.
@@ -68,12 +77,51 @@ def test_config_parses_and_uses_known_pages_and_groups():
             )
 
 
-def test_polkit_dependent_groups_stay_disabled():
-    """bootc staging and updex need /usr/share/polkit-1 files Bluefin does
-    not ship. Keep them off until frostyard/chairlift#54 is resolved."""
+def test_bootc_staging_enabled_now_that_polkit_glue_ships():
+    """frostyard/chairlift#54 resolved via the system-integration split
+    (frostyard/chairlift#102): Bluefin now ships the fixed
+    /usr/libexec/bootc-update-stage helper and the bootc polkit policy, so
+    bootc_updates_group can be enabled."""
     data = _load_config()
-    assert data["updates_page"]["bootc_updates_group"]["enabled"] is False
+    assert data["updates_page"]["bootc_updates_group"]["enabled"] is True
+
+
+def test_updex_features_group_stays_disabled():
+    """updex has no Bluefin helper yet, independent of the bootc polkit
+    fix. Keep it off until updex actually ships on Bluefin."""
+    data = _load_config()
     assert data["features_page"]["features_group"]["enabled"] is False
+
+
+def test_bootc_stage_polkit_policy_pins_fixed_helper_path():
+    """The polkit action must annotate the exact fixed path ChairLift's
+    pkexec invocation expects; auth is still required (auth_admin), so no
+    passwordless rules.d bypass should exist alongside it."""
+    content = BOOTC_POLICY.read_text(encoding="utf-8")
+    assert "org.frostyard.ChairLift.bootc.stage" in content
+    assert (
+        '<annotate key="org.freedesktop.policykit.exec.path">'
+        "/usr/libexec/bootc-update-stage</annotate>" in content
+    )
+    assert "<allow_any>auth_admin</allow_any>" in content
+
+
+def test_bootc_stage_script_is_executable_and_stages_only():
+    """The privileged helper must only stage (never auto-apply/reboot) so
+    uupd remains the sole owner of when an update actually takes effect."""
+    assert BOOTC_STAGE_SCRIPT.stat().st_mode & 0o111, (
+        "bootc-update-stage must be executable"
+    )
+    exec_lines = [
+        line
+        for line in BOOTC_STAGE_SCRIPT.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("exec ")
+    ]
+    assert len(exec_lines) == 1, "expected exactly one exec invocation"
+    (exec_line,) = exec_lines
+    assert "bootc upgrade" in exec_line
+    assert "--download-only" in exec_line
+    assert "--apply" not in exec_line
 
 
 def test_update_policy_stays_with_uupd():


### PR DESCRIPTION
Closes #855.

## What
frostyard/chairlift#54 (polkit integration blocker) resolved via frostyard/chairlift#102, which shipped **option (b)** from the issue: a `frostyard-chairlift-system-integration` package with fixed privileged paths, rather than a configurable stage-script path or fully upstreamed script. The distro (Bluefin) is still responsible for providing `/usr/libexec/bootc-update-stage` itself — upstream does not ship one.

This PR ships that image-side glue and flips the config flag per issue #855's step 2/3:

- **`system_files/shared/usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy`** — verbatim copy of upstream's bootc PolicyKit action (`auth_admin` / `auth_admin_keep`, no passwordless rule — matches ChairLift's own "no passwordless PolicyKit rules" posture).
- **`system_files/shared/usr/libexec/bootc-update-stage`** — new privileged helper, invoked only via the polkit action above (pkexec pins the exec path). It's a thin wrapper: `bootc upgrade --download-only`. It intentionally never applies/reboots — staging only. Applying still belongs to the user's own reboot, or uupd's existing background policy; this does not add any new update-scheduling behavior.
- **`config.yml`** — `bootc_updates_group.enabled: true`. `features_page.features_group` (updex) stays **disabled**: no updex helper ships on Bluefin yet, independent of this fix, so that part of #855 is intentionally left for a future PR.
- **`tests/test_chairlift_config.py`** — replaced `test_polkit_dependent_groups_stay_disabled` (now pins the opposite decision) with tests asserting: bootc staging is enabled, updex stays disabled, the polkit policy pins the fixed helper path with `auth_admin`, and the stage script is executable and only ever invokes `bootc upgrade --download-only` (no `--apply`).
- **`docs/skills/brew-lifecycle.md`** — updated to describe the resolved state instead of "disabled until #54 resolves."

## Why this is safe
- No passwordless PolicyKit rule is added — every staging invocation still requires `auth_admin` (the user authenticates), matching upstream's default and README's "ChairLift does not install passwordless PolicyKit rules" statement.
- The helper script takes no arguments and only ever execs one fixed, non-interactive `bootc upgrade --download-only` command — it cannot be used to run arbitrary bootc subcommands even if pkexec forwards args.
- Staging never applies/reboots — uupd remains the sole owner of when an update actually takes effect, matching Bluefin's "silent staging, user reboots on their own schedule" policy from issue #853/#855.

## Base branch note
This targets `feat/chairlift-preinstall` (PR #853), not `main` — `config.yml` and `tests/test_chairlift_config.py` only exist on that branch today (PR #853 is still open). This PR should land after/alongside #853, whichever order the maintainers prefer.

## Security review
Per `docs/skills/human-gates.md`, this touches a privileged pkexec/PolicyKit path and needs explicit maintainer security review before merge — flagging that here rather than self-approving.

## Testing
- `python3 -m pytest tests/test_chairlift_config.py -v` — 9/9 pass (full `tests/` pytest suite: 79/79 pass).
- Validated the PolicyKit XML parses (`xml.dom.minidom`).
- `shellcheck`/`bats` were not available in this sandbox; the new script has no unmanaged inputs (no args processed) and was reviewed by hand against the existing `brew-preinstall` libexec script's style.

Assisted-by: Claude Sonnet 5 via GitHub Copilot
