### PR TITLE
fix(brew-preinstall): journal-safe output capture, no /dev/stderr

### DIFF
--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -77,10 +77,16 @@ fi
 bundle_failed=0
 for brewfile in "${brewfiles[@]}"; do
     echo "brew-preinstall: bundling ${brewfile}"
-    bundle_output=$(brew bundle --file="${brewfile}" 2>&1 | tee /dev/stderr) || {
+    # Capture output for the skipped-cask check, then echo it. Do NOT pipe
+    # through `tee /dev/stderr`: under systemd, fd 2 is a journal socket and
+    # opening /dev/stderr fails with ENXIO, failing every bundle.
+    bundle_rc=0
+    bundle_output=$(brew bundle --file="${brewfile}" 2>&1) || bundle_rc=$?
+    printf '%s\n' "${bundle_output}"
+    if [[ "${bundle_rc}" -ne 0 ]]; then
         echo "brew-preinstall: error: bundling ${brewfile} failed"
         bundle_failed=1
-    }
+    fi
     # A skipped cask is a silent no-op that exits 0; treat it as a failure
     # so state stays unstamped and the run retries instead of never.
     if grep -q "^Skipping cask" <<< "${bundle_output}"; then

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -609,3 +609,28 @@ BREWMOCK
     ! grep -q "^brew bundle" "${WORKDIR}/brew.log"
     [ ! -f "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" ]
 }
+
+@test "brew-preinstall: bundle output surfaces in the run output" {
+    echo 'brew "ripgrep"' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+
+    cat > "${WORKDIR}/bin/brew" << BREWMOCK
+#!/usr/bin/env bash
+BREW_LOG="\${BREW_LOG:-/dev/null}"
+printf 'brew %s\n' "\$*" >> "\${BREW_LOG}"
+case "\$1" in
+    shellenv) printf 'export PATH="%s:\${PATH}"\n' "${WORKDIR}/bin" ;;
+    bundle)   echo "BUNDLE-OUTPUT-MARKER" ;;
+    list)     exit 0 ;;
+    uninstall) ;;
+esac
+BREWMOCK
+    chmod +x "${WORKDIR}/bin/brew"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"BUNDLE-OUTPUT-MARKER"* ]]
+}
+
+@test "brew-preinstall: never references /dev/stderr (ENXIO under systemd)" {
+    ! sed 's/#.*//' "${BREW_PREINSTALL}" | grep -q "/dev/stderr"
+}


### PR DESCRIPTION
## Summary

Follow-up to #997. The skipped-cask check piped bundle output through `tee /dev/stderr`, which works in a terminal but fails under systemd: fd 2 is a journal socket there, opening `/dev/stderr` returns ENXIO, and every bundle reports failure. Caught during pre-release hardware testing on Dakota, no published image carries the bug.

1. **Capture, then print.** Bundle output is captured for the skipped-cask check and echoed with `printf`, with the exit code checked directly. No `/dev/stderr` involved.

2. **Tests.** Two new bats cases: bundle output must surface in the run output, and the script may not reference `/dev/stderr` outside comments.

Verified: all 37 bats cases pass, and the fixed script completed a full clean pass under `systemd-run --user` (the exact context that failed), with taps, all three Brewfiles, and output landing in the journal.
