### PR TITLE
feat(security): provide shared runsc provisioning for Bluefin-family hosts

### DIFF
--- a/docs/skills/shell-scripts/SKILL.md
+++ b/docs/skills/shell-scripts/SKILL.md
@@ -86,6 +86,38 @@ Quick reference — full patterns with WRONG/CORRECT examples in
 Standard file layout, mocking, and pitfalls in
 [references/bats-patterns.md](references/bats-patterns.md).
 
+## Bluefin-family host runsc provisioning
+
+Common's shared overlay owns the reusable host-side gVisor runtime provisioner
+for Bluefin-family images. The provisioner does not change Podman's default
+runtime; consumers explicitly select `runsc` when they need the outer
+isolation boundary.
+
+The pinned upstream release is `release-20260817.0`. The helper selects the
+exact architecture asset and digest before it inspects or extracts the archive:
+
+- `x86_64`: `ae345a8c1466586b3a163fb534301913da663a97b8ed446bc711b2e1963a32c5`
+- `aarch64`: `a3c2443e9564dbf500893e66fd2463be3b79fe42f66825971c44dc1624d454b2`
+
+The acquisition is HTTPS-only and the archive member allowlist requires both
+`runsc` and its adjacent `gvisor-bin` payload. Installation stages a complete
+version, publishes `/usr/local/bin/runsc` atomically, and records ownership so
+install/update/remove refuse foreign, unowned, or symlinked paths. Repeating
+install or update is idempotent, and a failed update leaves the active version
+in place. The supported user commands are:
+
+```text
+ujust runsc install
+ujust runsc update
+ujust runsc remove
+```
+
+This capability does not add `ignore-cgroups=true`, use host networking, or
+claim native runtime acceptance. A consumer must separately prove executable
+`runsc`, rootless `podman --runtime=runsc`, `OCIRuntime=runsc`, ordinary
+networking, lifecycle behavior, and each supported architecture on real
+hardware.
+
 ## Shellcheck Reference
 
 Directive syntax, SC code notes, and quoting fix examples in

--- a/system_files/shared/usr/libexec/bluefin-runsc
+++ b/system_files/shared/usr/libexec/bluefin-runsc
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RUNSC_VERSION="release-20260817.0"
+RUNSC_ROOT="/usr/local/libexec/bluefin-runsc"
+RUNSC_LINK="/usr/local/bin/runsc"
+RUNSC_MARKER="${RUNSC_ROOT}/.bluefin-owned"
+RUNSC_MARKER_CONTENT="bluefin-runsc ownership marker v1"
+RUNSC_WORK_DIR=""
+RUNSC_STAGE=""
+RUNSC_LINK_DIR=""
+RUNSC_INSTALL_STAGE=""
+RUNSC_RELEASE_DIR=""
+RUNSC_RELEASE_PUBLISHED=0
+RUNSC_ROOT_CREATED=0
+
+die() {
+    echo "bluefin-runsc: $*" >&2
+    return 1
+}
+
+usage() {
+    echo "Usage: bluefin-runsc {install|update|remove}" >&2
+    return 2
+}
+
+cleanup() {
+    if [[ -n "${RUNSC_LINK_DIR}" && -d "${RUNSC_LINK_DIR}" ]]; then
+        rm -rf -- "${RUNSC_LINK_DIR}"
+    fi
+    if [[ -n "${RUNSC_STAGE}" && -d "${RUNSC_STAGE}" ]]; then
+        rm -rf -- "${RUNSC_STAGE}"
+    fi
+    if [[ -n "${RUNSC_INSTALL_STAGE}" && -d "${RUNSC_INSTALL_STAGE}" ]]; then
+        rm -rf -- "${RUNSC_INSTALL_STAGE}"
+    fi
+    if [[ "${RUNSC_RELEASE_PUBLISHED}" -eq 0 && -n "${RUNSC_RELEASE_DIR}" \
+        && -d "${RUNSC_RELEASE_DIR}" && ! -L "${RUNSC_RELEASE_DIR}" ]]; then
+        rm -rf -- "${RUNSC_RELEASE_DIR}"
+    fi
+    if [[ "${RUNSC_ROOT_CREATED}" -eq 1 && ! -e "${RUNSC_MARKER}" \
+        && ! -L "${RUNSC_MARKER}" && -d "${RUNSC_ROOT}" && ! -L "${RUNSC_ROOT}" ]]; then
+        rm -rf -- "${RUNSC_ROOT}"
+    fi
+    if [[ -n "${RUNSC_WORK_DIR}" && -d "${RUNSC_WORK_DIR}" ]]; then
+        rm -rf -- "${RUNSC_WORK_DIR}"
+    fi
+}
+
+ownership_marker_valid() {
+    [[ -f "${RUNSC_MARKER}" && ! -L "${RUNSC_MARKER}" ]] || return 1
+    printf '%s\n' "${RUNSC_MARKER_CONTENT}" | cmp -s - "${RUNSC_MARKER}"
+}
+
+ensure_owned_root() {
+    if [[ -L "${RUNSC_ROOT}" ]]; then
+        die "refusing symlinked runsc root ${RUNSC_ROOT}"
+    elif [[ -e "${RUNSC_ROOT}" ]]; then
+        [[ -d "${RUNSC_ROOT}" ]] || die "refusing non-directory runsc root ${RUNSC_ROOT}"
+        ownership_marker_valid || die "refusing unowned runsc root ${RUNSC_ROOT}"
+    else
+        install -d -m 0755 "${RUNSC_ROOT}"
+        RUNSC_ROOT_CREATED=1
+    fi
+
+    if [[ -L "${RUNSC_ROOT}/releases" ]]; then
+        die "refusing symlinked runsc release directory ${RUNSC_ROOT}/releases"
+    elif [[ -e "${RUNSC_ROOT}/releases" ]]; then
+        [[ -d "${RUNSC_ROOT}/releases" ]] || die "refusing non-directory runsc release path"
+    else
+        install -d -m 0755 "${RUNSC_ROOT}/releases"
+    fi
+}
+
+link_points_to_owned_release() {
+    local raw_target resolved release_dir
+
+    [[ -L "${RUNSC_LINK}" ]] || return 1
+    raw_target="$(readlink -- "${RUNSC_LINK}")" || return 1
+    case "${raw_target}" in
+        "${RUNSC_ROOT}"/releases/*/runsc) ;;
+        *) return 1 ;;
+    esac
+
+    release_dir="${raw_target%/runsc}"
+    [[ "$(dirname "${release_dir}")" == "${RUNSC_ROOT}/releases" ]] || return 1
+    if [[ -e "${release_dir}" || -L "${release_dir}" ]]; then
+        [[ -d "${release_dir}" && ! -L "${release_dir}" ]] || return 1
+    fi
+    resolved="$(readlink -f -- "${RUNSC_LINK}")" || return 1
+    [[ "${resolved}" == "${release_dir}/runsc" ]]
+}
+
+active_release() {
+    local link_target release_name release_dir expected_prefix
+
+    link_points_to_owned_release || return 1
+    link_target="$(readlink -f -- "${RUNSC_LINK}")" || return 1
+    expected_prefix="${RUNSC_VERSION}-${EXPECTED_SHA256:0:12}-"
+    case "${link_target}" in
+        "${RUNSC_ROOT}"/releases/*/runsc) ;;
+        *) return 1 ;;
+    esac
+
+    release_dir="$(dirname "${link_target}")"
+    release_name="$(basename "${release_dir}")"
+    [[ "${release_name}" == "${expected_prefix}"* ]] || return 1
+    [[ -x "${link_target}" && -d "${release_dir}/gvisor-bin" ]]
+}
+
+remove_installation() {
+    if [[ -L "${RUNSC_ROOT}" ]]; then
+        die "refusing symlinked runsc root ${RUNSC_ROOT}"
+    fi
+    if [[ ! -e "${RUNSC_ROOT}" ]]; then
+        [[ ! -e "${RUNSC_LINK}" && ! -L "${RUNSC_LINK}" ]] || \
+            die "refusing to remove an unowned runsc installation"
+        echo "Bluefin runsc installation removed."
+        return 0
+    fi
+    [[ -d "${RUNSC_ROOT}" ]] || die "refusing non-directory runsc root ${RUNSC_ROOT}"
+    ownership_marker_valid || die "refusing to remove unowned runsc root ${RUNSC_ROOT}"
+    [[ ! -L "${RUNSC_ROOT}/releases" ]] || \
+        die "refusing symlinked runsc release directory ${RUNSC_ROOT}/releases"
+    if [[ -e "${RUNSC_ROOT}/releases" ]]; then
+        [[ -d "${RUNSC_ROOT}/releases" ]] || die "refusing non-directory runsc release path"
+    fi
+
+    if [[ -e "${RUNSC_LINK}" || -L "${RUNSC_LINK}" ]]; then
+        [[ -L "${RUNSC_LINK}" ]] || die "refusing to remove non-symlink ${RUNSC_LINK}"
+        link_points_to_owned_release || die "refusing foreign runsc link ${RUNSC_LINK}"
+    fi
+
+    rm -rf -- "${RUNSC_ROOT}"
+
+    if [[ -L "${RUNSC_LINK}" ]]; then
+        rm -f -- "${RUNSC_LINK}"
+    fi
+
+    echo "Bluefin runsc installation removed."
+}
+
+provision() {
+    local machine_arch asset_arch expected_sha256 archive_url
+    local archive members member release_dir release_name
+    local link_target
+
+    machine_arch="$(uname -m)"
+    case "${machine_arch}" in
+        x86_64)
+            asset_arch="x86_64"
+            expected_sha256="ae345a8c1466586b3a163fb534301913da663a97b8ed446bc711b2e1963a32c5"
+            ;;
+        aarch64|arm64)
+            asset_arch="aarch64"
+            expected_sha256="a3c2443e9564dbf500893e66fd2463be3b79fe42f66825971c44dc1624d454b2"
+            ;;
+        *)
+            die "unsupported host architecture: ${machine_arch}"
+            ;;
+    esac
+    EXPECTED_SHA256="${expected_sha256}"
+    export EXPECTED_SHA256
+
+    trap cleanup EXIT
+    ensure_owned_root
+
+    if active_release; then
+        echo "Bluefin runsc ${RUNSC_VERSION} is already installed."
+        return 0
+    fi
+
+    archive_url="https://github.com/google/gvisor/releases/download/${RUNSC_VERSION}/gvisor-${asset_arch}.tar.bz2"
+    RUNSC_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bluefin-runsc.XXXXXXXX")"
+    RUNSC_STAGE=""
+    RUNSC_LINK_DIR=""
+    RUNSC_INSTALL_STAGE=""
+    RUNSC_RELEASE_DIR=""
+    RUNSC_RELEASE_PUBLISHED=0
+
+    archive="${RUNSC_WORK_DIR}/gvisor.tar.bz2"
+    curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+        --retry 3 --max-time 300 --output "${archive}" "${archive_url}"
+    printf '%s  %s\n' "${EXPECTED_SHA256}" "${archive}" | sha256sum --check --status -
+
+    members="$(tar -tjf "${archive}")"
+    grep -Eq '^runsc$' <<< "${members}" || die "verified archive has no runsc payload"
+    grep -Eq '^gvisor-bin/?$' <<< "${members}" || die "verified archive has no gvisor-bin payload"
+    while IFS= read -r member; do
+        case "${member}" in
+            runsc|gvisor-bin|gvisor-bin/*|containerd-shim-runsc-v1) ;;
+            *) die "verified archive contains unexpected member: ${member}" ;;
+        esac
+    done <<< "${members}"
+
+    RUNSC_STAGE="${RUNSC_WORK_DIR}/payload"
+    mkdir -p "${RUNSC_STAGE}"
+    tar -xjf "${archive}" --no-same-owner --no-same-permissions \
+        --directory "${RUNSC_STAGE}" runsc gvisor-bin
+    [[ -f "${RUNSC_STAGE}/runsc" && -d "${RUNSC_STAGE}/gvisor-bin" ]] || die "archive extraction omitted the runsc payload"
+    chmod a+rx "${RUNSC_STAGE}/runsc"
+    chmod -R a+rX "${RUNSC_STAGE}/gvisor-bin"
+
+    release_name="${RUNSC_VERSION}-${EXPECTED_SHA256:0:12}-$(basename "${RUNSC_WORK_DIR}")"
+    release_dir="${RUNSC_ROOT}/releases/${release_name}"
+    if [[ -e "${release_dir}" || -L "${release_dir}" ]]; then
+        [[ ! -L "${release_dir}" ]] || die "refusing symlinked runsc release path ${release_dir}"
+        die "refusing existing runsc release path ${release_dir}"
+    fi
+    RUNSC_INSTALL_STAGE="$(mktemp -d "${RUNSC_ROOT}/.staging.XXXXXXXX")"
+    cp -a "${RUNSC_STAGE}/." "${RUNSC_INSTALL_STAGE}/"
+    chmod a+rx "${RUNSC_INSTALL_STAGE}/runsc"
+    chmod -R a+rX "${RUNSC_INSTALL_STAGE}/gvisor-bin"
+    mv -T -- "${RUNSC_INSTALL_STAGE}" "${release_dir}"
+    RUNSC_RELEASE_DIR="${release_dir}"
+
+    if ! ownership_marker_valid; then
+        printf '%s\n' "${RUNSC_MARKER_CONTENT}" > "${RUNSC_WORK_DIR}/ownership-marker"
+        mv -T -- "${RUNSC_WORK_DIR}/ownership-marker" "${RUNSC_MARKER}"
+    fi
+
+    link_target="${release_dir}/runsc"
+    [[ "$(dirname "${link_target}")" == "${RUNSC_ROOT}/releases/${release_name}" ]] || \
+        die "computed release escaped the owned root"
+    install -d -m 0755 "$(dirname "${RUNSC_LINK}")"
+    if [[ -e "${RUNSC_LINK}" || -L "${RUNSC_LINK}" ]]; then
+        [[ -L "${RUNSC_LINK}" ]] || die "refusing to replace non-symlink ${RUNSC_LINK}"
+        link_points_to_owned_release || die "refusing to replace foreign runsc link ${RUNSC_LINK}"
+    fi
+    RUNSC_LINK_DIR="$(mktemp -d "$(dirname "${RUNSC_LINK}")/.bluefin-runsc.XXXXXXXX")"
+    ln -s -- "${link_target}" "${RUNSC_LINK_DIR}/runsc"
+    mv -Tf -- "${RUNSC_LINK_DIR}/runsc" "${RUNSC_LINK}"
+    RUNSC_RELEASE_PUBLISHED=1
+    echo "Installed Bluefin runsc ${RUNSC_VERSION} for ${machine_arch}."
+}
+
+main() {
+    local action="${1:-}"
+    case "${action}" in
+        install|update)
+            provision
+            ;;
+        remove)
+            remove_installation
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+main "$@"

--- a/system_files/shared/usr/share/ublue-os/just/shared.just
+++ b/system_files/shared/usr/share/ublue-os/just/shared.just
@@ -1,6 +1,11 @@
 # vim: set ft=make :
 # These are recipes that are generic and should be available in bluefin and aurora
 
+# Provision the shared host-side gVisor runtime used by isolated workloads.
+[group('System')]
+runsc action="install":
+    sudo /usr/libexec/bluefin-runsc "{{ action }}"
+
 # Toggle LUKS auto-unlock via TPM2
 [group('System')]
 toggle-tpm2:

--- a/tests/test_runsc_provisioning.bats
+++ b/tests/test_runsc_provisioning.bats
@@ -1,0 +1,286 @@
+#!/usr/bin/env bats
+# Deterministic contract tests for the Common-owned shared runsc provisioner.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+HELPER="${SCRIPT_DIR}/../system_files/shared/usr/libexec/bluefin-runsc"
+RUNSC_VERSION="release-20260817.0"
+
+setup() {
+    TEST_ROOT="${SCRIPT_DIR}/.bats-sandbox/runsc-provisioning.${BATS_TEST_NUMBER:-0}.$$"
+    STUB_BIN="${TEST_ROOT}/stub-bin"
+    PATCHED_HELPER="${TEST_ROOT}/bluefin-runsc"
+    mkdir -p "${STUB_BIN}" "${TEST_ROOT}/archive/gvisor-bin" "${TEST_ROOT}/bin"
+
+    printf '#!/usr/bin/env bash\n' > "${TEST_ROOT}/archive/runsc"
+    printf 'sandbox payload\n' > "${TEST_ROOT}/archive/gvisor-bin/runsc-sandbox"
+    printf 'shim payload\n' > "${TEST_ROOT}/archive/containerd-shim-runsc-v1"
+    chmod +x "${TEST_ROOT}/archive/runsc" "${TEST_ROOT}/archive/gvisor-bin/runsc-sandbox"
+    tar -cjf "${TEST_ROOT}/gvisor.tar.bz2" \
+        -C "${TEST_ROOT}/archive" runsc gvisor-bin containerd-shim-runsc-v1
+    VALID_SHA="$(sha256sum "${TEST_ROOT}/gvisor.tar.bz2" | awk '{print $1}')"
+
+    cat > "${STUB_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${CURL_LOG}"
+destination=""
+while (($#)); do
+    case "$1" in
+        -o) destination="$2"; shift 2 ;;
+        --output) destination="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [[ "$(cat "${CURL_MODE_FILE}" 2>/dev/null || true)" == corrupt ]]; then
+    printf 'corrupt archive\n' > "${destination}"
+else
+    cp "${FIXTURE_ARCHIVE}" "${destination}"
+fi
+EOF
+    chmod +x "${STUB_BIN}/curl"
+
+    export PATH="${STUB_BIN}:${PATH}"
+    export CURL_LOG="${TEST_ROOT}/curl.log"
+    export CURL_MODE_FILE="${TEST_ROOT}/curl-mode"
+    export FIXTURE_ARCHIVE="${TEST_ROOT}/gvisor.tar.bz2"
+    : > "${CURL_LOG}"
+}
+
+teardown() {
+    rm -f "${PATCHED_HELPER}"
+    rm -rf "${TEST_ROOT}"
+}
+
+patch_helper() {
+    sed \
+        -e "s|/usr/local/libexec/bluefin-runsc|${TEST_ROOT}/usr/local/libexec/bluefin-runsc|g" \
+        -e "s|/usr/local/bin/runsc|${TEST_ROOT}/usr/local/bin/runsc|g" \
+        -e "s|ae345a8c1466586b3a163fb534301913da663a97b8ed446bc711b2e1963a32c5|${VALID_SHA}|g" \
+        -e "s|a3c2443e9564dbf500893e66fd2463be3b79fe42f66825971c44dc1624d454b2|${VALID_SHA}|g" \
+        "${HELPER}" > "${PATCHED_HELPER}"
+    chmod +x "${PATCHED_HELPER}"
+}
+
+stub_uname() {
+    local architecture="$1"
+    cat > "${STUB_BIN}/uname" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "-m" ]]; then
+    printf '%s\\n' "${architecture}"
+else
+    /usr/bin/uname "\$@"
+fi
+EOF
+    chmod +x "${STUB_BIN}/uname"
+}
+
+@test "runsc helper installs the pinned payload and discoverable link" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -eq 0 ]
+    release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/${RUNSC_VERSION}-"*)
+    [ "${#release_dirs[@]}" -eq 1 ]
+    [ -x "${release_dirs[0]}/runsc" ]
+    [ -x "${release_dirs[0]}/gvisor-bin/runsc-sandbox" ]
+    [ -f "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/.bluefin-owned" ]
+    [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = \
+        "${release_dirs[0]}/runsc" ]
+    grep -Fq 'gvisor-x86_64.tar.bz2' "${CURL_LOG}"
+}
+
+@test "runsc helper rejects unsupported architecture before network access" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    stub_uname riscv64
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ ! -s "${CURL_LOG}" ]
+}
+
+@test "runsc helper maps arm64 hosts to the upstream aarch64 asset" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    stub_uname arm64
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -eq 0 ]
+    grep -Fq 'gvisor-aarch64.tar.bz2' "${CURL_LOG}"
+}
+
+@test "runsc helper verifies the archive before its first tar read" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    printf 'corrupt\n' > "${CURL_MODE_FILE}"
+    cat > "${STUB_BIN}/tar" <<'EOF'
+#!/usr/bin/env bash
+printf 'tar was called\n' > "${TAR_LOG}"
+exit 99
+EOF
+    chmod +x "${STUB_BIN}/tar"
+    export TAR_LOG="${TEST_ROOT}/tar.log"
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ ! -e "${TAR_LOG}" ]
+}
+
+@test "runsc helper install is idempotent after the pinned release is active" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+
+    run bash "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+    first_curl_count="$(wc -l < "${CURL_LOG}")"
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -eq 0 ]
+    [ "$(wc -l < "${CURL_LOG}")" -eq "${first_curl_count}" ]
+}
+
+@test "runsc helper leaves the active release unchanged after a failed update" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    run "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+    active_link="$(readlink "${TEST_ROOT}/usr/local/bin/runsc")"
+    rm -rf "$(dirname "${active_link}")/gvisor-bin"
+    printf 'corrupt\n' > "${CURL_MODE_FILE}"
+
+    run bash "${PATCHED_HELPER}" update
+
+    [ "${status}" -ne 0 ]
+    [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = "${active_link}" ]
+}
+
+@test "runsc helper removes only its owned installation" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    run bash "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+
+    run bash "${PATCHED_HELPER}" remove
+
+    [ "${status}" -eq 0 ]
+    [ ! -e "${TEST_ROOT}/usr/local/bin/runsc" ]
+    [ ! -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc" ]
+}
+
+@test "runsc helper refuses to remove a foreign runsc link" {
+    [[ -x "${HELPER}" ]]
+    patch_helper
+    mkdir -p "${TEST_ROOT}/usr/local/bin"
+    printf '#!/usr/bin/env bash\n' > "${TEST_ROOT}/foreign-runsc"
+    chmod +x "${TEST_ROOT}/foreign-runsc"
+    ln -s "${TEST_ROOT}/foreign-runsc" "${TEST_ROOT}/usr/local/bin/runsc"
+    mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    printf 'owned data\n' > "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/keep"
+
+    run bash "${PATCHED_HELPER}" remove
+
+    [ "${status}" -ne 0 ]
+    [ -L "${TEST_ROOT}/usr/local/bin/runsc" ]
+    [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/keep" ]
+}
+
+@test "runsc helper refuses an unowned root and preserves foreign children" {
+
+    [[ -x "${HELPER}" ]]
+
+    patch_helper
+    mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    printf 'foreign data\n' > "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign"
+
+    run "${PATCHED_HELPER}" remove
+
+    [ "${status}" -ne 0 ]
+    [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign" ]
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ ! -s "${CURL_LOG}" ]
+    [ -e "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/foreign" ]
+}
+
+@test "runsc helper refuses a symlinked root or release directory" {
+
+    [[ -x "${HELPER}" ]]
+
+    patch_helper
+    mkdir -p "${TEST_ROOT}/usr/local/libexec"
+    mkdir -p "${TEST_ROOT}/foreign"
+    ln -s "${TEST_ROOT}/foreign" "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+
+    run "${PATCHED_HELPER}" remove
+
+    [ "${status}" -ne 0 ]
+    [ -d "${TEST_ROOT}/foreign" ]
+
+    rm -f "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    mkdir -p "${TEST_ROOT}/usr/local/libexec/bluefin-runsc"
+    printf 'bluefin-runsc ownership marker v1\n' > \
+        "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/.bluefin-owned"
+    ln -s "${TEST_ROOT}/foreign" \
+        "${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases"
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [ -d "${TEST_ROOT}/foreign" ]
+}
+
+@test "runsc helper cleans a staged release after publication failure" {
+
+    [[ -x "${HELPER}" ]]
+
+    patch_helper
+    run "${PATCHED_HELPER}" install
+    [ "${status}" -eq 0 ]
+    active_link="$(readlink "${TEST_ROOT}/usr/local/bin/runsc")"
+    release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/"*)
+
+    cat > "${STUB_BIN}/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${!#}" == "${FAIL_MV_TARGET}" ]]; then
+    exit 23
+fi
+exec /usr/bin/mv "$@"
+EOF
+    chmod +x "${STUB_BIN}/mv"
+    sed 's/release-20260817.0/release-20260818.0/g' \
+        "${PATCHED_HELPER}" > "${TEST_ROOT}/bluefin-runsc-update"
+    chmod +x "${TEST_ROOT}/bluefin-runsc-update"
+    export FAIL_MV_TARGET="${TEST_ROOT}/usr/local/bin/runsc"
+
+    run bash "${TEST_ROOT}/bluefin-runsc-update" update
+
+    [ "${status}" -ne 0 ]
+    [ "$(readlink "${TEST_ROOT}/usr/local/bin/runsc")" = "${active_link}" ]
+    [ -x "${active_link}" ]
+    [ -d "$(dirname "${active_link}")/gvisor-bin" ]
+    after_release_dirs=("${TEST_ROOT}/usr/local/libexec/bluefin-runsc/releases/"*)
+    [ "${#after_release_dirs[@]}" -eq "${#release_dirs[@]}" ]
+}
+
+@test "runsc recipe and helper do not change defaults or weaken runtime isolation" {
+    [[ -x "${HELPER}" ]]
+    RECIPE="${SCRIPT_DIR}/../system_files/shared/usr/share/ublue-os/just/shared.just"
+    [[ -f "${RECIPE}" ]]
+    run grep -Eiq 'runsc action=' "${RECIPE}"
+    [ "${status}" -eq 0 ]
+    run grep -Eiq 'bluefin-runsc' "${RECIPE}"
+    [ "${status}" -eq 0 ]
+    run grep -Eiq 'runtime[[:space:]]*=' "${RECIPE}"
+    [ "${status}" -ne 0 ]
+    run grep -Eiq 'ignore-cgroups|network=host|curl[^\n]*PATH' "${HELPER}" "${RECIPE}"
+    [ "${status}" -ne 0 ]
+}

--- a/tests/test_runsc_provisioning.bats
+++ b/tests/test_runsc_provisioning.bats
@@ -131,6 +131,21 @@ EOF
     [ ! -e "${TAR_LOG}" ]
 }
 
+@test "runsc helper rejects unexpected archive members" {
+    [[ -x "${HELPER}" ]]
+    printf 'unexpected payload\n' > "${TEST_ROOT}/archive/unexpected"
+    tar -cjf "${FIXTURE_ARCHIVE}" \
+        -C "${TEST_ROOT}/archive" runsc gvisor-bin containerd-shim-runsc-v1 unexpected
+    VALID_SHA="$(sha256sum "${FIXTURE_ARCHIVE}" | awk '{print $1}')"
+    patch_helper
+
+    run bash "${PATCHED_HELPER}" install
+
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"unexpected member"* ]]
+    [ ! -e "${TEST_ROOT}/usr/local/bin/runsc" ]
+}
+
 @test "runsc helper install is idempotent after the pinned release is active" {
     [[ -x "${HELPER}" ]]
     patch_helper


### PR DESCRIPTION
## Summary

- re-home the reviewed runsc provisioner into Common's shared Bluefin-family overlay
- expose `ujust runsc install`, `ujust runsc update`, and `ujust runsc remove` from Common's canonical shared recipe
- preserve the pinned release, architecture/digest checks, archive allowlist, ownership protection, atomic lifecycle, and no-runtime-fallback contract from Bluefin #1142

Closes #1038
Refs projectbluefin/bluefin#1139
Supersedes the implementation location in projectbluefin/bluefin#1142
Consumer contract: projectbluefin/review#348 and merged #349
Future consumer: projectbluefin/review#362

## Why Common

Common owns reusable host infrastructure in `system_files/shared/`, which is
distributed through the Bluefin-family image composition path. Bluefin consumes
Common's image and copies its shared overlay into the resulting image. The
runsc capability is not GNOME-specific or image-specific.

## Validation

- `just check`
- `shellcheck -S warning system_files/shared/usr/libexec/bluefin-runsc`
- `npx --yes bats tests/test_runsc_provisioning.bats` — 13/13
- affected Python tests with ephemeral pytest/jsonschema dependencies — 109 passed
- ephemeral `uv run ... pre-commit run --all-files` — passed
- `git diff --check`
- Bluefin composition source proof: Common is consumed as `COMMON_IMAGE`, and
  Bluefin copies Common's shared overlay; old Bluefin-local helper and
  `60-custom.just` are absent from testing

The host's broad BATS sweep has unrelated existing setup/changelog/update
failures; all 13 transferred runsc cases pass. No local image build or native
runtime proof is claimed.

## Native acceptance boundary

After a capable Bluefin Testing image consumes this Common layer, native
acceptance must separately prove `ujust runsc install`, `runsc --version`,
rootless `podman --runtime=runsc`, `OCIRuntime=runsc`, ordinary networking,
install/update/remove lifecycle, no `ignore-cgroups=true`, no host networking,
the real Review fail-closed path, and separate arm64 evidence. This PR does
not close Bluefin #1139 or Review #348.
