### PR TITLE
fix(uwelcome): skip greeting for root and dedupe chained shells

### DIFF
--- a/system_files/shared/etc/profile.d/uwelcome.sh
+++ b/system_files/shared/etc/profile.d/uwelcome.sh
@@ -4,4 +4,13 @@ if [ -e ~/.config/no-show-user-motd ]; then
 	mkdir -p ~/.config/uwelcome
 	mv ~/.config/no-show-user-motd ~/.config/uwelcome/disabled 2>/dev/null
 fi
-uwelcome
+
+# Skip for root: root shells (sudo su -, sudo -i) have no desktop session,
+# and the portal lookup uwelcome makes can stall the prompt when the portal
+# cannot start. Guard against double greetings when a shell chains into
+# another (bash login shell starting fish): the first one wins.
+if [ "$(id -u)" != "0" ] && [ -z "${UWELCOME_SHOWN-}" ]; then
+	UWELCOME_SHOWN=1
+	export UWELCOME_SHOWN
+	uwelcome
+fi

--- a/system_files/shared/usr/share/fish/vendor_conf.d/fish_greeting.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/fish_greeting.fish
@@ -5,5 +5,15 @@ function fish_greeting
         mv ~/.config/no-show-user-motd ~/.config/uwelcome/disabled 2>/dev/null
     end
 
+    # Skip for root (no desktop session, portal lookups can stall), and skip
+    # when a parent shell already greeted (bash login shell starting fish).
+    if test (id -u) = 0
+        return
+    end
+    if set -q UWELCOME_SHOWN
+        return
+    end
+    set -gx UWELCOME_SHOWN 1
+
     uwelcome
 end


### PR DESCRIPTION
## Summary

The uwelcome greeting hooks were stalling root shells and greeting twice in chained shells. Root's login shell runs uwelcome via `/etc/profile.d/uwelcome.sh`, and with `"color": "auto"` uwelcome queries the desktop portal, which cannot start in a root session and holds the prompt for two 120 second D-Bus timeouts, the four minute `sudo su -` stall in projectbluefin/dakota#1418. Separately, a bash login shell that starts fish runs the profile.d hook and then fish's `fish_greeting`, printing "Welcome to Bluefin" twice per window (projectbluefin/dakota#1428).

1. **Both hooks now skip for root.** Root shells have no desktop session, and there is no reason a greeting should ever sit between a maintainer and a root prompt.
2. **First greeting wins in chained shells.** The profile.d hook exports `UWELCOME_SHOWN` and the fish greeting checks it, so bash-into-fish setups greet once; a plain fish login greets from fish as before.

This complements projectbluefin/uwelcome#4, which bounds the portal read itself with a 2 second timeout so no remaining caller can stall on it.

**Verified:** both files pass `bash -n`/`fish -n`, the normal path still renders the banner (27 lines), the fish dedup path renders nothing when `UWELCOME_SHOWN` is set, and sourcing is clean under `set -u` callers. Root-skip verified by inspection only, my terminal had no passwordless sudo; worth one `sudo su -` on a booted image before release.

Related: projectbluefin/dakota#1418, projectbluefin/dakota#1428, projectbluefin/dakota#1444, projectbluefin/dakota#1462



