### PR TITLE
fix(report): preserve external queue preferences

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Run bats (oem-brew hook)
         run: bats tests/test_oem_brew.bats
 
+      - name: Run bats (bonedigger report)
+        run: bats tests/test_bonedigger_report.bats
+
       - name: Smoke-test brew bundle accepts preinstall Brewfile (real Homebrew)
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,7 @@ test:
     bats tests/test_geoclue_latitude.bats
     bats tests/test_brew_preinstall.bats
     bats tests/test_oem_brew.bats
+    bats tests/test_bonedigger_report.bats
     bats tests/test_hardware_hooks.bats
     bats tests/test_nvidia_flatpak_sync.bats
 

--- a/docs/skills/bonedigger.md
+++ b/docs/skills/bonedigger.md
@@ -1,7 +1,7 @@
 ---
 name: bonedigger
 version: "1.0"
-last_updated: "2026-07-30"
+last_updated: "2026-08-06"
 id: bonedigger
 one_line_purpose: Operate bonedigger and kubestellar-bot issue/report automation.
 entry_point: docs/skills/bonedigger.md
@@ -93,6 +93,12 @@ flow.
 Every payload is previewed locally. Submission requires explicit consent,
 uses `gh issue create` rather than a browser form, and offers final-submission
 queue preferences: `3-clanker-queue`, `3-human-queue`, or no queue label.
+GitHub silently drops labels requested by reporters without repository triage
+access, so the client also records a validated
+`bonedigger-queue-preference` marker in the issue body, including `none` when
+normal triage is selected. The write-enabled
+Bonedigger intake workflow applies that preference after creation. The direct
+`--label` argument remains as the fast path for reporters who do have access.
 Selected smart logs are
 published to a public gist only after that preview and consent. `gh` is
 required and authenticated; if it is absent, the user can consent to

--- a/docs/skills/index.json
+++ b/docs/skills/index.json
@@ -34,7 +34,7 @@
       ],
       "description": "bonedigger + kubestellar-bot lifecycle automation. Use when working on ujust report, issue lifecycle, priority escalation, or how fixes ship back to images.",
       "version": "1.0",
-      "last_updated": "2026-07-30",
+      "last_updated": "2026-08-06",
       "doc_type": "reference"
     },
     {

--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -522,6 +522,18 @@ queue_label_for_choice() {
     esac
 }
 
+save_queue_preference() {
+    local queue_label="$1"
+    local marker_value="${queue_label:-none}"
+
+    sed -i -E \
+        '/^<!-- bonedigger-queue-preference: (3-clanker-queue|3-human-queue|none) -->$/d' \
+        "$DRAFT_DIR/issue.md"
+    printf '%s\n' "$queue_label" > "$DRAFT_DIR/queue-label.txt"
+    printf '\n<!-- bonedigger-queue-preference: %s -->\n' "$marker_value" \
+        >> "$DRAFT_DIR/issue.md"
+}
+
 choose_queue_preference() {
     local queue_choice
     local queue_label
@@ -534,7 +546,7 @@ choose_queue_preference() {
         "Submit to the clanker queue for machine analysis" \
         "I only want human interaction")" || return
     queue_label="$(queue_label_for_choice "$queue_choice")" || return
-    printf '%s\n' "$queue_label" > "$DRAFT_DIR/queue-label.txt"
+    save_queue_preference "$queue_label"
 }
 
 parse_confirm_target() {

--- a/tests/test_bonedigger_report.bats
+++ b/tests/test_bonedigger_report.bats
@@ -78,6 +78,58 @@ teardown() {
     [ -z "$output" ]
 }
 
+@test "queue selection records one workflow-readable routing preference" {
+    cat << 'EOF' > "$WORKDIR/bin/gum"
+#!/usr/bin/bash
+case "$1" in
+    choose) printf 'Submit to the clanker queue for machine analysis\n' ;;
+    style) exit 0 ;;
+esac
+EOF
+    chmod +x "$WORKDIR/bin/gum"
+    mkdir -p "$WORKDIR/draft"
+    : > "$WORKDIR/draft/queue-label.txt"
+    printf '%s\n' \
+        '## Bluefin report' \
+        '<!-- bonedigger-queue-preference: 3-human-queue -->' \
+        > "$WORKDIR/draft/issue.md"
+
+    run env PATH="$WORKDIR/bin:$PATH" bash -c '
+        source "$1"
+        DRAFT_DIR="$2"
+        choose_queue_preference
+    ' _ "$BONEDIGGER_SCRIPT" "$WORKDIR/draft"
+
+    [ "$status" -eq 0 ]
+    [ "$(< "$WORKDIR/draft/queue-label.txt")" = "3-clanker-queue" ]
+    [ "$(grep -cF '<!-- bonedigger-queue-preference: 3-clanker-queue -->' "$WORKDIR/draft/issue.md")" -eq 1 ]
+    ! grep -qF '<!-- bonedigger-queue-preference: 3-human-queue -->' "$WORKDIR/draft/issue.md"
+}
+
+@test "no queue preference still records ujust report intake" {
+    cat << 'EOF' > "$WORKDIR/bin/gum"
+#!/usr/bin/bash
+case "$1" in
+    choose) printf 'No queue preference\n' ;;
+    style) exit 0 ;;
+esac
+EOF
+    chmod +x "$WORKDIR/bin/gum"
+    mkdir -p "$WORKDIR/draft"
+    : > "$WORKDIR/draft/queue-label.txt"
+    printf '## Bluefin report\n' > "$WORKDIR/draft/issue.md"
+
+    run env PATH="$WORKDIR/bin:$PATH" bash -c '
+        source "$1"
+        DRAFT_DIR="$2"
+        choose_queue_preference
+    ' _ "$BONEDIGGER_SCRIPT" "$WORKDIR/draft"
+
+    [ "$status" -eq 0 ]
+    [ -z "$(< "$WORKDIR/draft/queue-label.txt")" ]
+    grep -qF '<!-- bonedigger-queue-preference: none -->' "$WORKDIR/draft/issue.md"
+}
+
 @test "network smart logs are redacted and bounded" {
     cat << 'EOF' > "$WORKDIR/bin/journalctl"
 #!/usr/bin/bash


### PR DESCRIPTION
# bluefin-common PR

## What does this change?

Carry every `ujust report` queue choice in a validated issue-body marker so write-enabled Bonedigger intake can recover labels GitHub drops for external contributors.

## Why?

GitHub silently discards labels supplied during issue creation by reporters without repository triage access. The command currently reports success while losing the selected route, and a read-only contributor cannot repair it manually.

Depends on projectbluefin/bonedigger#34, which should merge first.

Closes #935

## PR pipeline

```
opened ──▶ 4-review ──▶ approved ──▶ merged
```

> A maintainer reviews and approves; merge goes through the merge queue.
> Select `blocked` or `hold` to pause the work.

## Validation

- `just build` on Bluefin via Podman: passed; produced `localhost/bluefin-common:latest` with digest `sha256:1d406678f358377b0924db1ee7e08804d1e5673aa21e22fe4d16d848455cf308`
- `just test` in an ephemeral Ubuntu 24.04 container: passed, including all 18 Bonedigger report tests
- `just check`: passed
- `shellcheck -S warning system_files/bluefin/usr/libexec/bonedigger-report`: passed
- `actionlint .github/workflows/unit-tests.yml`: passed
- `pre-commit run --all-files`: passed
- The new tests were observed failing before implementation, then passing after the marker transport was added
- [Fork Unit Tests run 31125282605](https://github.com/joshyorko/common/actions/runs/31125282605): queued; not counted as a pass

The generated skill indexes and missing `queue-feed` router entry are included because upstream `main` already failed the mandatory skill-index pre-commit hooks; the minimal catalog repair restores a clean required gate.

## Checklist

- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`, `ci:`, `refactor:`, etc.)
- [x] `just check` passes
- [x] `pre-commit run --all-files` passes
- [x] Skill doc updated if the change affects agent-facing conventions or behavior (see `docs/skills/skill-improvement.md`)
- [x] `AGENTS.md` / `docs/SKILL.md` / `docs/skills/` links remain valid
- [ ] CI is green after push: `gh run list --repo projectbluefin/common --limit 5`

## AI attribution

The commit includes both required attribution trailers.
