### PR TITLE
fix(brew): trust vendored taps so preinstalled casks actually install

### DIFF
--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -34,31 +34,26 @@ if [[ ${#brewfiles[@]} -eq 0 ]]; then
     exit 0
 fi
 
-# Content-addressed check: hash all Brewfiles combined.
-# If unchanged, nothing to do — fast exit without touching brew.
-current_hash=$(cat "${brewfiles[@]}" | sha256sum | cut -d' ' -f1)
-stored_hash=$(jq -r '.hash // ""' "${STATE_FILE}" 2>/dev/null || echo "")
-
-if [[ "${current_hash}" == "${stored_hash}" ]]; then
-    echo "brew-preinstall: Brewfiles unchanged (${current_hash:0:12}...), nothing to do"
-    exit 0
-fi
-
 eval "$("${BREW_BIN}" shellenv)"
-
-echo "brew-preinstall: Brewfiles changed (${current_hash:0:12}...), applying..."
 
 # Install every tap before any bundle runs. brew bundle decides cask
 # installability before processing the Brewfile's own tap lines, so on a
 # system that has never seen the tap it skips the cask as "requires macOS"
 # and still exits 0 — the cask is silently never installed (first boot of
 # any image shipping a tap+cask pair, e.g. frostyard/tap + chairlift).
+# Vendored taps are also trusted: brew refuses casks from untrusted taps,
+# and the Brewfile's own `trusted:` flag doesn't apply to an already-present
+# tap. This runs every boot, before the hash early-exit, because
+# `brew bundle cleanup` resets the global trust store; both commands are
+# idempotent no-ops once the tap is present and trusted.
 tap_failed=0
 while IFS= read -r tap; do
     [[ -z "${tap}" ]] && continue
-    echo "brew-preinstall: tapping ${tap}"
     if ! brew tap "${tap}"; then
         echo "brew-preinstall: error: tapping ${tap} failed"
+        tap_failed=1
+    elif ! brew trust "${tap}"; then
+        echo "brew-preinstall: error: trusting ${tap} failed"
         tap_failed=1
     fi
 done < <(sed -nE \
@@ -70,6 +65,18 @@ if [[ "${tap_failed}" -ne 0 ]]; then
     echo "brew-preinstall: one or more taps failed; state unchanged, will retry"
     exit 1
 fi
+
+# Content-addressed check: hash all Brewfiles combined.
+# If unchanged, nothing else to do — fast exit without touching bundle.
+current_hash=$(cat "${brewfiles[@]}" | sha256sum | cut -d' ' -f1)
+stored_hash=$(jq -r '.hash // ""' "${STATE_FILE}" 2>/dev/null || echo "")
+
+if [[ "${current_hash}" == "${stored_hash}" ]]; then
+    echo "brew-preinstall: Brewfiles unchanged (${current_hash:0:12}...), nothing to do"
+    exit 0
+fi
+
+echo "brew-preinstall: Brewfiles changed (${current_hash:0:12}...), applying..."
 
 # Install all packages declared in Brewfiles (brew bundle is idempotent).
 # Continue after an individual failure so independent Brewfiles still install,


### PR DESCRIPTION
## Summary

Since Homebrew 6.0.0 made tap trust mandatory, brew-preinstall has been failing on every boot for images that ship a tap and cask pair, and ChairLift never gets installed (projectbluefin/dakota#1364, also the brew half of projectbluefin/dakota#1396). Users see `Refusing to load cask frostyard/tap/chairlift from untrusted tap` in the journal.

1. **The pre-tap loop was defeating the Brewfile's own trust declaration.** We deliberately `brew tap` everything before bundle runs (bundle decides cask installability before processing tap lines), but that registers the tap untrusted, and a Brewfile's `trusted: true` does not apply to a tap that already exists. Once in that state, bundle refuses the cask forever. The fix runs `brew trust` right after each successful `brew tap`. Vendoring a Brewfile into the image is the trust decision, so every vendored tap gets trusted, matching what Aurora's common already does with its `ublue-brew-trust-brewfile` helper.
2. **The tap and trust loop now runs every boot, ahead of the hash early-exit.** `brew bundle cleanup` resets Homebrew's global trust store to whatever the user's own Brewfile declares, which would silently wipe our grant until the next OS update happens to change a vendored Brewfile. Running the loop unconditionally self-heals that on the next boot. Both commands are offline-safe no-ops on a converged system, and the content hash still guards the expensive bundle and uninstall work.
3. **Why not `HOMEBREW_NO_REQUIRE_TAP_TRUST` on the service:** upgrades run later in the user's own brew context, so bypassing trust only inside the service would fix first install and leave every subsequent cask upgrade broken. The trust store genuinely needs the entry.

**Verified:** `bash -n` passes, the tap extraction was tested against sample Brewfiles in both quote styles, and `brew trust` was confirmed idempotent on a live trusted tap (exit 0, "Already trusted tap"). Still needs end-to-end verification on a machine where frostyard/tap is currently untrusted; the service retry loop means existing broken installs should self-heal on first boot with this script.

Related: projectbluefin/dakota#1364, projectbluefin/dakota#1396
