### PR TITLE
fix(flatpak): correct metered check in appstream refresh service

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/flatpak-appstream-refresh.service
+++ b/system_files/shared/usr/lib/systemd/system/flatpak-appstream-refresh.service
@@ -4,7 +4,7 @@ Documentation=https://docs.projectbluefin.io
 After=network-online.target flatpak-system-helper.service
 Wants=network-online.target
 ConditionPathExists=/usr/bin/flatpak
-ExecCondition=bash -c 'v=$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered 2>/dev/null | cut -d" " -f2); [ "$v" != "1" ] && [ "$v" != "2" ]'
+ExecCondition=bash -c 'v=$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered 2>/dev/null | cut -d" " -f2); case "$v" in 1|3) exit 1;; esac'
 StartLimitIntervalSec=600
 StartLimitBurst=3
 


### PR DESCRIPTION
ExecCondition skipped NM_METERED_YES(1) and NM_METERED_NO(2), so an explicitly-unmetered connection 2 was never refreshed while a guessed-metered connection 3 was. NetworkManager's NMMetered docs say to treat NM_METERED_GUESS_YES(3) as metered and all else as unmetered.

Skip only 1 and 3; keep 0/unknown fail-open. Moved to a case statement for clearer intent and to avoid future numeric miscomparisons.

Closes [#1027](https://github.com/projectbluefin/common/issues/1027)

Assisted-by: big-pickle (opencode) via OpenCode