### PR TITLE
feat: add llmman to ai-tools Brewfile

### DIFF
--- a/system_files/shared/usr/share/ublue-os/homebrew/ai-tools.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/ai-tools.Brewfile
@@ -1,5 +1,6 @@
 tap "anomalyco/tap"
 tap "charmbracelet/tap"
+tap "llmmanorg/tap"
 tap "ublue-os/tap", trusted: true
 tap "ublue-os/experimental-tap", trusted: true
 brew "anomalyco/tap/opencode"
@@ -8,6 +9,7 @@ brew "charmbracelet/tap/crush"
 brew "kimi-code"
 brew "llm"
 brew "llmfit"
+brew "llmmanorg/tap/llmman"
 brew "mistral-vibe"
 brew "qwen-code"
 brew "ramalama"

--- a/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile
+++ b/system_files/shared/usr/share/ublue-os/homebrew/preinstall.d/chairlift.Brewfile
@@ -1,2 +1,2 @@
 tap "frostyard/tap", trusted: true
-cask "chairlift"
+cask "frostyard/tap/chairlift"


### PR DESCRIPTION
# bluefin-common PR

## What does this change?

Adds `tap "llmmanorg/tap"` and `brew "llmmanorg/tap/llmman"` to `ai-tools.Brewfile` so `ujust bbrew` -> `ai` installs llmman alongside ramalama on Bluefin and Aurora.

## Why?

[llmman](https://github.com/llmmanorg/llmman) is a local model runner that pulls models from Hugging Face or any OCI registry (Docker Hub, GHCR, quay), serves them with upstream `llama.cpp`/`vllm`/`mlx-lm`, and launches coding agents (Claude Code, Codex, OpenCode, ...) against local or hosted models. It replaces the Docker Model Runner plugin being removed from the DX images (ublue-os/bluefin, ublue-os/aurora, ublue-os/bluefin-lts).

## PR pipeline

```
opened ──▶ 4-review ──▶ approved ──▶ merged
```

## Checklist

- [x] PR title follows Conventional Commits
- [ ] `just check` passes (Brewfile-only change; `scripts/validate-brewfiles.sh` is the networked check for this file)
- [ ] `pre-commit run --all-files` passes
- [x] Skill doc: n/a, no agent-facing convention change
- [x] `AGENTS.md` / `docs/SKILL.md` / `docs/skills/` links remain valid

## AI attribution

Assisted-by: Claude via OpenCode