### PR TITLE
fix: restore native recipes without bluefinctl

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Run bats (changelog.just)
         run: bats tests/test_changelog.bats
 
-      - name: Run bats (update.just)
-        run: bats tests/test_update_just.bats
+      - name: Run bats (update.just and native recipes)
+        run: bats tests/test_update_just.bats tests/test_native_recipes.bats
 
       - name: Run bats (ublue-fastfetch)
         run: bats tests/test_ublue_fastfetch.bats

--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,7 @@ test:
     bats tests/test_bling_fastfetch.bats
     bats tests/test_changelog.bats
     bats tests/test_update_just.bats
+    bats tests/test_native_recipes.bats
     bats tests/test_ujust.bats
     bats tests/test_ublue_fastfetch.bats
     bats tests/test_motd_integration.bats

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -88,6 +88,7 @@ Do not add exemptions for scripts with branching logic.
 | `tests/test_rechunker_group_fix.bats` | `rechunker-group-fix` — group/gshadow append, duplicate detection, format |
 | `tests/test_bling_fastfetch.bats` | `ublue-bling-fastfetch` — all 9 accent colors, dconf/gsettings fallback chain, FASTFETCH_FORCE_THEME override |
 | `tests/test_changelog.bats` | `changelog.just` — LTS/non-LTS repo selection, URL construction, exit behaviour |
+| `tests/test_native_recipes.bats` | Native recipes with a leftover `bctl`: CLI setup, devmode, signed channel switching, VM setup, Flatpak bundles, and both reset confirmations |
 | `tests/test_ublue_fastfetch.bats` | `ublue-fastfetch` — config reads, shuffle branch, DEFAULT_THEME export to ublue-bling-fastfetch |
 | `tests/test_theming_hook.bats` | `10-theming.sh` — Framework/Thelio branches and setup idempotency |
 | `tests/test_brew_preinstall.bats` | Managed Brewfile lifecycle plus user-unit ordering, resource priority, and preset delivery |

--- a/docs/skills/brew-lifecycle/SKILL.md
+++ b/docs/skills/brew-lifecycle/SKILL.md
@@ -60,8 +60,15 @@ pattern, and the rules for what can and cannot move to brew.
 ### Remove a package
 1. Remove the `brew "<name>"` line from the Brewfile.
 2. Open a PR.
-3. On next login after the OS update, users who got it through the managed set
-   get it uninstalled. Users who installed it themselves are unaffected.
+3. On next successful login sync after the OS update, packages recorded in
+   the previous managed state get uninstalled. Packages outside that state
+   are unaffected. State records the desired set, not who originally installed
+   each package, so a manually installed package can later become managed.
+
+Bluefinctl is no longer provisioned by common. Removing its dedicated Brewfile
+uses this existing lifecycle to uninstall state-tracked copies; no separate
+cleanup script is needed. Native `ujust` recipes must not delegate to `bctl`,
+even if an untracked copy remains installed.
 
 ### Add or remove a cask
 
@@ -123,8 +130,8 @@ launcher.
 
 Homebrew 6.0 syntax — `trusted: true` is required:
 ```ruby
-tap "projectbluefin/bluefinctl", trusted: true
-brew "bluefinctl"
+tap "frostyard/tap", trusted: true
+cask "chairlift"
 ```
 Without `trusted: true` the tap is blocked and the formula is silently
 unavailable. See [placement-rules.md](references/placement-rules.md#homebrew-60-tap-trust-required-as-of-2026-06-11).

--- a/docs/skills/brew-lifecycle/references/package-set.md
+++ b/docs/skills/brew-lifecycle/references/package-set.md
@@ -7,8 +7,8 @@ Part of [brew-lifecycle](../SKILL.md) — current default package list, what bel
 ## Current default package set (preinstall.d)
 
 `system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/system-cli.Brewfile`
-is the only file that auto-installs packages for every user on every variant.
-As of 2026-06, it contains 11 packages:
+defines the default CLI set. Other Brewfiles in the same directory also
+provision managed packages for every variant. The CLI set contains 11 packages:
 
 | Package | Purpose | Deps |
 |---|---|---|
@@ -117,4 +117,6 @@ that touches `system_files/shared/usr/share/ublue-os/homebrew/**`.
 
 **Resolution:** `shared/preinstall.d/` is the unambiguous home for any package that is factory-wide. `bluefin/preinstall.d/` should only contain packages that are intentionally absent from Dakota.
 
-**Concrete example:** `bluefinctl.Brewfile` was in `bluefin/preinstall.d/` — Dakota appeared to get it incidentally but the intent was ambiguous. Moving it to `shared/preinstall.d/` made the intent explicit and confirmed coverage for all variants (common PR 750, 2026-06-21).
+**Concrete example:** `chairlift.Brewfile` lives in
+`system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/`, making its
+all-variant provisioning explicit.

--- a/docs/skills/devmode.md
+++ b/docs/skills/devmode.md
@@ -40,7 +40,7 @@ metadata:
 
 File: `system_files/bluefin/usr/share/ublue-os/just/system.just`
 
-`ujust toggle-devmode` is a legacy compatibility name. Docs and UX should point users to `ujust devmode` or `bctl --screen developer`.
+`ujust toggle-devmode` is a legacy compatibility name. Docs and UX should point users to `ujust devmode`.
 
 ---
 
@@ -150,7 +150,7 @@ The old `image-flavor =~ dx` gate was removed. That gate was dead once the -dx i
 
 1. Treat `ujust devmode` as the canonical entrypoint; only mention `toggle-devmode` as legacy compatibility context.
 2. Verify the current implementation in `system_files/bluefin/usr/share/ublue-os/just/system.just` before documenting behavior.
-3. Describe Developer Mode as an in-place setup flow: `bctl --screen developer` first when available, otherwise the gum wizard.
+3. Describe Developer Mode as an in-place setup flow: `ujust devmode` opens the gum wizard.
 4. Document optional tools exactly as the wizard presents them, including incus via `brew install incus`.
 5. Reject stale fallbacks: no `setup-incus` recipe, no `rpm-ostree install`, no `incus-distrobox` guidance.
 6. If touching downstream overrides, prefer removing stale overrides so common's implementation remains the source of truth.
@@ -174,7 +174,7 @@ The old `image-flavor =~ dx` gate was removed. That gate was dead once the -dx i
 
 ## Verification
 
-- [ ] User-facing docs recommend `ujust devmode` or `bctl`, not `ujust toggle-devmode`
+- [ ] User-facing docs recommend `ujust devmode`, not `ujust toggle-devmode`
 - [ ] No docs mention `setup-incus`
 - [ ] No docs recommend `rpm-ostree install` for Developer Mode tooling
 - [ ] Bluefin Developer Mode is described as in-place setup, not image rebasing

--- a/docs/skills/lab-testing/references/methodology.md
+++ b/docs/skills/lab-testing/references/methodology.md
@@ -44,7 +44,7 @@ The last successful nightly build is the benchmark: if it ran < 6h ago, dakota b
 
 ## Live toggle-testing methodology (production-accurate rebase testing)
 
-**Purpose:** Verify that `ujust toggle-testing` / `bctl toggle-testing` works correctly
+**Purpose:** Verify that the native `ujust toggle-testing` recipe works correctly
 for real production users — not by testing with a pre-baked testing disk, but by starting
 from a **stable** VM and rebasing live to **testing** exactly as a user would.
 
@@ -61,12 +61,16 @@ The live toggle test is the correct methodology because:
 - It tests the actual recipe logic: reading `image-info.json`, detecting `stable` tag,
   constructing `ghcr.io/projectbluefin/bluefin:testing`, calling `bootc switch`
 - The `:testing` image is pulled live from GHCR during the test — not from a local cache
-- It validates `bctl toggle-testing` (bluefinctl path) AND `ujust toggle-testing` (bash fallback)
+- It must execute the native `ujust toggle-testing` recipe, not a separate wrapper
 - It exercises `--enforce-container-sigpolicy` against the real production cosign signatures
 
 ### Live toggle workflow pattern
 
-Use the `toggle-testing-rebase` WorkflowTemplate with stable as the starting point:
+Inspect the deployed `toggle-testing-rebase` WorkflowTemplate before using it
+with stable as the starting point. Templates that still invoke `bctl` or
+substitute a direct `bootc switch` after recipe failure need updating in their
+owning repository. They do not prove the native recipe works. The requirements
+below do not imply that the deployed template has already been updated:
 
 ```yaml
 # Bluefin: stable → testing → stable (production user flow)
@@ -106,17 +110,17 @@ For LTS:
       value: bluefin-lts-test
 ```
 
-### What the workflow does (step by step)
+### Required workflow behavior (step by step)
 
 ```
 1. ensure-disk    → build/verify golden disk from :stable (BIB, ~20 min first run)
 2. provision-vm   → btrfs reflink clone (~32ms), boot VM with stable image
 3. pre-state      → collect-evidence: bootc status shows booted=stable ✓
 4. toggle-to-target →
-   a. Check bctl availability and version
-   b. Run: echo yes | bctl toggle-testing  (or ujust toggle-testing)
+   a. Verify the VM contains the recipe revision under test
+   b. Run ujust toggle-testing and accept its gum confirmation in a TTY
    c. Verify: bootc status shows staged=testing (live pull from GHCR)
-   d. If bctl didn't stage, guarantee via: sudo bootc switch ghcr.io/.../bluefin:testing
+   d. Fail if the recipe fails or no target is staged; do not bypass it
 5. reboot-forward → VM reboots into the newly staged :testing image
 6. verify-on-target → collect-evidence: bootc status shows booted=testing ✓
 7. toggle-back    → same process, testing → stable (tests the reverse direction)
@@ -125,12 +129,12 @@ For LTS:
 10. teardown      → delete VM + disk.raw
 ```
 
-### What the toggle-testing-rebase WorkflowTemplate tests
+### Required toggle-testing evidence
 
 For each VM, per direction (forward + backward):
-- **bctl availability**: is `bctl` installed and what version?
-- **bctl toggle-testing**: does it correctly invoke `bootc switch` to the target?
-- **ujust toggle-testing logic** (Python-side verification):
+- **Recipe revision**: does the VM contain the change being tested?
+- **Native recipe**: does `ujust toggle-testing` succeed after confirmation?
+- **ujust toggle-testing logic** (verify actual behavior, not just a reimplementation):
   - Reads `image-tag` from `/usr/share/ublue-os/image-info.json`
   - Applies the same mapping logic as the recipe (`stable→testing`, `lts→lts-testing`, etc.)
   - Confirms computed target matches expected

--- a/docs/skills/shell-scripts/references/testability-patterns.md
+++ b/docs/skills/shell-scripts/references/testability-patterns.md
@@ -156,20 +156,24 @@ and `INDEX_PATH` to point at the fixture tree before calling `build_catalog()`
 or `main()`. This keeps `--write` and `--check` safe in unit tests without
 touching the live repo files.
 
-### Isolate fallback paths from host-installed commands
+### Test retired delegation with a failing stub
 
-When testing a script's fallback implementation, a developer-machine command
-can short-circuit the code under test before mocks run. For example, a host
-`bctl` can bypass the `ujust changelogs` repository-selection logic. Filter
-known host-only paths from `PATH` after prepending the test stubs:
+Native recipes must work even when a retired delegate remains installed.
+Put a failing stub ahead of host commands in `PATH`, rather than hiding a
+particular installation directory:
 
 ```bash
-export PATH="${MOCKDIR}:$(printf '%s' "${PATH}" | tr ':' '\\n' \\
-    | grep -v '/.local/bin' | paste -sd: -)"
+printf '#!/bin/bash\necho "unexpected bctl invocation" >&2\nexit 99\n' > "${MOCKDIR}/bctl"
+chmod +x "${MOCKDIR}/bctl"
+export PATH="${MOCKDIR}:${PATH}"
 ```
 
-This keeps the test deterministic while retaining system tools needed by the
-script. Do not weaken assertions to accommodate the host command.
+The update and changelog suites use this to prove that an installed `bctl`
+cannot take over the recipe. Mock all remaining side-effecting commands and
+assert their calls as well as the exit status. Use `run ! grep ...` for negative
+Bats assertions: plain `! grep ...` can be ignored when another assertion follows.
+Never execute real host updates, channel switches, package installs, or resets
+in unit tests.
 
 ### XDG_CONFIG_HOME isolation in bats tests
 

--- a/system_files/bluefin/usr/share/ublue-os/homebrew/full-desktop.Brewfile
+++ b/system_files/bluefin/usr/share/ublue-os/homebrew/full-desktop.Brewfile
@@ -3,8 +3,7 @@
 #
 # This Brewfile contains a curated list of high-quality flatpak applications
 # that provide a full desktop experience on Bluefin. Install with:
-#   bluefinctl
-# and select "full-desktop" from the menu.
+#   brew bundle --file=/usr/share/ublue-os/homebrew/full-desktop.Brewfile
 #
 # These applications are all available from Flathub and include GNOME Circle
 # apps and other well-maintained community applications.

--- a/system_files/bluefin/usr/share/ublue-os/just/changelog.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/changelog.just
@@ -3,9 +3,6 @@
 # Show the changelog
 changelogs:
     #!/usr/bin/bash
-    if command -v bctl &>/dev/null; then
-        exec bctl changelogs
-    fi
 
     # Get Image Tag
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"

--- a/system_files/bluefin/usr/share/ublue-os/just/system.just
+++ b/system_files/bluefin/usr/share/ublue-os/just/system.just
@@ -7,9 +7,6 @@
 [no-exit-message]
 bluefin-cli:
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        exec bctl bluefin-cli
-    fi
     set -e
     BLING_SRC_DIR="/usr/share/ublue-os/bling"
     BLING_SCRIPT="bling.sh"
@@ -42,21 +39,15 @@ bluefin-cli:
         brew bundle --file=/usr/share/ublue-os/homebrew/cli.Brewfile
     fi
 
-# alias for toggle-devmode — opens the Developer panel in bluefinctl when available
+# alias for toggle-devmode
 devmode:
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        exec bctl --screen developer
-    fi
     ujust toggle-devmode
 
 # Set up the Developer Experience
 [group('System')]
 toggle-devmode:
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        exec bctl devmode --enable
-    fi
     set -e
     JUSTFILE="{{ justfile() }}"
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
@@ -241,9 +232,6 @@ toggle-devmode:
 [group('System')]
 toggle-testing:
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        exec bctl toggle-testing
-    fi
     set -euo pipefail
     IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
     IMAGE_TAG="$(jq -r '."image-tag"' < "${IMAGE_INFO_FILE}")"
@@ -275,9 +263,6 @@ toggle-testing:
 [group('System')]
 setup-vms:
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        exec bctl setup-vms
-    fi
     set -euo pipefail
     flatpak install --system --noninteractive flathub \
         org.virt_manager.virt-manager \
@@ -289,9 +274,6 @@ setup-vms:
 [group('System')]
 toggle-vms:
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        exec bctl toggle-vms
-    fi
     set -euo pipefail
     if flatpak list --system --columns=application 2>/dev/null | grep -q "org.virt_manager.virt-manager"; then
         gum confirm "Remove the VM stack (virt-manager + QEMU)?" || exit 0
@@ -309,10 +291,6 @@ toggle-vms:
 [group('System')]
 install-system-flatpaks $confirm="1":
     #!/usr/bin/env bash
-    if command -v bctl &>/dev/null; then
-        FLAG=""; [ "$confirm" = "0" ] && FLAG="--yes"
-        exec bctl install-system-flatpaks $FLAG
-    fi
     if [ "$confirm" != 0 ] ; then
         gum confirm "Install system flatpaks?" || exit 0
     fi
@@ -320,7 +298,7 @@ install-system-flatpaks $confirm="1":
 
 # Install default system flatpaks (alias for install-system-flatpaks)
 
-# For additional applications, run: bctl --screen developer
+# For additional developer tools, run: ujust devmode
 [group('System')]
 bluefin-apps:
     echo "Installing default system flatpaks..."

--- a/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile
@@ -1,2 +1,0 @@
-tap "projectbluefin/bluefinctl", trusted: true
-brew "bluefinctl"

--- a/system_files/shared/usr/share/ublue-os/just/apps.just
+++ b/system_files/shared/usr/share/ublue-os/just/apps.just
@@ -47,7 +47,7 @@ install-opentabletdriver:
       flatpak --system remove -y flathub net.opentabletdriver.OpenTabletDriver
     fi
 
-# Install CNCF tools from curated Brewfile | run: bctl --screen developer
+# Install CNCF tools from curated Brewfile
 [group('Apps')]
 cncf:
     #!/usr/bin/env bash

--- a/system_files/shared/usr/share/ublue-os/just/shared.just
+++ b/system_files/shared/usr/share/ublue-os/just/shared.just
@@ -10,9 +10,6 @@ toggle-tpm2:
 [group('System')]
 powerwash:
     #!/usr/bin/bash
-    if command -v bctl &>/dev/null; then
-        exec bctl powerwash
-    fi
     FIRST_CONFIRMATION=$(gum choose --header='Warning: This is an experimental feature that will reset this device to its factory state.' "No" "Yes - wipe this machine")
     if [[ "$FIRST_CONFIRMATION" != "Yes - wipe this machine" ]]; then
         echo "Powerwash cancelled."

--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -19,12 +19,8 @@ update:
         echo "Run an \`rpm-ostree reset\` and try again. This removes the Zero Maintenance guarantee, take appropriate precautions!"
         exit 1
     fi
-    # Hand off to bluefinctl when available — richer progress UI, same update logic
-    if command -v bctl &>/dev/null; then
-        exec bctl update
-    fi
     echo "Starting OS image update (this may take a while as layers download)..."
-    sudo bootc upgrade
+    sudo bootc upgrade || exit $?
     # Updates system Flatpaks
     if flatpak remotes | grep -q system; then
         flatpak update -y
@@ -44,7 +40,7 @@ alias auto-update := toggle-updates
 # Turn automatic updates on or off
 # Pass `enable`, `disable`, or `cancel` (case-insensitive) as ACTION or a
 # positional argument (e.g. `ujust toggle-updates enable`) to run non-
-# interactively without the bctl panel or gum prompt; the default
+# interactively without the gum prompt; the default
 
 # ACTION="prompt" keeps the interactive prompt.
 toggle-updates ACTION="prompt":
@@ -61,10 +57,6 @@ toggle-updates ACTION="prompt":
             exit 0
             ;;
         *)
-            # Open the bluefinctl Updates panel when available
-            if command -v bctl &>/dev/null; then
-                exec bctl --screen updates
-            fi
             CURRENT_STATE="disabled"
             if systemctl is-enabled -q rpm-ostreed-automatic.timer; then
                 CURRENT_STATE="enabled"

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -10,6 +10,8 @@
 #
 # Run: bats tests/test_brew_preinstall.bats
 
+bats_require_minimum_version 1.5.0
+
 BREW_PREINSTALL="$BATS_TEST_DIRNAME/../system_files/shared/usr/libexec/brew-preinstall"
 BREW_PREINSTALL_WRAPPER="$BATS_TEST_DIRNAME/../system_files/shared/usr/bin/brew-preinstall"
 BREW_PREINSTALL_SERVICE="$BATS_TEST_DIRNAME/../system_files/shared/usr/lib/systemd/user/brew-preinstall.service"
@@ -226,6 +228,30 @@ EOF
     [ "${status}" -eq 0 ]
     grep -q "brew uninstall" "${WORKDIR}/brew.log"
     grep -q "fd" "${WORKDIR}/brew.log"
+}
+
+@test "brew-preinstall: repository manifests remove previously managed bluefinctl" {
+    cp "${BATS_TEST_DIRNAME}/../system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/"*.Brewfile \
+        "${WORKDIR}/preinstall.d/"
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"oldhash","packages":["bluefinctl"],"casks":[]}' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q '^brew uninstall bluefinctl --ignore-dependencies$' "${WORKDIR}/brew.log"
+    run ! grep -q 'bluefinctl' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+    run ! grep -q '^brew tap .*bluefinctl' "${WORKDIR}/brew.log"
+}
+
+@test "brew-preinstall: repository manifests leave untracked installs alone" {
+    cp "${BATS_TEST_DIRNAME}/../system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/"*.Brewfile \
+        "${WORKDIR}/preinstall.d/"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    run ! grep -q '^brew uninstall ' "${WORKDIR}/brew.log"
+    run ! grep -q 'bluefinctl' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
 }
 
 @test "brew-preinstall: does not uninstall package still in Brewfile" {

--- a/tests/test_changelog.bats
+++ b/tests/test_changelog.bats
@@ -85,9 +85,10 @@ fi
 EOF
     chmod +x "${MOCKDIR}/grep"
 
-    # Keep the fallback recipe under test; a developer's host bctl must not
-    # short-circuit repository selection before the mocked curl calls.
-    export PATH="${MOCKDIR}:$(printf '%s' "${PATH}" | tr ':' '\n' | grep -v '/.local/bin' | paste -sd: -)"
+    # An installed copy must never bypass native repository selection.
+    printf '#!/bin/bash\necho "unexpected bctl invocation" >&2\nexit 99\n' > "${MOCKDIR}/bctl"
+    chmod +x "${MOCKDIR}/bctl"
+    export PATH="${MOCKDIR}:${PATH}"
 
     SCRIPT_FILE="${WORKDIR}/changelog.sh"
     _extract_script "${SCRIPT_FILE}"

--- a/tests/test_native_recipes.bats
+++ b/tests/test_native_recipes.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+# Stub scripts and extracted recipes must expand variables only when executed.
+# shellcheck disable=SC2016
+# Exercise native recipes with a leftover bctl installed. All system-changing
+# commands are mocked; never switch images, install packages, or reset the host.
+
+bats_require_minimum_version 1.5.0
+
+# Match the extraction approach used by the update/changelog suites so CI
+# needs only bash and bats, not a particular version of the just parser.
+_extract_recipe() {
+    local file="$1" recipe="$2"
+    awk -v recipe="${recipe}" '
+        $0 ~ ("^" recipe "([[:space:]].*)?:$") { found=1; next }
+        found && /^[^[:space:]]/ { exit }
+        found { sub(/^    /, ""); print }
+    ' "${file}" | sed 's/{{ justfile() }}/${SYSTEM_JUST}/g'
+}
+
+_run_recipe() {
+    local file="$1" recipe="$2"
+    _extract_recipe "${file}" "${recipe}" > "${WORKDIR}/${recipe}.sh"
+    run env confirm="${3:-1}" bash "${WORKDIR}/${recipe}.sh"
+}
+
+setup() {
+    WORKDIR="$(mktemp -d)"
+    export WORKDIR
+    export HOME="${WORKDIR}/home" XDG_CONFIG_HOME="${WORKDIR}/home/.config"
+    export SHELL=/bin/bash
+    unset ZDOTDIR
+    mkdir -p "${WORKDIR}/bin" "${HOME}"
+    export COMMAND_LOG="${WORKDIR}/commands.log"
+    touch "${COMMAND_LOG}"
+    ROOT="${BATS_TEST_DIRNAME}/.."
+    export SYSTEM_JUST="${WORKDIR}/system.just"
+    SHARED_JUST="${ROOT}/system_files/shared/usr/share/ublue-os/just/shared.just"
+    # Keep the absolute libvirt helper isolated without changing production code.
+    sed "s|/usr/libexec/ensure-libvirt-session-config|${WORKDIR}/bin/ensure-libvirt-session-config|g" \
+        "${ROOT}/system_files/bluefin/usr/share/ublue-os/just/system.just" > "${SYSTEM_JUST}"
+    _extract_recipe "${SYSTEM_JUST}" setup-vms > "${WORKDIR}/setup-vms.sh"
+    export IMAGE_INFO_FILE="${WORKDIR}/image-info.json"
+    printf '{"image-tag":"stable","image-ref":"ostree-image-signed:docker://ghcr.io/projectbluefin/bluefin"}' > "${IMAGE_INFO_FILE}"
+
+    for cmd in bootc brew ublue-bling ujust ensure-libvirt-session-config; do
+        printf '#!/bin/bash\necho "%s $*" >> "${COMMAND_LOG}"\n' "${cmd}" > "${WORKDIR}/bin/${cmd}"
+    done
+    for cmd in sudo pkexec; do
+        printf '#!/bin/bash\necho "%s $*" >> "${COMMAND_LOG}"\nexec "$@"\n' "${cmd}" > "${WORKDIR}/bin/${cmd}"
+    done
+    cat > "${WORKDIR}/bin/just" <<'MOCK'
+#!/bin/bash
+[[ "$1" == "--justfile" && "$2" == "${SYSTEM_JUST}" && "$3" == "setup-vms" ]] || exit 99
+exec bash "${WORKDIR}/setup-vms.sh"
+MOCK
+    cat > "${WORKDIR}/bin/bctl" <<'MOCK'
+#!/bin/bash
+echo "unexpected bctl invocation" >> "${COMMAND_LOG}"
+exit 99
+MOCK
+    cat > "${WORKDIR}/bin/flatpak" <<'MOCK'
+#!/bin/bash
+echo "flatpak $*" >> "${COMMAND_LOG}"
+if [[ "$1" == "list" ]]; then
+    printf '%s\n' "${MOCK_FLATPAK_LIST:-}"
+fi
+MOCK
+    cat > "${WORKDIR}/bin/gum" <<'MOCK'
+#!/bin/bash
+echo "gum $*" >> "${COMMAND_LOG}"
+case "$1" in
+    confirm) exit "${MOCK_CONFIRM_STATUS:-1}" ;;
+    choose)
+        if [[ -f "${WORKDIR}/chosen-once" ]]; then
+            printf '%s\n' "${MOCK_SECOND_CHOICE:-No}"
+        else
+            touch "${WORKDIR}/chosen-once"
+            printf '%s\n' "${MOCK_FIRST_CHOICE:-No}"
+        fi
+        ;;
+esac
+MOCK
+    chmod +x "${WORKDIR}/bin/"*
+    export PATH="${WORKDIR}/bin:${PATH}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+@test "native recipes: shipped files contain no bluefinctl provisioning or handoffs" {
+    run grep -rInE '\b(bctl|bluefinctl)\b' "${ROOT}/system_files"
+    [ "${status}" -eq 1 ]
+    [ ! -e "${ROOT}/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/bluefinctl.Brewfile" ]
+}
+
+@test "native bluefin-cli: enabling installs CLI bundle" {
+    _run_recipe "${SYSTEM_JUST}" bluefin-cli
+    [ "${status}" -eq 0 ]
+    grep -q '^ublue-bling ' "${COMMAND_LOG}"
+    grep -q '^brew bundle --file=/usr/share/ublue-os/homebrew/cli.Brewfile$' "${COMMAND_LOG}"
+}
+
+@test "native bluefin-cli: disabling does not reinstall CLI bundle" {
+    echo 'source /usr/share/ublue-os/bling/bling.sh' > "${HOME}/.bashrc"
+    _run_recipe "${SYSTEM_JUST}" bluefin-cli
+    [ "${status}" -eq 0 ]
+    grep -q '^ublue-bling ' "${COMMAND_LOG}"
+    run ! grep -q '^brew ' "${COMMAND_LOG}"
+}
+
+@test "native devmode: compatibility entry point opens the native wizard" {
+    _run_recipe "${SYSTEM_JUST}" devmode
+    [ "${status}" -eq 0 ]
+    grep -q '^ujust toggle-devmode$' "${COMMAND_LOG}"
+}
+
+@test "native toggle-devmode: declining installation makes no package or privilege calls" {
+    _run_recipe "${SYSTEM_JUST}" toggle-devmode
+    [ "${status}" -eq 0 ]
+    grep -q '^gum confirm Install now?$' "${COMMAND_LOG}"
+    run ! grep -qE '^(brew|flatpak|pkexec|sudo) ' "${COMMAND_LOG}"
+    [ ! -e "${HOME}/.config/bluefin/devmode" ]
+}
+
+@test "native toggle-testing: all supported channels retain signature enforcement" {
+    local source target
+    while read -r source target; do
+        printf '{"image-tag":"%s","image-ref":"ostree-image-signed:docker://ghcr.io/projectbluefin/bluefin"}' "${source}" > "${IMAGE_INFO_FILE}"
+        : > "${COMMAND_LOG}"
+        MOCK_CONFIRM_STATUS=0 _run_recipe "${SYSTEM_JUST}" toggle-testing
+        [ "${status}" -eq 0 ]
+        grep -qFx "pkexec bootc switch --enforce-container-sigpolicy ghcr.io/projectbluefin/bluefin:${target}" "${COMMAND_LOG}"
+    done <<'CHANNELS'
+stable testing
+latest testing
+testing stable
+lts lts-testing
+lts-testing lts
+lts-hwe lts-hwe-testing
+lts-hwe-testing lts-hwe
+CHANNELS
+}
+
+@test "native toggle-testing: declining confirmation does not switch images" {
+    _run_recipe "${SYSTEM_JUST}" toggle-testing
+    [ "${status}" -eq 0 ]
+    run ! grep -qE '^(pkexec|bootc) ' "${COMMAND_LOG}"
+}
+
+@test "native setup-vms: installs both flatpaks and runs the libvirt helper" {
+    _run_recipe "${SYSTEM_JUST}" setup-vms
+    [ "${status}" -eq 0 ]
+    grep -qFx 'flatpak install --system --noninteractive flathub org.virt_manager.virt-manager org.virt_manager.virt_manager.Extension.Qemu' "${COMMAND_LOG}"
+    grep -q '^ensure-libvirt-session-config ' "${COMMAND_LOG}"
+}
+
+@test "native toggle-vms: confirmation installs the native VM stack" {
+    MOCK_CONFIRM_STATUS=0 _run_recipe "${SYSTEM_JUST}" toggle-vms
+    [ "${status}" -eq 0 ]
+    grep -q '^flatpak install ' "${COMMAND_LOG}"
+    grep -q '^ensure-libvirt-session-config ' "${COMMAND_LOG}"
+}
+
+@test "native toggle-vms: declining removal leaves the VM stack alone" {
+    MOCK_FLATPAK_LIST=org.virt_manager.virt-manager _run_recipe "${SYSTEM_JUST}" toggle-vms
+    [ "${status}" -eq 0 ]
+    grep -q '^gum confirm Remove the VM stack' "${COMMAND_LOG}"
+    run ! grep -q '^flatpak uninstall ' "${COMMAND_LOG}"
+}
+
+@test "native install-system-flatpaks: confirmation is required by default" {
+    _run_recipe "${SYSTEM_JUST}" install-system-flatpaks
+    [ "${status}" -eq 0 ]
+    grep -q '^gum confirm Install system flatpaks?' "${COMMAND_LOG}"
+    run ! grep -q '^brew ' "${COMMAND_LOG}"
+}
+
+@test "native install-system-flatpaks: explicit noninteractive mode bundles flatpaks" {
+    _run_recipe "${SYSTEM_JUST}" install-system-flatpaks 0
+    [ "${status}" -eq 0 ]
+    grep -qFx 'brew bundle --file=/usr/share/ublue-os/homebrew/system-flatpaks.Brewfile' "${COMMAND_LOG}"
+    run ! grep -q '^gum confirm ' "${COMMAND_LOG}"
+}
+
+@test "native powerwash: declining first confirmation cancels reset" {
+    _run_recipe "${SHARED_JUST}" powerwash
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Powerwash cancelled."* ]]
+    [ "$(grep -c '^gum choose ' "${COMMAND_LOG}")" -eq 1 ]
+    run ! grep -qE '^(sudo|bootc) ' "${COMMAND_LOG}"
+}
+
+@test "native powerwash: declining second confirmation cancels reset" {
+    MOCK_FIRST_CHOICE='Yes - wipe this machine' _run_recipe "${SHARED_JUST}" powerwash
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Powerwash cancelled."* ]]
+    [ "$(grep -c '^gum choose ' "${COMMAND_LOG}")" -eq 2 ]
+    run ! grep -qE '^(sudo|bootc) ' "${COMMAND_LOG}"
+}
+
+@test "native powerwash: only two explicit confirmations reach the mocked reset" {
+    MOCK_FIRST_CHOICE='Yes - wipe this machine' MOCK_SECOND_CHOICE='Yes - wipe this machine' \
+        _run_recipe "${SHARED_JUST}" powerwash
+    [ "${status}" -eq 0 ]
+    [ "$(grep -c '^gum choose ' "${COMMAND_LOG}")" -eq 2 ]
+    grep -qFx 'sudo bootc install reset --experimental' "${COMMAND_LOG}"
+}

--- a/tests/test_update_just.bats
+++ b/tests/test_update_just.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Tests for update.just and toggle-updates recipes
 
+bats_require_minimum_version 1.5.0
+
 UPDATE_JUST="${BATS_TEST_DIRNAME}/../system_files/shared/usr/share/ublue-os/just/update.just"
 WORKDIR=""
 MOCKDIR=""
@@ -77,13 +79,21 @@ echo "sudo $*" >> "${COMMAND_LOG}"
 exec "$@"
 MOCK
 
-    for cmd in bootc; do
-        cat > "${MOCKDIR}/${cmd}" <<MOCK
+    _write_mock "bootc" <<'MOCK'
 #!/bin/bash
-echo "${cmd} \$*" >> "\${COMMAND_LOG}"
+echo "bootc $*" >> "${COMMAND_LOG}"
+if [[ "${MOCK_BOOTC_STATUS:-0}" != "0" ]]; then
+    echo "mock bootc upgrade failure" >&2
+fi
+exit "${MOCK_BOOTC_STATUS:-0}"
 MOCK
-        chmod +x "${MOCKDIR}/${cmd}"
-    done
+
+    # An installed copy must never take over the native recipes.
+    _write_mock "bctl" <<'MOCK'
+#!/bin/bash
+echo "unexpected bctl invocation" >&2
+exit 99
+MOCK
 
     _write_mock "rpm-ostree" <<'MOCK'
 #!/bin/bash
@@ -128,6 +138,7 @@ _run() {
     run env \
         PATH="${MOCKDIR}:${PATH}" \
         COMMAND_LOG="${COMMAND_LOG}" \
+        MOCK_BOOTC_STATUS="${MOCK_BOOTC_STATUS:-0}" \
         MOCK_HAS_UUPD_TIMER="${MOCK_HAS_UUPD_TIMER:-0}" \
         MOCK_ACTIVE_SERVICE="${MOCK_ACTIVE_SERVICE:-}" \
         MOCK_ENABLED_TIMER="${MOCK_ENABLED_TIMER:-}" \
@@ -164,6 +175,30 @@ _run() {
     [[ "${output}" == *"Starting OS image update"* ]]
     grep -qF "sudo bootc upgrade" "${COMMAND_LOG}"
     ! grep -qF "rpm-ostree upgrade" "${COMMAND_LOG}"
+}
+
+@test "update: preserves bootc failure and diagnostics without running package updates" {
+    _write_mock "brew" <<'MOCK'
+#!/bin/bash
+echo "brew $*" >> "${COMMAND_LOG}"
+MOCK
+    MOCK_BOOTC_STATUS=42 MOCK_FLATPAK_REMOTES=$'system\nuser' \
+        MOCK_BREW_BIN="${MOCKDIR}/brew" _run "${UPDATE_SCRIPT}"
+    [ "${status}" -eq 42 ]
+    [[ "${output}" == *"mock bootc upgrade failure"* ]]
+    run ! grep -qE '^(flatpak|brew) ' "${COMMAND_LOG}"
+}
+
+@test "update: updates both flatpak scopes and user-owned brew after bootc succeeds" {
+    _write_mock "brew" <<'MOCK'
+#!/bin/bash
+echo "brew $*" >> "${COMMAND_LOG}"
+MOCK
+    MOCK_FLATPAK_REMOTES=$'system\nuser' MOCK_BREW_BIN="${MOCKDIR}/brew" _run "${UPDATE_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -qF "flatpak update -y" "${COMMAND_LOG}"
+    grep -qF "flatpak update --user -y" "${COMMAND_LOG}"
+    grep -qFx "brew upgrade" "${COMMAND_LOG}"
 }
 
 @test "update: exits early with layered-packages warning when rpm-ostree has layered packages" {


### PR DESCRIPTION
## Summary

`ujust update` immediately reports “System Image failed” in projectbluefin/dakota#1481 and projectbluefin/common#806. I also reproduced the failure on Dakota while `sudo bootc upgrade` worked directly. This removes bluefinctl integration from common for all consuming images instead of adding Dakota-specific overrides.

1. **Remove automatic provisioning.** The shared bluefinctl Brewfile is deleted. The existing Homebrew lifecycle removes copies recorded in the previous managed state on the next successful sync. Untracked copies are left alone.

2. **Use the native recipes.** All `bctl` handoffs are removed, including updates, developer setup, channel switching, VM setup, Flatpak installation, changelogs, and powerwash. Existing confirmations and channel-switch signature enforcement remain intact.

3. **Keep update failures visible.** The update recipe calls `sudo bootc upgrade` directly and stops with its failure status instead of continuing into package updates. Registry and network errors remain visible, this does not add automatic retries.

4. **Keep tests independent of installed bluefinctl copies.** The update and changelog suites use a failing `bctl` stub so an installed copy cannot bypass the mocked commands. Both suites pass, addressing the failures reported in projectbluefin/common#946. Additional tests cover managed removal and the restored native recipes.

Fixes projectbluefin/dakota#1481
Fixes projectbluefin/common#806
Fixes projectbluefin/common#946
