### PR TITLE
ci: stop running E2E on docs-only pushes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,9 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**.md"
+      - "docs/**"
+      - "AGENTS.md"
       - "LICENSE"
       - ".gitignore"
       - ".gitattributes"


### PR DESCRIPTION
## What

Adds `docs/**`, `AGENTS.md`, and `**.md` to `e2e.yml`'s `paths-ignore`, matching what `build.yml` already does.

## Why

`e2e.yml` ignores `"*.md"`, which in GitHub Actions matches only markdown **at the repository root**. It does not match `docs/skills/workflow-map.md` or anything else under `docs/`.

`build.yml` already ignores `docs/**` and `AGENTS.md`. `e2e.yml` was never updated to match.

So every documentation change on `main` boots **three VMs** and runs the full common suite against `bluefin:lts-testing`, `bluefin:testing`, and `dakota:testing`.

**Three of the last six E2E runs on `main` were triggered by docs-only commits:**

| Run commit | Content | Could it validate the layer? |
|---|---|---|
| `1b353bc` | docs-only | no |
| `56944dd` | real change | yes |
| `c7b4a71` | real change | yes |
| `057d213` | docs-only | no |
| `bf0a49f` | docs-only | no |
| `862c077` | real change | yes |

## Note

`**.md` is added because that is what `"*.md"` was presumably intended to do — match markdown at any depth.

No change to what E2E validates on real changes.

## Verification

`just check` and `pre-commit run --all-files` pass, including `actionlint`.