### PR TITLE
ci: make the advisory E2E signal mean something

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,9 +31,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Bluefin LTS
-            image: ghcr.io/projectbluefin/bluefin:lts-testing
-            suites: common
+          # Bluefin LTS is deliberately absent. Its common suite fails on every
+          # run (bootupd missing, bootloader-update.service failing,
+          # LockLayering blocking rpm-ostree) — see
+          # https://github.com/projectbluefin/bluefin-lts/issues/492.
+          #
+          # A permanently red advisory check teaches everyone to ignore it, and
+          # GitHub does not allow `continue-on-error` on a job that calls a
+          # reusable workflow, so the entry cannot simply be soft-failed here.
+          #
+          # LTS is still covered: promotion-candidate-e2e.yml runs `smoke,common`
+          # against bluefin:lts-testing every Tuesday. Restore this entry once
+          # bluefin-lts#492 is fixed.
           - name: Bluefin Stable
             image: ghcr.io/projectbluefin/bluefin:testing
             suites: common
@@ -48,3 +57,57 @@ jobs:
     with:
       image: ${{ matrix.image }}
       suites: ${{ matrix.suites }}
+
+  # This workflow is advisory — it is not a required check and does not gate
+  # publication (common:latest is already pushed by the time it runs). Without
+  # a report, a red run is only visible to whoever happens to open the Actions
+  # tab; it went unnoticed for four days in July 2026. This reports, it does
+  # not block.
+  report-failure:
+    name: "Report E2E failure"
+    needs: [e2e]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          TITLE="ci: post-merge E2E is failing on main"
+
+          # Post-merge runs are frequent, so reuse one tracking issue rather
+          # than filing a new one per merge.
+          existing=$(gh issue list --repo "$REPO" --state open --limit 100 \
+            --json number,title \
+            | jq -r --arg t "$TITLE" '[.[] | select(.title == $t)][0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "Still failing on \`${SHA:0:7}\` — ${RUN_URL}"
+            echo "Updated existing issue #${existing}"
+            exit 0
+          fi
+
+          gh issue create --repo "$REPO" --title "$TITLE" --label "1-triage" --body \
+          "Post-merge E2E failed on \`${SHA:0:7}\`.
+
+          Run: ${RUN_URL}
+
+          This workflow is **advisory** — it is not a required check and does not
+          gate publication. \`common:latest\` was already pushed before this ran,
+          so a failure here means a regression is already shipped, not that a
+          release was blocked.
+
+          It exercises the downstream \`*-testing\` images, so the cause may be in
+          a downstream base image rather than in \`system_files/\`. Check which
+          matrix entry failed before assuming otherwise.
+
+          This issue is reused for subsequent failures. Close it once the run is
+          green again."

--- a/docs/skills/index.json
+++ b/docs/skills/index.json
@@ -657,7 +657,7 @@
         "reference"
       ],
       "description": "What each GitHub workflow in common is for. Use when editing workflows, debugging CI, or understanding pipeline stages.",
-      "version": "2.1",
+      "version": "2.2",
       "last_updated": "2026-08-02",
       "doc_type": "reference"
     },

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-map
-version: "2.1"
+version: "2.2"
 last_updated: "2026-08-02"
 id: workflow-map
 one_line_purpose: Understand what each GitHub workflow in common does.
@@ -33,7 +33,7 @@ Load this when you need to understand **what each GitHub workflow in `projectblu
 | `unit-tests.yml` | Runs `pytest` + `bats` on `system_files/**`, `tests/**`, and the `Justfile`. Triggers on PR, push to `main`, and `merge_group`. | Adding or changing unit tests, or changing the paths they cover |
 | `build.yml` | Builds and publishes the `common` OCI layer on merge. Runs parallel per-arch jobs (x86_64 on `ubuntu-24.04`, aarch64 on `ubuntu-24.04-arm`). Build uses rootless `buildah-build`; after build, `sudo skopeo copy` promotes the image into root storage so `push-image` (which uses `sudo podman push`) can find it. Then a `manifest` job assembles the multi-arch manifest, logs into GHCR, signs with keyless OIDC, generates SBOM, and attests SLSA L2. Downstream propagation is handled by Renovate (bluefin/bluefin-lts, ~3h) and dakota's daily cron — there is no direct dispatch from this workflow. | Changing how the shared layer is built or pushed |
 | `pr-e2e.yml` | Pre-merge composed-image gate for the PR's common layer (composes + runs common suite via `run-testsuite.yml`) | Changing how PR-time downstream composition is tested |
-| `e2e.yml` | Post-merge, **advisory** common-suite validation. Tests the downstream `*-testing` images (`bluefin:lts-testing`, `bluefin:testing`, `dakota:testing`) — not the layer just built. Triggers on `push: main` in parallel with `build.yml`, is **not** a required check, and does **not** gate publication: `common:latest` is pushed regardless of the result. Treat it as regression detection for downstream, not as a publication gate. | Changing shipped-layer validation after merge |
+| `e2e.yml` | Post-merge, **advisory** common-suite validation. Tests the downstream `*-testing` images (`bluefin:testing`, `dakota:testing`) — not the layer just built. Triggers on `push: main` in parallel with `build.yml`, is **not** a required check, and does **not** gate publication: `common:latest` is pushed regardless of the result. On failure it opens or updates a single tracking issue. **Bluefin LTS is deliberately excluded** while [bluefin-lts#492](https://github.com/projectbluefin/bluefin-lts/issues/492) is open — it failed every run, and GitHub does not allow `continue-on-error` on a reusable-workflow call, so it could not be soft-failed in place. LTS is still covered weekly by `promotion-candidate-e2e.yml`. | Changing shipped-layer validation after merge |
 | `run-testsuite.yml` | Local wrapper that centralizes the pinned `projectbluefin/testsuite` SHA | Updating the shared testsuite pin or common-side testsuite wiring |
 | `promotion-candidate-e2e.yml` | Weekly smoke/common check against `bluefin:testing` and `bluefin:lts-testing` | Adjusting common-side signal before downstream Tuesday promotions |
 | `scorecard.yml` | Weekly OpenSSF Scorecard analysis. Runs on schedule and on push to main. Uploads SARIF to the GitHub Security tab. | Adjusting security posture reporting |


### PR DESCRIPTION
Implements the decision to **keep post-merge E2E advisory**.

That contract is right: `e2e.yml` exercises downstream `*-testing` images, so making it block would let a defect `common` doesn't own halt `common`'s releases. The publication-blocking gate is `pr-e2e.yml`, pre-merge.

But an advisory check is only worth having if it's **green when healthy** and **someone hears about it when it isn't**. Neither was true.

## 1. It was red on every single run

Bluefin LTS has failed continuously since at least 2026-07-29 — `bootupd` missing during `bootc install`, `bootloader-update.service` failing, `LockLayering=true` blocking `rpm-ostree`. Tracked in projectbluefin/bluefin-lts#492.

With one entry permanently red, the workflow was permanently red — no merge distinguishable from any other.

### The obvious fix doesn't exist

GitHub does **not** allow `continue-on-error` on a job that calls a reusable workflow. Confirmed with actionlint:

```
when a reusable workflow is called with "uses", "continue-on-error" is not available.
only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", "permissions"
```

Both `e2e.yml` and `run-testsuite.yml` are `uses:` calls, so the LTS entry can't be soft-failed in place.

> Worth noting: the docs previously claimed Dakota was non-blocking via exactly this key. That wasn't just wrong — it was impossible. Removed in 1b353bc.

**So LTS is dropped from the post-merge matrix**, with a comment explaining why and when to restore it.

**Coverage is not lost.** `promotion-candidate-e2e.yml` already runs `smoke,common` against `bluefin:lts-testing` every Tuesday — a *broader* suite than the one dropped here.

## 2. Nothing reported the red

It went unnoticed for four days in July. Adds a `report-failure` job using the pattern already proven in `promotion-candidate-e2e.yml`.

Post-merge runs are frequent, so it **reuses one tracking issue** rather than filing per merge — finds an open issue with the same title and comments, otherwise opens one at `1-triage`.

The body states up front that publication already happened and that the cause may be downstream, so nobody reads it as a blocked release or starts by grepping `system_files/`.

## Not a gate

Per `agentic-model.md`, CI gates protect the image artifact. This runs *after* the artifact is published, so it reports and does not block.

## Verification

`just check`, `actionlint`, `shellcheck` on the report script, and `pre-commit run --all-files` all pass. `docs/skills/workflow-map.md` updated in the same PR.