### PR TITLE
fix(systemd): avoid rechunker local-fs ordering cycle

### DIFF
--- a/docs/skills/submodule-boundary.md
+++ b/docs/skills/submodule-boundary.md
@@ -84,11 +84,11 @@ As of [common#530](https://github.com/projectbluefin/common/pull/530), the servi
 
 ```ini
 DefaultDependencies=no
-Wants=local-fs.target
-After=local-fs.target
 After=bootc-sysusers-shadow-sync.service
 Before=systemd-sysusers.service
 ```
+
+Do **not** add `Wants=local-fs.target` or `After=local-fs.target`: this is an early-boot bridge and those edges can create an ordering cycle through `local-fs-pre.target`, `systemd-tmpfiles-setup-dev.service`, and `systemd-sysusers.service` during upgrades from legacy-rechunked images. The service's `/etc` file operations do not require all filesystem mounts to be complete.
 
 **Why:** `systemd-sysusers` is what fails if gshadow is corrupt. The service must run *before* sysusers, not after. `bootc-sysusers-shadow-sync.service` is the upstream fix shipped in bootc ≥1.16 ([bootc#2207](https://github.com/bootc-dev/bootc/pull/2207), merged May 2025); our service must run after it so they coexist correctly. `DefaultDependencies=no` is required for any early-boot unit.
 

--- a/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
+++ b/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
@@ -16,8 +16,6 @@
 Description=Fix groups for Legacy rechunker
 ConditionPathExists=/run/ostree-booted
 DefaultDependencies=no
-Wants=local-fs.target
-After=local-fs.target
 After=bootc-sysusers-shadow-sync.service
 Before=systemd-sysusers.service
 

--- a/tests/test_rechunker_group_fix.bats
+++ b/tests/test_rechunker_group_fix.bats
@@ -4,6 +4,7 @@
 # Run: bats tests/test_rechunker_group_fix.bats
 
 SCRIPT="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/rechunker-group-fix"
+UNIT="$BATS_TEST_DIRNAME/../system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service"
 WORKDIR=""
 
 setup() {
@@ -14,6 +15,18 @@ setup() {
 
 teardown() {
     rm -rf "${WORKDIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Unit ordering
+# ---------------------------------------------------------------------------
+
+@test "rechunker-group-fix service avoids local-fs ordering edges" {
+    ! grep -q '^Wants=local-fs\.target$' "${UNIT}"
+    ! grep -q '^After=local-fs\.target$' "${UNIT}"
+    grep -q '^DefaultDependencies=no$' "${UNIT}"
+    grep -q '^After=bootc-sysusers-shadow-sync\.service$' "${UNIT}"
+    grep -q '^Before=systemd-sysusers\.service$' "${UNIT}"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #918

## Summary

- remove `Wants=local-fs.target` and `After=local-fs.target` from the early-boot `rechunker-group-fix.service` bridge;
- preserve ordering after `bootc-sysusers-shadow-sync.service` and before `systemd-sysusers.service`;
- add Bats regression coverage for the unit ordering and document the invariant.

These local-fs edges can create an ordering cycle through `local-fs-pre.target`, `systemd-tmpfiles-setup-dev.service`, and `systemd-sysusers.service` when upgrading legacy-rechunked images. The bridge only operates on `/etc` and does not require all local filesystems to be mounted.

## Validation

- `git diff --check` passed.
- Focused Bats test could not run locally because `bats` is not installed in the environment.
- Full `just test` / `pre-commit run --all-files` could not run because `just`, `pre-commit`, and `pytest` are not installed.
