### PR TITLE
fix(report): read booted tag from bootc, not baked image-info

### DIFF
--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -16,6 +16,7 @@ RESUME_DIR=""
 IMAGE_NAME=""
 IMAGE_REF=""
 IMAGE_TAG=""
+IMAGE_VERSION="unknown"
 IMAGE_FLAVOR=""
 BUG_REPO=""
 BOOTC_JSON="{}"
@@ -79,15 +80,29 @@ read_image_info() {
 }
 
 read_boot_status() {
+    local booted_ref
+
     BOOTC_JSON="$(bootc status --json 2>/dev/null || printf '{}')"
     BOOTC_STATUS="$(bootc status 2>/dev/null || printf 'Unavailable')"
 
     if command -v jq &>/dev/null; then
         BOOTED_DIGEST="$(printf '%s' "$BOOTC_JSON" | \
             jq -r '.status.booted.imageDigest // "unknown"' 2>/dev/null || printf 'unknown')"
+        # The image-tag baked into image-info.json is whatever the build
+        # was tagged at compose time (always "latest"); promotion retags
+        # the same digest, so only bootc knows the followed tag.
+        booted_ref="$(printf '%s' "$BOOTC_JSON" | \
+            jq -r '.status.booted.image.image.image // .spec.image.image // empty' 2>/dev/null || true)"
+        case "$booted_ref" in
+            *@*) ;; # digest-pinned ref, no tag to extract
+            *:*) IMAGE_TAG="${booted_ref##*:}" ;;
+        esac
     else
         BOOTED_DIGEST="unknown"
     fi
+
+    IMAGE_VERSION="$(sed -n 's/^IMAGE_VERSION="\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' /etc/os-release 2>/dev/null | head -1)"
+    IMAGE_VERSION="${IMAGE_VERSION:-unknown}"
 }
 
 route_issue_repo() {
@@ -303,7 +318,8 @@ collect_baseline() {
         printf '### System\n\n'
         printf '| Field | Value |\n| --- | --- |\n'
         printf '| Image | `%s` |\n' "$IMAGE_REF"
-        printf '| Version | `%s` |\n' "$IMAGE_TAG"
+        printf '| Tag | `%s` |\n' "$IMAGE_TAG"
+        printf '| Version | `%s` |\n' "$IMAGE_VERSION"
         printf '| Flavor | `%s` |\n' "$IMAGE_FLAVOR"
         printf '| Kernel | `%s` |\n' "$(uname -r)"
         printf '| Architecture | `%s` |\n' "$(uname -m)"
@@ -606,8 +622,8 @@ confirm_report() {
     failed_units="$(systemctl list-units --state=failed --no-legend --plain 2>/dev/null | \
         awk '{print $1}' | head -10 | scrub_journal_log || true)"
     failed_units="${failed_units:-none}"
-    body="$(printf '**System fingerprint** (via `ujust report --confirm`)\n\n* Image: %s\n* Version: %s\n* Digest: %s\n* Kernel: %s\n* Arch: %s\n* Failed units: %s' \
-        "$IMAGE_REF" "$IMAGE_TAG" "${BOOTED_DIGEST:-unknown}" "$(uname -r)" "$(uname -m)" \
+    body="$(printf '**System fingerprint** (via `ujust report --confirm`)\n\n* Image: %s\n* Tag: %s\n* Version: %s\n* Digest: %s\n* Kernel: %s\n* Arch: %s\n* Failed units: %s' \
+        "$IMAGE_REF" "$IMAGE_TAG" "$IMAGE_VERSION" "${BOOTED_DIGEST:-unknown}" "$(uname -r)" "$(uname -m)" \
         "$failed_units")"
 
     printf '\nWill post to: https://github.com/%s/issues/%s\n\n%s\n\n' \
@@ -653,6 +669,9 @@ start_bug_report() {
     local reproduction
 
     read_image_info
+    # read_boot_status must run before routing: it corrects IMAGE_TAG
+    # from the booted bootc image, and lts routing keys off the tag.
+    read_boot_status
     route_issue_repo
     gum style --bold --foreground 212 "Bug report"
     gum style --foreground 245 \
@@ -663,7 +682,6 @@ start_bug_report() {
 
     printf '\nSelect any relevant smart-log profiles (or none):\n'
     choose_profiles
-    read_boot_status
     create_draft "$BUG_REPO"
     : > "$DRAFT_DIR/bug-report.txt"
     collect_baseline "$title" "$description" "$reproduction"

--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -93,6 +93,11 @@ read_boot_status() {
         # the same digest, so only bootc knows the followed tag.
         booted_ref="$(printf '%s' "$BOOTC_JSON" | \
             jq -r '.status.booted.image.image.image // .spec.image.image // empty' 2>/dev/null || true)"
+        if [[ -n "$booted_ref" ]]; then
+            # The baked image-ref is equally stale for rebased or locally
+            # built deployments (projectbluefin/dakota#1328).
+            IMAGE_REF="$booted_ref"
+        fi
         case "$booted_ref" in
             *@*) ;; # digest-pinned ref, no tag to extract
             *:*) IMAGE_TAG="${booted_ref##*:}" ;;

--- a/system_files/shared/usr/bin/ublue-image-info.sh
+++ b/system_files/shared/usr/bin/ublue-image-info.sh
@@ -2,7 +2,20 @@
 
 # shellcheck disable=2046
 IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
-echo -n "$(jq -r '"\(.["image-name"]):\(.["image-tag"])"' < "${IMAGE_INFO_FILE}")"
+IMAGE_NAME="$(jq -r '.["image-name"]' < "${IMAGE_INFO_FILE}")"
+IMAGE_TAG="$(jq -r '.["image-tag"]' < "${IMAGE_INFO_FILE}")"
+
+# The baked image-tag is always the compose-time tag ("latest");
+# promotion retags the same digest, so the followed tag only exists
+# in bootc. Fall back to the baked value when bootc is unavailable.
+BOOTED_REF="$(bootc status --json 2>/dev/null | \
+	jq -r '.status.booted.image.image.image // .spec.image.image // empty' 2>/dev/null)"
+case "${BOOTED_REF}" in
+	*@*) ;; # digest-pinned ref, no tag to extract
+	*:*) IMAGE_TAG="${BOOTED_REF##*:}" ;;
+esac
+
+echo -n "${IMAGE_NAME}:${IMAGE_TAG}"
 
 if [[ "$(rpm-ostree status --booted)" =~ "signed" ]]; then
 	echo -n " 🔐"


### PR DESCRIPTION
## Summary

`ujust report` and the fastfetch header print `dakota:latest` no matter which channel the machine follows, because the baked `image-tag` can never be truthful: promotion retags the same digest, so the followed tag only exists in `bootc status`. Both scripts now derive the tag from the booted bootc image and fall back to the baked value when bootc is unavailable, and the report's System table shows the already-stamped `IMAGE_VERSION` alongside it. The report's Image row now shows the booted ref as well, so rebased and locally built deployments (projectbluefin/dakota#1328) report what they actually run. This also lets lts issue routing see the real tag.

**Verified:** shellcheck clean, all 19 bonedigger bats cases pass, extraction tested against canned bootc JSON (tagged, untagged, digest-pinned, containers-storage, no bootc). Still needs a live `ujust report` and fastfetch render on hardware.

Related: projectbluefin/dakota#1383, projectbluefin/dakota#1328
