### PR TITLE
chore: update motd + config

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,14 +1,14 @@
 FROM docker.io/library/golang:alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS umotd-build
 RUN apk add git && \
     git clone https://github.com/projectbluefin/umotd /src && \
-    git -C /src checkout c9df8ec6b53e9b2a644a6dc511fd6fde1baad08b
+    git -C /src checkout 97520c61e8fca7eae7359bf3d329542078f17412
 WORKDIR /src
 RUN go build -ldflags="-s -w" -o /umotd .
 
 FROM docker.io/library/golang:alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS uwelcome-build
 RUN apk add git && \
     git clone https://github.com/projectbluefin/uwelcome /src && \
-    git -C /src checkout 5280521bf21e14802d5a8bb1cffb942fa0b5efb7
+    git -C /src checkout d260ccbb56db820f78b0b2a18b07c1a213918ce1
 WORKDIR /src
 RUN go build -ldflags="-s -w" -o /uwelcome .
 

--- a/system_files/shared/etc/uwelcome/config.json
+++ b/system_files/shared/etc/uwelcome/config.json
@@ -16,6 +16,10 @@
     {
       "cmd": "brew help",
       "desc": "cli_pkg"
+    },
+    {
+      "cmd": "ujust report",
+      "desc": "cmd_report"
     }
   ],
   "greeting": {


### PR DESCRIPTION
# bluefin-common PR

## What does this change?

Updates umotd + uwelcome + config

<!-- Required: one sentence -->

## Why?

<!-- Link the issue this closes: "Closes #NNN" -->
Adds a hotfix + ujust report in the config

## PR pipeline

```
opened ──▶ 4-review ──▶ approved ──▶ merged
```

> A maintainer reviews and approves; merge goes through the merge queue.
> Select `blocked` or `hold` to pause the work.

## Checklist

- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`, `ci:`, `refactor:`, etc.)
- [x] `just check` passes
- [ ] `pre-commit run --all-files` passes
- [ ] Skill doc updated if the change affects agent-facing conventions or behavior (see `docs/skills/skill-improvement.md`)
- [x] `AGENTS.md` / `docs/SKILL.md` / `docs/skills/` links remain valid
- [ ] CI is green after push: `gh run list --repo projectbluefin/common --limit 5`

## AI attribution

If this PR includes AI-authored commits, include both trailers:
```
Assisted-by: <Model> via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
```

## Note

Maybe look if we still have an issue where umotd is still the old version for users and maybe get rid of it and its config file / find another way to update it more reliably ? 