### PR TITLE
fix: resolve cask references and expose validation errors

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "system_files/**"
       - "tests/**"
+      - "scripts/validate-brewfiles.sh"
       - "Justfile"
   push:
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - "system_files/**"
       - "tests/**"
+      - "scripts/validate-brewfiles.sh"
       - "Justfile"
   merge_group:
   workflow_dispatch:
@@ -114,6 +116,11 @@ jobs:
 
       - name: Run bats (brew-preinstall)
         run: bats tests/test_brew_preinstall.bats
+
+      - name: Test Brewfile validator
+        run: |
+          shellcheck scripts/validate-brewfiles.sh tests/test_validate_brewfiles.bats
+          bats tests/test_validate_brewfiles.bats
 
       - name: Run bats (oem-brew hook)
         run: bats tests/test_oem_brew.bats

--- a/.github/workflows/validate-brewfiles.yaml
+++ b/.github/workflows/validate-brewfiles.yaml
@@ -6,9 +6,14 @@ on:
   pull_request:
     paths:
       - "system_files/shared/usr/share/ublue-os/homebrew/**"
+      - "scripts/validate-brewfiles.sh"
+      - "tests/test_validate_brewfiles.bats"
+      - ".github/workflows/validate-brewfiles.yaml"
+      - "Justfile"
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -18,50 +23,4 @@ jobs:
 
       - name: Validate Brewfiles
         shell: bash
-        run: |
-          echo "Validating Brewfiles in homebrew directory..."
-
-          STATUS_FILE=$(mktemp)
-          echo "PASS" > "$STATUS_FILE"
-
-          while IFS= read -r -d '' brewfile ; do
-            echo "::group:: ===$(basename "$brewfile")==="
-
-            echo "Syncing taps..."
-            grep -E -e "^tap" "$brewfile" > taps.Brewfile || true
-            brew bundle --file=./taps.Brewfile > /dev/null 2>&1 || true
-
-            # Extract combined list for parallel check
-            FORMULAS=$(grep -E '^\s*brew\s+["'\'']' "$brewfile" | sed -E 's/^\s*brew\s+["'\'']([^"'\'']+)["'\''].*/formula \1/' || true)
-            CASKS=$(grep -E '^\s*cask\s+["'\'']' "$brewfile" | sed -E 's/^\s*cask\s+["'\'']([^"'\'']+)["'\''].*/cask \1/' || true)
-
-            ENTRIES=$(printf "%s\n%s" "$FORMULAS" "$CASKS" | grep -v '^\s*$' || true)
-
-            if [ -n "$ENTRIES" ]; then
-              # shellcheck disable=SC2016
-              echo "$ENTRIES" | xargs -P 8 -I {} bash -c '
-                TYPE=$(echo "{}" | cut -d" " -f1)
-                NAME=$(echo "{}" | cut -d" " -f2)
-                if ! brew info --$TYPE "$NAME" &> /dev/null; then
-                  echo "✗ $TYPE \"$NAME\" is invalid or missing tap"
-                  echo "FAIL" >> "'"$STATUS_FILE"'"
-                else
-                  echo "✓ $TYPE \"$NAME\" is valid"
-                fi
-              '
-            else
-              echo "No formulas or casks found."
-            fi
-
-            echo "::endgroup::"
-          done < <(find "system_files/shared/usr/share/ublue-os/homebrew" -iname '*\.Brewfile*' -print0)
-
-          rm -f taps.Brewfile
-
-          if grep -q "FAIL" "$STATUS_FILE"; then
-            echo "Validation complete. Some Brewfiles FAILED."
-            exit 1
-          else
-            echo "Validation complete. All Brewfiles PASSED."
-            exit 0
-          fi
+        run: bash scripts/validate-brewfiles.sh

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,7 @@ test:
     bats tests/test_dynamic_wallpaper.bats
     bats tests/test_geoclue_latitude.bats
     bats tests/test_brew_preinstall.bats
+    bats tests/test_validate_brewfiles.bats
     bats tests/test_oem_brew.bats
     bats tests/test_bonedigger_report.bats
     bats tests/test_hardware_hooks.bats
@@ -68,6 +69,11 @@ _fmt mode verb:
 # .github/workflows/validate-chairlift-config.yaml owns this gate.
 check-chairlift-config:
     python3 tests/check-chairlift-config
+
+# Networked metadata check; syncs/trusts declared taps but installs no packages.
+# Keep separate from the hermetic check recipe.
+check-brewfiles:
+    bash scripts/validate-brewfiles.sh
 
 check: (_fmt "--check" "Checking")
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -11,6 +11,11 @@ just check         # lint Justfile
 pre-commit run --all-files  # hygiene checks (shellcheck, yaml, sha-pinning)
 ```
 
+`just check-brewfiles` is a separate networked check against real Homebrew
+metadata. It syncs/trusts taps declared by the shared Brewfiles, but does not
+install formulae or casks. Use a disposable Homebrew environment when testing
+it locally. Its offline regression suite is `bats tests/test_validate_brewfiles.bats`.
+
 ## What Must Be Tested
 
 ### Rule: new script in `system_files/*/usr/bin/` → new test file in `tests/`
@@ -91,6 +96,7 @@ Do not add exemptions for scripts with branching logic.
 | `tests/test_ublue_fastfetch.bats` | `ublue-fastfetch` — config reads, shuffle branch, DEFAULT_THEME export to ublue-bling-fastfetch |
 | `tests/test_theming_hook.bats` | `10-theming.sh` — Framework/Thelio branches and setup idempotency |
 | `tests/test_brew_preinstall.bats` | Managed Brewfile lifecycle plus user-unit ordering, resource priority, and preset delivery |
+| `tests/test_validate_brewfiles.bats` | Brewfile metadata validation, tap setup failures, ambiguity diagnostics, safe argument passing, and qualified wallpaper/Zed references |
 
 ## Quality Epic
 

--- a/docs/skills/ci-pitfalls/SKILL.md
+++ b/docs/skills/ci-pitfalls/SKILL.md
@@ -46,6 +46,33 @@ metadata:
 
 ---
 
+## Brewfile metadata validation must preserve the actual failure
+
+`just check-brewfiles` runs `scripts/validate-brewfiles.sh`, the same entrypoint
+as `.github/workflows/validate-brewfiles.yaml`. It checks every shared Brewfile,
+not only changed entries. The workflow also triggers for validator/test changes.
+This is networked and syncs the declared taps, so it stays outside `just check`.
+
+Sync the complete declared tap set before checking any package names. Per-file
+tap setup makes bare-name resolution depend on traversal order: ChairLift adds
+`frostyard/tap`, which also provides the five wallpaper casks in `ublue-os/tap`.
+Use fully qualified names in `artwork.Brewfile`; do not hide the collision by
+isolating taps or skipping unchanged Brewfiles. Zed's Linux cask lives in
+`ublue-os/tap`, not `ublue-os/experimental-tap`.
+
+A tap-setup failure must fail validation before package checks. For package
+failures, report the Brewfile and line, exact command, exit status, and captured
+stdout/stderr, then continue to collect the remaining failures. Do not collapse
+ambiguity, authentication, trust, network, and unavailable-cask errors into
+"invalid or missing tap". Pass package names as arguments, never into `bash -c`.
+
+The validator accepts literal `brew`/`cask` declarations (both quote styles,
+indentation, comments, and inline options). Malformed or computed names fail
+explicitly. This is a metadata check, not a complete Ruby DSL, Flatpak,
+installation, checksum-download, or desktop-runtime test. It never installs
+formulae or casks. Keep mock regression tests in `tests/test_validate_brewfiles.bats`
+and retain real Homebrew validation in CI.
+
 ## Red Flags
 
 - A PR targets `testing` but the branch was created from `main`

--- a/scripts/validate-brewfiles.sh
+++ b/scripts/validate-brewfiles.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Check every shared Brewfile against real Homebrew metadata. This syncs declared
+# taps but never installs formulae/casks. It is networked, not part of just check.
+
+main() (
+    set -euo pipefail
+    if [[ $# -gt 1 ]]; then
+        echo "Usage: $0 [brewfile-directory]" >&2
+        exit 2
+    fi
+    root="${1:-system_files/shared/usr/share/ublue-os/homebrew}"
+    if [[ ! -d "${root}" ]]; then
+        printf 'Brewfile directory does not exist: %s\n' "${root}" >&2
+        exit 2
+    fi
+    if ! command -v brew >/dev/null; then
+        echo "Homebrew is required to validate Brewfiles." >&2
+        exit 2
+    fi
+
+    workdir=$(mktemp -d)
+    trap 'rm -rf -- "${workdir}"' EXIT
+    # Materialize discovery so find/sort failures cannot become an empty success.
+    find "${root}" -type f -iname '*.Brewfile' -print0 | sort -z > "${workdir}/files"
+    mapfile -d '' -t brewfiles < "${workdir}/files"
+    if [[ ${#brewfiles[@]} -eq 0 ]]; then
+        printf 'No Brewfiles found in %s\n' "${root}" >&2
+        exit 2
+    fi
+
+    # Sync the complete tap set first: otherwise bare-name ambiguity depends on
+    # which Brewfile find happens to visit first. Preserve declared trust flags.
+    sed -n '/^[[:space:]]*tap[[:space:]]/p' "${brewfiles[@]}" | sort -u > "${workdir}/taps.Brewfile"
+    if [[ -s "${workdir}/taps.Brewfile" ]]; then
+        echo "Syncing declared taps from:"
+        printf '  %s\n' "${brewfiles[@]}"
+        sed 's/^/  /' "${workdir}/taps.Brewfile"
+        if brew bundle --file="${workdir}/taps.Brewfile" > "${workdir}/output" 2>&1; then
+            echo "Tap setup passed."
+        else
+            rc=$?
+            printf 'FAIL: tap setup (exit %s). Package checks were not run.\n' "${rc}" >&2
+            printf 'Command: brew bundle --file=%q\n' "${workdir}/taps.Brewfile" >&2
+            sed 's/^/  /' "${workdir}/output" >&2
+            exit 1
+        fi
+    fi
+
+    # The repository uses literal brew/cask declarations, not computed Ruby.
+    # Reject malformed declarations rather than silently skipping them.
+    double_entry='^[[:space:]]*(brew|cask)[[:space:]]+"([^"]+)"([[:space:]]*,.*|[[:space:]]*(#.*)?)$'
+    single_entry="^[[:space:]]*(brew|cask)[[:space:]]+'([^']+)'([[:space:]]*,.*|[[:space:]]*(#.*)?)$"
+    declaration='^[[:space:]]*(brew|cask)([^[:alnum:]_]|$)'
+    checked=0
+    failed=0
+    for brewfile in "${brewfiles[@]}"; do
+        printf '\nBrewfile: %s\n' "${brewfile}"
+        line_number=0
+        while IFS= read -r line || [[ -n "${line}" ]]; do
+            line_number=$((line_number + 1))
+            if [[ "${line}" =~ ${double_entry} || "${line}" =~ ${single_entry} ]]; then
+                type="${BASH_REMATCH[1]}"
+                name="${BASH_REMATCH[2]}"
+                [[ "${type}" != brew ]] || type=formula
+                checked=$((checked + 1))
+                # Pass names as data, never interpolate them into bash -c.
+                # Serial checks keep each error adjacent to its source location.
+                if brew info "--${type}" -- "${name}" > "${workdir}/output" 2>&1; then
+                    printf 'PASS: %s:%s: %s %s\n' "${brewfile}" "${line_number}" "${type}" "${name}"
+                else
+                    rc=$?
+                    failed=$((failed + 1))
+                    printf 'FAIL: %s:%s: %s %s (exit %s)\n' "${brewfile}" "${line_number}" "${type}" "${name}" "${rc}" >&2
+                    printf 'Command: brew info --%s -- %q\n' "${type}" "${name}" >&2
+                    sed 's/^/  /' "${workdir}/output" >&2
+                fi
+            elif [[ "${line}" =~ ${declaration} ]]; then
+                failed=$((failed + 1))
+                printf 'FAIL: %s:%s: expected a quoted literal brew/cask name: %s\n' "${brewfile}" "${line_number}" "${line}" >&2
+            fi
+        done < "${brewfile}"
+    done
+    printf '\nValidation complete: %s Brewfiles, %s package checks, %s failures.\n' "${#brewfiles[@]}" "${checked}" "${failed}"
+    [[ "${failed}" -eq 0 ]]
+)
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/system_files/shared/usr/share/ublue-os/homebrew/artwork.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/artwork.Brewfile
@@ -1,7 +1,7 @@
 tap "ublue-os/tap", trusted: true
 
-cask "aurora-wallpapers"
-cask "bazzite-wallpapers"
-cask "bluefin-wallpapers"
-cask "bluefin-wallpapers-extra"
-cask "framework-wallpapers"
+cask "ublue-os/tap/aurora-wallpapers"
+cask "ublue-os/tap/bazzite-wallpapers"
+cask "ublue-os/tap/bluefin-wallpapers"
+cask "ublue-os/tap/bluefin-wallpapers-extra"
+cask "ublue-os/tap/framework-wallpapers"

--- a/system_files/shared/usr/share/ublue-os/homebrew/experimental-ide.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/experimental-ide.Brewfile
@@ -1,4 +1,5 @@
 tap "ublue-os/experimental-tap", trusted: true
+tap "ublue-os/tap", trusted: true
 cask "ublue-os/experimental-tap/cursor-linux"
 cask "ublue-os/experimental-tap/clion-linux"
 cask "ublue-os/experimental-tap/datagrip-linux"
@@ -12,4 +13,4 @@ cask "ublue-os/experimental-tap/rider-linux"
 cask "ublue-os/experimental-tap/rubymine-linux"
 cask "ublue-os/experimental-tap/rustrover-linux"
 cask "ublue-os/experimental-tap/webstorm-linux"
-cask "ublue-os/experimental-tap/zed-linux"
+cask "ublue-os/tap/zed-linux"

--- a/tests/test_validate_brewfiles.bats
+++ b/tests/test_validate_brewfiles.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+# All commands use a fake brew, never the host's package manager.
+bats_require_minimum_version 1.5.0
+
+setup() {
+    WORKDIR=$(mktemp -d)
+    ROOT="${BATS_TEST_DIRNAME}/.."
+    SCRIPT="${ROOT}/scripts/validate-brewfiles.sh"
+    export FIXTURES="${WORKDIR}/Brewfiles with spaces"
+    export CALLS="${WORKDIR}/calls" TAPS="${WORKDIR}/taps"
+    export TMPDIR="${WORKDIR}/scratch"
+    mkdir -p "${FIXTURES}" "${TMPDIR}" "${WORKDIR}/bin"
+    touch "${CALLS}"
+    cat > "${WORKDIR}/bin/brew" <<'MOCK'
+#!/bin/bash
+printf '%s|%s|%s\n' "${1:-}" "${2:-}" "${@: -1}" >> "${CALLS}"
+case "$1" in
+    bundle)
+        cp "${2#--file=}" "${TAPS}"
+        if [[ "${MOCK_TAP_STATUS:-0}" != 0 ]]; then
+            echo 'tap stdout diagnostic'
+            echo 'tap stderr: authentication/network/trust error' >&2
+            exit "${MOCK_TAP_STATUS}"
+        fi
+        ;;
+    info)
+        [[ $# -eq 4 && "$3" == -- ]] || exit 99
+        case " ${MOCK_INFO_FAILURES:-} " in
+            *" $4 "*)
+                echo 'metadata stdout diagnostic'
+                echo "${MOCK_INFO_ERROR:-metadata stderr: cask unavailable}" >&2
+                exit 42
+                ;;
+        esac
+        ;;
+    *) echo "unexpected brew operation: $*" >&2; exit 99 ;;
+esac
+MOCK
+    chmod +x "${WORKDIR}/bin/brew"
+    export PATH="${WORKDIR}/bin:${PATH}"
+}
+
+teardown() {
+    rm -rf "${WORKDIR}"
+}
+
+@test "validator checks formulas and casks recursively with source lines" {
+    mkdir "${FIXTURES}/nested"
+    printf '  brew "ripgrep" # comment\n' > "${FIXTURES}/nested/test.Brewfile"
+    echo "  cask 'demo', args: { no_quarantine: true }" >> "${FIXTURES}/nested/test.Brewfile"
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"test.Brewfile:1: formula ripgrep"* ]]
+    [[ "${output}" == *"test.Brewfile:2: cask demo"* ]]
+    [[ "${output}" == *"1 Brewfiles, 2 package checks, 0 failures"* ]]
+    grep -qFx 'info|--formula|ripgrep' "${CALLS}"
+    grep -qFx 'info|--cask|demo' "${CALLS}"
+    [ ! -e "${TAPS}" ]
+}
+
+@test "validator syncs all declared taps before any package checks" {
+    printf 'tap "one/tap", trusted: true\ncask "one/tap/demo"\n' > "${FIXTURES}/a.Brewfile"
+    printf 'tap "two/tap", trusted: true\ntap "one/tap", trusted: true\n' > "${FIXTURES}/z.Brewfile"
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 0 ]
+    grep -qFx 'tap "one/tap", trusted: true' "${TAPS}"
+    grep -qFx 'tap "two/tap", trusted: true' "${TAPS}"
+    [ "$(wc -l < "${TAPS}")" -eq 2 ]
+    [[ "$(head -1 "${CALLS}")" == bundle\|* ]]
+    run ! grep -qE '^[[:space:]]*(brew|cask) ' "${TAPS}"
+}
+
+@test "tap failure is fatal and preserves both output streams" {
+    printf 'tap "broken/tap", trusted: true\ncask "demo"\n' > "${FIXTURES}/test.Brewfile"
+    MOCK_TAP_STATUS=17 run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"tap setup (exit 17)"* ]]
+    [[ "${output}" == *"Package checks were not run"* ]]
+    [[ "${output}" == *"Command: brew bundle"* ]]
+    [[ "${output}" == *"broken/tap"* ]]
+    [[ "${output}" == *"tap stdout diagnostic"* ]]
+    [[ "${output}" == *"tap stderr: authentication/network/trust error"* ]]
+    run ! grep -q '^info|' "${CALLS}"
+}
+
+@test "cask failure reports file line command exit code and original error" {
+    printf '# heading\ncask "missing"\n' > "${FIXTURES}/test.Brewfile"
+    MOCK_INFO_FAILURES=missing run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"${FIXTURES}/test.Brewfile:2: cask missing (exit 42)"* ]]
+    [[ "${output}" == *"Command: brew info --cask -- missing"* ]]
+    [[ "${output}" == *"metadata stdout diagnostic"* ]]
+    [[ "${output}" == *"metadata stderr: cask unavailable"* ]]
+    [[ "${output}" == *"1 package checks, 1 failures"* ]]
+}
+
+@test "ambiguity is not mislabeled as a missing tap" {
+    echo 'cask "wallpapers"' > "${FIXTURES}/test.Brewfile"
+    MOCK_INFO_FAILURES=wallpapers MOCK_INFO_ERROR='Cask wallpapers exists in multiple taps: frostyard/tap, ublue-os/tap' \
+        run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"exists in multiple taps: frostyard/tap, ublue-os/tap"* ]]
+    [[ "${output}" != *"invalid or missing tap"* ]]
+}
+
+@test "validator reports every failure and continues through later files" {
+    printf 'cask "missing"\nbrew "ripgrep"\n' > "${FIXTURES}/a.Brewfile"
+    printf 'brew "other"\ncask "good"\n' > "${FIXTURES}/z.Brewfile"
+    MOCK_INFO_FAILURES='missing other' run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"2 Brewfiles, 4 package checks, 2 failures"* ]]
+    grep -qFx 'info|--formula|ripgrep' "${CALLS}"
+    grep -qFx 'info|--cask|good' "${CALLS}"
+}
+
+@test "validator checks final declaration without newline and ignores comments and flatpaks" {
+    printf '# cask "ignored"\nflatpak "org.example.App"\nbrew "ripgrep"' > "${FIXTURES}/test.Brewfile"
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 0 ]
+    [ "$(wc -l < "${CALLS}")" -eq 1 ]
+    grep -qFx 'info|--formula|ripgrep' "${CALLS}"
+}
+
+@test "malformed and computed declarations fail instead of disappearing" {
+    printf 'brew "missing-close\ncask package_name\nbrew "good"\ncask(package_name)\n' > "${FIXTURES}/test.Brewfile"
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"test.Brewfile:1: expected a quoted literal"* ]]
+    [[ "${output}" == *"test.Brewfile:2: expected a quoted literal"* ]]
+    [[ "${output}" == *"test.Brewfile:4: expected a quoted literal"* ]]
+    [[ "${output}" == *"1 package checks, 3 failures"* ]]
+}
+
+# The malicious command substitution must stay literal in both fixture and assertion.
+# shellcheck disable=SC2016
+@test "package names are passed as data and never evaluated as shell code" {
+    printf 'cask "$(touch %s/pwned)"\n' "${WORKDIR}" > "${FIXTURES}/test.Brewfile"
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 0 ]
+    [ ! -e "${WORKDIR}/pwned" ]
+    grep -qF 'info|--cask|$(touch ' "${CALLS}"
+}
+
+@test "validator fails for nonexistent or empty directories and invalid arguments" {
+    run bash "${SCRIPT}" "${WORKDIR}/missing"
+    [ "${status}" -eq 2 ]
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 2 ]
+    [[ "${output}" == *"No Brewfiles found"* ]]
+    run bash "${SCRIPT}" one two
+    [ "${status}" -eq 2 ]
+    [[ "${output}" == *"Usage:"* ]]
+    [ ! -s "${CALLS}" ]
+}
+
+@test "validator reports missing Homebrew before running any commands" {
+    rm "${WORKDIR}/bin/brew"
+    run /usr/bin/env PATH="${WORKDIR}/bin" /bin/bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 2 ]
+    [[ "${output}" == *"Homebrew is required"* ]]
+}
+
+@test "validator cleans scratch files on success and failure" {
+    echo 'cask "missing"' > "${FIXTURES}/test.Brewfile"
+    run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 0 ]
+    [ -z "$(ls -A "${TMPDIR}")" ]
+    MOCK_INFO_FAILURES=missing run bash "${SCRIPT}" "${FIXTURES}"
+    [ "${status}" -eq 1 ]
+    [ -z "$(ls -A "${TMPDIR}")" ]
+}
+
+@test "repository artwork and Zed use the intended unambiguous cask names" {
+    local shared="${ROOT}/system_files/shared/usr/share/ublue-os/homebrew"
+    local name
+    for name in aurora-wallpapers bazzite-wallpapers bluefin-wallpapers bluefin-wallpapers-extra framework-wallpapers; do
+        grep -qFx "cask \"ublue-os/tap/${name}\"" "${shared}/artwork.Brewfile"
+    done
+    grep -qFx 'cask "ublue-os/tap/zed-linux"' "${shared}/experimental-ide.Brewfile"
+    grep -qFx 'tap "ublue-os/tap", trusted: true' "${shared}/experimental-ide.Brewfile"
+    run ! grep -q 'ublue-os/experimental-tap/zed-linux' "${shared}/experimental-ide.Brewfile"
+}


### PR DESCRIPTION
## Summary

The Brewfile validation failure on #1083 exposed six existing package-reference problems. The check hid Homebrew’s actual errors behind “invalid or missing tap”, so I reproduced them locally to identify what was failing.

1. **Correct Zed’s tap.** The Linux cask moved from `ublue-os/experimental-tap` to `ublue-os/tap` in [upstream PR #572](https://github.com/ublue-os/homebrew-experimental-tap/pull/572). The Brewfile now uses its current location.

2. **Disambiguate the wallpaper casks.** Both `frostyard/tap` and `ublue-os/tap` provide these five names. The artwork Brewfile now uses fully qualified `ublue-os/tap` references.

3. **Make validation failures actionable.** The validator reports the Brewfile, line, command, exit code, and original Homebrew output. Tap setup failures stop validation, while package checks continue collecting errors rather than stopping at the first failure.

4. **Keep the check strict and reproducible.** All shared Brewfiles remain covered, with the complete tap set prepared before checking package names. CI and `just check-brewfiles` use the same script, backed by 13 regression tests.

Verified: Real Homebrew passed all 186 package checks. The unchanged Brewfiles reproduced exactly the six original failures with useful diagnostics, and a fixture incorporating #1083 passed all 185 remaining checks. ShellCheck, pre-commit, and `just check` pass. The full local suite still encounters two pre-existing setup-test failures.

Related: #1083
