### PR TITLE
test: isolate UWELCOME_SHOWN in test_motd_integration.bats

### DIFF
--- a/docs/skills/shell-scripts/references/bats-patterns.md
+++ b/docs/skills/shell-scripts/references/bats-patterns.md
@@ -87,3 +87,19 @@ grep -q "^name:!\*::" file
 # ALSO CORRECT — -F disables regex entirely
 grep -qF "name:!*::" file
 ```
+
+## Isolating environment in profile/login scripts
+
+Scripts under `etc/profile.d/` often check guard variables (e.g. `UWELCOME_SHOWN`)
+to prevent duplicate execution across chained shells. When bats runs in an
+interactive login session, those guard variables are already set in the caller's
+environment, causing tests to fail silently or unexpectedly skip script bodies.
+Always unset or isolate session guard variables in `setup()`:
+
+```bash
+setup() {
+    WORKDIR="$(mktemp -d)"
+    ...
+    unset UWELCOME_SHOWN
+}
+```

--- a/tests/test_motd_integration.bats
+++ b/tests/test_motd_integration.bats
@@ -37,6 +37,7 @@ setup() {
 
     export HOME="${WORKDIR}/home"
     export PATH="${WORKDIR}/bin:${PATH}"
+    unset UWELCOME_SHOWN
 }
 
 teardown() {
@@ -102,6 +103,13 @@ teardown() {
 @test "uwelcome.sh: does not call legacy ublue-motd" {
     run grep 'ublue-motd' "${UWELCOME_PROFILE}"
     [ "${status}" -ne 0 ]
+}
+
+@test "uwelcome.sh: skips invocation if UWELCOME_SHOWN is set" {
+    export UWELCOME_SHOWN=1
+    run bash "${UWELCOME_PROFILE}"
+    [ "${status}" -eq 0 ]
+    [ ! -f "${WORKDIR}/uwelcome.log" ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When bats tests run in an interactive login session where `uwelcome.sh` has already run, `UWELCOME_SHOWN=1` is inherited by the subshells executing `system_files/shared/etc/profile.d/uwelcome.sh`. This causes tests asserting that `uwelcome` was executed to fail because `uwelcome.sh` skips execution when `UWELCOME_SHOWN` is non-empty.

This PR:
1. Adds `unset UWELCOME_SHOWN` to `setup()` in `tests/test_motd_integration.bats`.
2. Adds a regression test asserting that `uwelcome.sh` skips invocation when `UWELCOME_SHOWN` is set.
3. Documents the profile.d environment isolation pattern in `docs/skills/shell-scripts/references/bats-patterns.md`.

## Verification
- `just check` passes.
- `pytest tests/` passes (109 passed).
- `bats tests/test_motd_integration.bats` passes (21 passed).
- `bats tests/` passes (313 passed).

Assisted-by: Gemini 3.8 Flash via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
