### PR TITLE
fix(report): read the boot-time booted-image snapshot when bootc status fails

### DIFF
--- a/system_files/bluefin/usr/libexec/bonedigger-report
+++ b/system_files/bluefin/usr/libexec/bonedigger-report
@@ -93,6 +93,12 @@ read_boot_status() {
         # the same digest, so only bootc knows the followed tag.
         booted_ref="$(printf '%s' "$BOOTC_JSON" | \
             jq -r '.status.booted.image.image.image // .spec.image.image // empty' 2>/dev/null || true)"
+        # Unprivileged `bootc status` fails on bootc >= 1.14, so fall back to
+        # the boot-time snapshot written by ublue-booted-image.service on
+        # images that ship it (projectbluefin/dakota#1418).
+        if [[ -z "$booted_ref" && -r /run/ublue-os/booted-image ]]; then
+            read -r booted_ref < /run/ublue-os/booted-image || true
+        fi
         if [[ -n "$booted_ref" ]]; then
             # The baked image-ref is equally stale for rebased or locally
             # built deployments (projectbluefin/dakota#1328).


### PR DESCRIPTION
## Summary

`ujust report` on Dakota still shows `Tag: latest` instead of the followed stream (projectbluefin/dakota#1418). The tag correction from #1020 relies on unprivileged `bootc status`, which fails on bootc 1.14 and newer, so it silently no-ops and the baked compose-time tag leaks through.

When bootc returns no ref, we now fall back to `/run/ublue-os/booted-image`, the once-per-boot snapshot written as root by `ublue-booted-image.service` that fastfetch already reads for the same reason. The fallback is guarded on the file existing, so Bluefin and LTS are unaffected.

Verified: all 19 cases in `tests/test_bonedigger_report.bats` pass locally. Still needs a report filed from a booted Dakota `stable` or `testing` deployment to confirm the tag shows correctly.

Related: #1020
Related: projectbluefin/dakota#1418
