### PR TITLE
fix(brew): allow dedicated ChairLift migration

### DIFF
--- a/docs/skills/brew-lifecycle/SKILL.md
+++ b/docs/skills/brew-lifecycle/SKILL.md
@@ -126,6 +126,27 @@ desktop file at `/usr/share/applications/org.frostyard.ChairLift.desktop`
 upstream icons under `/usr/share/icons/hicolor/`, so every user gets a
 launcher.
 
+### Hand ChairLift to a dedicated installer
+
+Images that supply their own ChairLift migration may invoke
+`/usr/libexec/brew-preinstall --external-chairlift`. Without that argument,
+common's existing behavior is unchanged. The opt-in excludes the entire
+`chairlift.Brewfile` from tapping, hashing, bundling and managed state, and
+protects the historical unqualified, Frostyard-qualified and Bluefin-qualified
+ChairLift names from OS-diet removal. Other packages keep their usual lifecycle.
+Keep that Brewfile dedicated to ChairLift; do not place unrelated packages in it.
+
+The caller must capture any old managed-state authorization before invoking this
+mode: a successful generic sync drops ChairLift from its state. The caller owns
+first installation, migration, retry and future removal policy. Run generic sync
+even if that dedicated installer fails, so unrelated packages are not blocked.
+
+`brew-preinstall --capabilities` prints `external-chairlift-v1` without touching
+Homebrew or user state. Downstream image builds should require this capability
+before enabling the handoff. Land this common change and update the downstream
+common pin before shipping; do not carry a downstream source patch or silently
+call an older script that ignores the option.
+
 ### Add a tap + package from a non-core tap
 
 Homebrew 6.0 syntax — `trusted: true` is required:

--- a/system_files/shared/usr/libexec/brew-preinstall
+++ b/system_files/shared/usr/libexec/brew-preinstall
@@ -12,6 +12,16 @@
 # Older state files without a "casks" key are read as an empty cask list.
 set -euo pipefail
 
+# Opt-in handoff for images with a dedicated ChairLift installer. Other images
+# retain the normal bundle/install/remove lifecycle with no arguments.
+external_chairlift=0
+case "$*" in
+    '') ;;
+    --external-chairlift) external_chairlift=1 ;;
+    --capabilities) printf '%s\n' external-chairlift-v1; exit 0 ;;
+    *) echo 'Usage: brew-preinstall [--external-chairlift|--capabilities]' >&2; exit 2 ;;
+esac
+
 PREINSTALL_DIR="/usr/share/ublue-os/homebrew/preinstall.d"
 STATE_FILE="${HOME}/.local/share/ublue-os/brew-preinstall-state.json"
 BREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
@@ -27,7 +37,15 @@ if [[ ! -d "${PREINSTALL_DIR}" ]]; then
 fi
 
 shopt -s nullglob
-brewfiles=("${PREINSTALL_DIR}"/*.Brewfile)
+# A dedicated installer owns the whole ChairLift Brewfile when requested,
+# including taps, hash, bundle and managed state. Never partially bundle it.
+brewfiles=()
+for brewfile in "${PREINSTALL_DIR}"/*.Brewfile; do
+    if [[ "${external_chairlift}" -eq 1 && "${brewfile##*/}" == chairlift.Brewfile ]]; then
+        continue
+    fi
+    brewfiles+=("${brewfile}")
+done
 
 if [[ ${#brewfiles[@]} -eq 0 ]]; then
     echo "brew-preinstall: no Brewfiles in ${PREINSTALL_DIR}, skipping"
@@ -130,7 +148,12 @@ fi
 
 previous_packages=$(jq -r '.packages[]? // empty' "${STATE_FILE}" 2>/dev/null \
     | sort -u || true)
-previous_casks=$(jq -r '.casks[]? // empty' "${STATE_FILE}" 2>/dev/null \
+# Hand ChairLift ownership to the caller, not the OS-diet remover. This must
+# work even if the old Brewfile has already disappeared from the new image.
+previous_casks=$(jq -r --argjson external "${external_chairlift}" '
+    .casks[]? // empty |
+    select($external == 0 or (. != "chairlift" and . != "frostyard/tap/chairlift" and . != "ublue-os/tap/chairlift"))
+' "${STATE_FILE}" 2>/dev/null \
     | sort -u || true)
 
 managed_name_present() {

--- a/tests/test_brew_preinstall.bats
+++ b/tests/test_brew_preinstall.bats
@@ -135,6 +135,86 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Opt-in ChairLift lifecycle handoff
+# ---------------------------------------------------------------------------
+
+@test "brew-preinstall: ChairLift still installs normally without handoff" {
+    printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' > "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_WRAPPER}"
+    [ "${status}" -eq 0 ]
+    grep -Fxq 'brew tap frostyard/tap' "${WORKDIR}/brew.log"
+    grep -Fxq "brew bundle --file=${WORKDIR}/preinstall.d/chairlift.Brewfile" "${WORKDIR}/brew.log"
+    jq -e '.casks == ["chairlift"]' "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+}
+
+@test "brew-preinstall: external ChairLift skips its tap bundle hash and removal only" {
+    printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' > "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+    printf 'brew "jq"\n' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"old","packages":["jq"],"casks":["chairlift","frostyard/tap/chairlift","ublue-os/tap/chairlift","other"]}\n' \
+        > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_WRAPPER}" --external-chairlift
+    [ "${status}" -eq 0 ]
+    ! grep -q 'chairlift\|frostyard/tap' "${WORKDIR}/brew.log"
+    grep -Fxq "brew bundle --file=${WORKDIR}/preinstall.d/system-cli.Brewfile" "${WORKDIR}/brew.log"
+    grep -Fxq 'brew uninstall --cask other' "${WORKDIR}/brew.log"
+    expected_hash="$(sha256sum "${WORKDIR}/preinstall.d/system-cli.Brewfile" | cut -d' ' -f1)"
+    jq -e --arg hash "${expected_hash}" '.hash == $hash and .packages == ["jq"] and .casks == []' \
+        "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    # Changes to the externally owned declaration must not trigger bundle.
+    printf '# external installer update\n' >> "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+    BREW_LOG="${WORKDIR}/second.log" run bash "${PATCHED_WRAPPER}" --external-chairlift
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"nothing to do"* ]]
+    ! grep -q 'brew bundle' "${WORKDIR}/second.log"
+}
+
+@test "brew-preinstall: external ChairLift remains protected when its Brewfile is gone" {
+    printf 'brew "jq"\n' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"old","packages":[],"casks":["chairlift"]}\n' > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}" --external-chairlift
+    [ "${status}" -eq 0 ]
+    ! grep -q 'brew uninstall' "${WORKDIR}/brew.log"
+}
+
+@test "brew-preinstall: no handoff still removes ChairLift dropped from the managed set" {
+    printf 'brew "jq"\n' > "${WORKDIR}/preinstall.d/system-cli.Brewfile"
+    mkdir -p "${WORKDIR}/.local/share/ublue-os"
+    printf '{"hash":"old","packages":[],"casks":["chairlift"]}\n' > "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json"
+
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -Fxq 'brew uninstall --cask chairlift' "${WORKDIR}/brew.log"
+}
+
+@test "brew-preinstall: only externally owned ChairLift is a no-op" {
+    printf 'tap "frostyard/tap", trusted: true\ncask "chairlift"\n' > "${WORKDIR}/preinstall.d/chairlift.Brewfile"
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}" --external-chairlift
+    [ "${status}" -eq 0 ]
+    [ ! -e "${WORKDIR}/brew.log" ]
+    [ ! -e "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" ]
+}
+
+@test "brew-preinstall: capability probe works without Homebrew and touches no state" {
+    rm "${WORKDIR}/bin/brew"
+    run bash "${PATCHED_WRAPPER}" --capabilities
+    [ "${status}" -eq 0 ]
+    [ "${output}" = external-chairlift-v1 ]
+    [ ! -e "${WORKDIR}/.local/share/ublue-os/brew-preinstall-state.json" ]
+}
+
+@test "brew-preinstall: unknown option fails before any Brew operation" {
+    BREW_LOG="${WORKDIR}/brew.log" run bash "${PATCHED_SCRIPT}" --external-chairlif
+    [ "${status}" -eq 2 ]
+    [ ! -e "${WORKDIR}/brew.log" ]
+}
+
+# ---------------------------------------------------------------------------
 # Early-exit guards
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Dakota’s ChairLift migration needs to manage installation separately from `brew-preinstall`. Otherwise, the generic Brewfile lifecycle can install ChairLift before migration validation or uninstall it when ownership changes.

1. **Add an explicit handoff.** `--external-chairlift` excludes ChairLift’s Brewfile from tapping, hashing, bundling, and managed state. It also prevents removal of previously tracked ChairLift casks while unrelated packages continue through the normal lifecycle.
2. **Preserve existing behavior.** Images that do not pass the option continue installing and removing ChairLift normally.
3. **Expose capability detection.** `--capabilities` reports `external-chairlift-v1` without accessing Homebrew or user state, so downstream builds can reject an incompatible common revision.

Verified: All 48 preinstall tests, ShellCheck, and `just check` pass. The full suite could not run because `pytest` is missing, and `pre-commit` is not installed. Live migration testing remains on the Dakota side.
