### PR TITLE
fix(brew): correct linuxbrew prefix spelling and preinstall tap ordering

### DIFF
--- a/docs/skills/brew-lifecycle/SKILL.md
+++ b/docs/skills/brew-lifecycle/SKILL.md
@@ -114,7 +114,7 @@ Desktop integration ships from the image, not the cask. Homebrew has one
 shared prefix, so the cask's `~/.local/share` desktop entry and icons only
 ever reach the first user to run `brew bundle`. `common` ships the upstream
 desktop file at `/usr/share/applications/org.frostyard.ChairLift.desktop`
-(`Exec=/var/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper`) and the three
+(`Exec=/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper`) and the three
 upstream icons under `/usr/share/icons/hicolor/`, so every user gets a
 launcher.
 

--- a/docs/skills/brew-lifecycle/references/placement-rules.md
+++ b/docs/skills/brew-lifecycle/references/placement-rules.md
@@ -114,8 +114,8 @@ into the image). Each shell initializes it with a silent fallback:
 ```sh
 if command -v starship >/dev/null 2>&1; then
     _starship_bin="starship"
-elif [ -x "/var/home/linuxbrew/.linuxbrew/bin/starship" ]; then
-    _starship_bin="/var/home/linuxbrew/.linuxbrew/bin/starship"
+elif [ -x "/home/linuxbrew/.linuxbrew/bin/starship" ]; then
+    _starship_bin="/home/linuxbrew/.linuxbrew/bin/starship"
 else
     return 0  # silent fallback to default prompt
 fi

--- a/docs/skills/brew-lifecycle/references/service-mechanics.md
+++ b/docs/skills/brew-lifecycle/references/service-mechanics.md
@@ -17,7 +17,7 @@ systemd unit. The actual brew packages are installed at **first user login**.
 `network-online.target` and `ublue-user-setup.service`. It is enabled globally
 via `usr/lib/systemd/user-preset/01-brew-preinstall.preset`. Downstream repos
 do **not** need `systemctl --global enable` calls. The service only runs when
-brew is installed at `/var/home/linuxbrew/.linuxbrew/bin/brew`.
+brew is installed at `/home/linuxbrew/.linuxbrew/bin/brew`.
 
 ### State file
 
@@ -164,7 +164,7 @@ To keep them that way they are excluded from `end-of-file-fixer` and
 `check-added-large-files` in `.pre-commit-config.yaml`; upstream's two scalable
 icons carry no trailing newline and exceed the 500 KiB default, and vendored
 assets are not re-encoded. `Exec` points at
-`/var/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper`: the wrapper sets up the
+`/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper`: the wrapper sets up the
 Homebrew environment that a GDM-launched session PATH lacks, and `/var/home` is
 the real path (`/home` is a symlink on bootc systems). The per-user copies the
 cask still writes for the first user are harmless duplicates of the same entry.

--- a/docs/skills/oem-hardware-hooks/references/hook-patterns.md
+++ b/docs/skills/oem-hardware-hooks/references/hook-patterns.md
@@ -14,7 +14,7 @@ will never retry on future logins.
 
 ```bash
 # Check ALL transient preconditions before calling version-script
-BREW_BIN="/var/home/linuxbrew/.linuxbrew/bin/brew"
+BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
 if [[ ! -x "${BREW_BIN}" ]]; then
     echo "hook: brew not found, will retry on next login"
     exit 0   # ← exit 0 to retry; version-script not yet called

--- a/docs/skills/qa.md
+++ b/docs/skills/qa.md
@@ -91,7 +91,7 @@ See each repo's AGENTS.md for repo-specific test commands. Common entry points:
 
 ### Testing `update.just` on GitHub Actions
 
-`tests/test_update_just.bats` must avoid `bwrap` bind-mount tricks for `/etc` and `/var/home` on GitHub-hosted runners. Use PATH mocks for `systemctl`, `sudo`, `bootc`, `flatpak`, `gum`, and `grep`, and keep the assertions focused on the bootc, flatpak, and toggle-updates branches that are reliable in CI. Parameterize the extracted brew path inside the test harness so a host-owned `/var/home/linuxbrew/.linuxbrew/bin/brew` cannot make the brew-absent branch nondeterministic on local machines.
+`tests/test_update_just.bats` must avoid `bwrap` bind-mount tricks for `/etc` and `/var/home` on GitHub-hosted runners. Use PATH mocks for `systemctl`, `sudo`, `bootc`, `flatpak`, `gum`, and `grep`, and keep the assertions focused on the bootc, flatpak, and toggle-updates branches that are reliable in CI. Parameterize the extracted brew path inside the test harness so a host-owned `/home/linuxbrew/.linuxbrew/bin/brew` cannot make the brew-absent branch nondeterministic on local machines.
 
 ```bash
 # common

--- a/system_files/shared/usr/bin/ujust
+++ b/system_files/shared/usr/bin/ujust
@@ -10,7 +10,7 @@ done
 
 if [[ "${CHOOSE}" == true ]] && ! command -v fzf >/dev/null 2>&1; then
     BREW_BIN="${BREW_BIN:-$(command -v brew 2>/dev/null || true)}"
-    BREW_BIN="${BREW_BIN:-/var/home/linuxbrew/.linuxbrew/bin/brew}"
+    BREW_BIN="${BREW_BIN:-/home/linuxbrew/.linuxbrew/bin/brew}"
 
     if [[ ! -x "${BREW_BIN}" ]]; then
         echo "ujust: fzf is missing and Homebrew was not found" >&2

--- a/system_files/shared/usr/lib/systemd/user/brew-preinstall.service
+++ b/system_files/shared/usr/lib/systemd/user/brew-preinstall.service
@@ -3,7 +3,7 @@ Description=Preinstall OS-managed Homebrew packages
 After=network-online.target ublue-user-setup.service
 Wants=network-online.target
 ConditionUser=!@system
-ConditionPathExists=/var/home/linuxbrew/.linuxbrew/bin/brew
+ConditionPathExists=/home/linuxbrew/.linuxbrew/bin/brew
 StartLimitIntervalSec=600
 
 [Service]

--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -14,7 +14,7 @@ set -euo pipefail
 
 PREINSTALL_DIR="/usr/share/ublue-os/homebrew/preinstall.d"
 STATE_FILE="${HOME}/.local/share/ublue-os/brew-preinstall-state.json"
-BREW_BIN="/var/home/linuxbrew/.linuxbrew/bin/brew"
+BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
 
 if [[ ! -x "${BREW_BIN}" ]]; then
     echo "brew-preinstall: brew not found at ${BREW_BIN}, skipping"
@@ -48,14 +48,43 @@ eval "$("${BREW_BIN}" shellenv)"
 
 echo "brew-preinstall: Brewfiles changed (${current_hash:0:12}...), applying..."
 
+# Install every tap before any bundle runs. brew bundle decides cask
+# installability before processing the Brewfile's own tap lines, so on a
+# system that has never seen the tap it skips the cask as "requires macOS"
+# and still exits 0 — the cask is silently never installed (first boot of
+# any image shipping a tap+cask pair, e.g. frostyard/tap + chairlift).
+tap_failed=0
+while IFS= read -r tap; do
+    [[ -z "${tap}" ]] && continue
+    echo "brew-preinstall: tapping ${tap}"
+    if ! brew tap "${tap}"; then
+        echo "brew-preinstall: error: tapping ${tap} failed"
+        tap_failed=1
+    fi
+done < <(sed -nE \
+    -e "s/^[[:space:]]*tap[[:space:]]+\"([^\"]+)\".*/\\1/p" \
+    -e "s/^[[:space:]]*tap[[:space:]]+'([^']+)'.*/\\1/p" \
+    "${brewfiles[@]}" | sort -u)
+
+if [[ "${tap_failed}" -ne 0 ]]; then
+    echo "brew-preinstall: one or more taps failed; state unchanged, will retry"
+    exit 1
+fi
+
 # Install all packages declared in Brewfiles (brew bundle is idempotent).
 # Continue after an individual failure so independent Brewfiles still install,
 # but leave state untouched so the complete run is retried.
 bundle_failed=0
 for brewfile in "${brewfiles[@]}"; do
     echo "brew-preinstall: bundling ${brewfile}"
-    if ! brew bundle --file="${brewfile}"; then
+    bundle_output=$(brew bundle --file="${brewfile}" 2>&1 | tee /dev/stderr) || {
         echo "brew-preinstall: error: bundling ${brewfile} failed"
+        bundle_failed=1
+    }
+    # A skipped cask is a silent no-op that exits 0; treat it as a failure
+    # so state stays unstamped and the run retries instead of never.
+    if grep -q "^Skipping cask" <<< "${bundle_output}"; then
+        echo "brew-preinstall: error: ${brewfile} skipped a cask; treating as failure"
         bundle_failed=1
     fi
 done

--- a/system_files/shared/usr/share/applications/org.frostyard.ChairLift.desktop
+++ b/system_files/shared/usr/share/applications/org.frostyard.ChairLift.desktop
@@ -10,7 +10,7 @@
 # makes ChairLift appear for all users; see
 # docs/skills/brew-lifecycle/references/service-mechanics.md.
 Name=ChairLift
-Exec=/var/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper
+Exec=/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper
 Icon=org.frostyard.ChairLift
 Terminal=false
 Type=Application

--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -34,9 +34,9 @@ update:
         flatpak update --user -y
     fi
     # Guard Brew if the user does not own brew/doesn't exist
-    if [[ -O /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
+    if [[ -O /home/linuxbrew/.linuxbrew/bin/brew ]]; then
         # Upgrade will run brew update if needed
-        /var/home/linuxbrew/.linuxbrew/bin/brew upgrade
+        /home/linuxbrew/.linuxbrew/bin/brew upgrade
     fi
 
 alias auto-update := toggle-updates

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-oem-brew.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/20-oem-brew.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 source /usr/lib/ublue/setup-services/libsetup.sh
 
-BREW_BIN="/var/home/linuxbrew/.linuxbrew/bin/brew"
+BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
 OEM_DIR="/usr/share/ublue-os/oem"
 
 # Normalize DMI vendor strings to canonical oem/ directory name.

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -49,7 +49,7 @@ BREWMOCK
     # Patch hardcoded paths in the script to temp-dir equivalents
     PATCHED_SCRIPT="${WORKDIR}/brew-preinstall"
     sed \
-        -e "s|/var/home/linuxbrew/.linuxbrew/bin/brew|${WORKDIR}/bin/brew|g" \
+        -e "s|/home/linuxbrew/.linuxbrew/bin/brew|${WORKDIR}/bin/brew|g" \
         -e "s|/usr/share/ublue-os/homebrew/preinstall.d|${WORKDIR}/preinstall.d|g" \
         "${BREW_PREINSTALL}" > "${PATCHED_SCRIPT}"
     chmod +x "${PATCHED_SCRIPT}"
@@ -549,4 +549,63 @@ BREWMOCK
     [ "${stored_hash}" = "oldhash" ]
     pkgs="$(jq -r '.packages[]' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json")"
     [[ "${pkgs}" == *"fd"* ]]
+}
+
+@test "brew-preinstall: taps all Brewfile taps before any bundle runs" {
+    printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' \
+        > "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^brew tap frostyard/tap$" "${WORKDIR}/brew.log"
+    first_bundle=$(grep -n "^brew bundle" "${WORKDIR}/brew.log" | head -1 | cut -d: -f1)
+    tap_line=$(grep -n "^brew tap frostyard/tap$" "${WORKDIR}/brew.log" | head -1 | cut -d: -f1)
+    [ "${tap_line}" -lt "${first_bundle}" ]
+}
+
+@test "brew-preinstall: skipped cask marks the run failed so it retries" {
+    printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' \
+        > "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+
+    cat > "${WORKDIR}/bin/brew" << BREWMOCK
+#!/usr/bin/env bash
+BREW_LOG="\${BREW_LOG:-/dev/null}"
+printf 'brew %s\n' "\$*" >> "\${BREW_LOG}"
+case "\$1" in
+    shellenv) printf 'export PATH="%s:\${PATH}"\n' "${WORKDIR}/bin" ;;
+    bundle)   echo "Skipping cask chairlift (requires macOS)" ;;
+    list)     exit 0 ;;
+    uninstall) ;;
+esac
+BREWMOCK
+    chmod +x "${WORKDIR}/bin/brew"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"skipped a cask"* ]]
+    [ ! -f "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" ]
+}
+
+@test "brew-preinstall: failed tap aborts before bundling and leaves state unstamped" {
+    printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' \
+        > "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+
+    cat > "${WORKDIR}/bin/brew" << BREWMOCK
+#!/usr/bin/env bash
+BREW_LOG="\${BREW_LOG:-/dev/null}"
+printf 'brew %s\n' "\$*" >> "\${BREW_LOG}"
+case "\$1" in
+    shellenv) printf 'export PATH="%s:\${PATH}"\n' "${WORKDIR}/bin" ;;
+    tap)      exit 1 ;;
+    list)     exit 0 ;;
+esac
+BREWMOCK
+    chmod +x "${WORKDIR}/bin/brew"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"will retry"* ]]
+    ! grep -q "^brew bundle" "${WORKDIR}/brew.log"
+    [ ! -f "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" ]
 }

--- a/tests/test_chairlift_config.py
+++ b/tests/test_chairlift_config.py
@@ -50,7 +50,7 @@ ICONS = (
     ICON_ROOT / "symbolic/apps/org.frostyard.ChairLift-symbolic.svg",
 )
 #: Homebrew's shared prefix on Bluefin. The cask links chairlift-wrapper here.
-CHAIRLIFT_WRAPPER = "/var/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper"
+CHAIRLIFT_WRAPPER = "/home/linuxbrew/.linuxbrew/bin/chairlift-wrapper"
 
 #: bootc flags the privileged helper must never carry. --apply and
 #: --soft-reboot reboot the machine; --download-only locks finalization so

--- a/tests/test_oem_brew.bats
+++ b/tests/test_oem_brew.bats
@@ -64,7 +64,7 @@ _patched_script() {
     local patched_script="${WORKDIR}/oem-brew-patched.sh"
     sed \
         -e "s|source /usr/lib/ublue/setup-services/libsetup.sh|source ${LIBSETUP_REAL}|" \
-        -e "s|BREW_BIN=\"/var/home/linuxbrew/.linuxbrew/bin/brew\"|BREW_BIN=\"${WORKDIR}/bin/brew\"|" \
+        -e "s|BREW_BIN=\"/home/linuxbrew/.linuxbrew/bin/brew\"|BREW_BIN=\"${WORKDIR}/bin/brew\"|" \
         -e "s|OEM_DIR=\"/usr/share/ublue-os/oem\"|OEM_DIR=\"${WORKDIR}/oem\"|" \
         -e "s|/sys/devices/virtual/dmi/id/chassis_vendor|${WORKDIR}/sys/devices/virtual/dmi/id/chassis_vendor|g" \
         -e "s|/sys/devices/virtual/dmi/id/sys_vendor|${WORKDIR}/sys/devices/virtual/dmi/id/sys_vendor|g" \

--- a/tests/test_update_just.bats
+++ b/tests/test_update_just.bats
@@ -44,7 +44,7 @@ from pathlib import Path
 import sys
 p = Path(sys.argv[1])
 text = p.read_text()
-text = text.replace("/var/home/linuxbrew/.linuxbrew/bin/brew", "${MOCK_BREW_BIN:-/var/home/linuxbrew/.linuxbrew/bin/brew}")
+text = text.replace("/home/linuxbrew/.linuxbrew/bin/brew", "${MOCK_BREW_BIN:-/home/linuxbrew/.linuxbrew/bin/brew}")
 p.write_text(text)
 PY2
     chmod +x "${UPDATE_SCRIPT}" "${TOGGLE_SCRIPT}"


### PR DESCRIPTION
## Summary

Two brew bugs surfaced on the first Dakota image built with v2026.08-51: ChairLift's cask is silently skipped on first boot, and the `/var/home/linuxbrew` spelling breaks bottle-prefix detection on systems with a real `/home`.

1. **Prefix.** Respell every `/var/home/linuxbrew` in the repo to `/home/linuxbrew`, which resolves on both layouts and matches the rest of the ecosystem.

2. **Tap ordering.** `brew bundle` skips a cask as "requires macOS" when its tap is not installed yet, exits 0, and the state stamp prevents any retry. brew-preinstall now taps everything before bundling, and treats a skipped cask or failed tap as a failure so the run retries.

Verified: all bats and pytest suites pass locally including 3 new regression cases. A fresh first boot from a release with this fix still needs verification.
